### PR TITLE
Add expandable reaction/zap details and fix event dedup

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip57.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip57.kt
@@ -19,6 +19,21 @@ object Nip57 {
         return event.tags.firstOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
     }
 
+    /**
+     * Extract the zapper's pubkey from a kind 9735 zap receipt.
+     * The description tag contains the serialized kind 9734 zap request whose pubkey is the sender.
+     */
+    fun getZapperPubkey(event: NostrEvent): String? {
+        val description = event.tags.firstOrNull { it.size >= 2 && it[0] == "description" }?.get(1)
+            ?: return null
+        return try {
+            val zapRequest = NostrEvent.fromJson(description)
+            zapRequest.pubkey.takeIf { it.isNotBlank() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     fun getZapAmountSats(event: NostrEvent): Long {
         val bolt11 = event.tags.firstOrNull { it.size >= 2 && it[0] == "bolt11" }?.get(1)
             ?: return 0

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
@@ -1,0 +1,177 @@
+package com.wisp.app.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.wisp.app.nostr.ProfileData
+
+@Composable
+fun StackedAvatarRow(
+    pubkeys: List<String>,
+    resolveProfile: (String) -> ProfileData?,
+    onProfileClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    maxAvatars: Int = 5
+) {
+    val displayed = if (pubkeys.size <= maxAvatars) pubkeys else pubkeys.take(maxAvatars)
+    val overflow = pubkeys.size - displayed.size
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box {
+            displayed.forEachIndexed { index, pubkey ->
+                val profile = resolveProfile(pubkey)
+                ProfilePicture(
+                    url = profile?.picture,
+                    size = 24,
+                    modifier = Modifier
+                        .zIndex((displayed.size - index).toFloat())
+                        .offset(x = (18 * index).dp)
+                        .clickable { onProfileClick(pubkey) }
+                )
+            }
+        }
+        // Account for the stacked width
+        Spacer(Modifier.width((18 * (displayed.size - 1) + 24).dp))
+        if (overflow > 0) {
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "+$overflow",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+fun ZapRow(
+    pubkey: String,
+    sats: Long,
+    profile: ProfileData?,
+    onProfileClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ProfilePicture(
+            url = profile?.picture,
+            size = 24,
+            modifier = Modifier.clickable { onProfileClick(pubkey) }
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = profile?.displayString ?: (pubkey.take(8) + "..."),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .weight(1f)
+                .clickable { onProfileClick(pubkey) }
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = formatSats(sats),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.tertiary
+        )
+    }
+}
+
+@Composable
+fun ReactionDetailsSection(
+    reactionDetails: Map<String, List<String>>,
+    zapDetails: List<Pair<String, Long>>,
+    resolveProfile: (String) -> ProfileData?,
+    onProfileClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val sortedZaps = zapDetails.sortedByDescending { it.second }
+    val hasZaps = sortedZaps.isNotEmpty()
+    val hasReactions = reactionDetails.isNotEmpty()
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        if (hasZaps) {
+            sortedZaps.forEach { (pubkey, sats) ->
+                ZapRow(
+                    pubkey = pubkey,
+                    sats = sats,
+                    profile = resolveProfile(pubkey),
+                    onProfileClick = onProfileClick
+                )
+            }
+        }
+
+        if (hasZaps && hasReactions) {
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 6.dp),
+                color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+            )
+        }
+
+        if (hasReactions) {
+            reactionDetails.forEach { (emoji, pubkeys) ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 3.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = emoji,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    StackedAvatarRow(
+                        pubkeys = pubkeys,
+                        resolveProfile = resolveProfile,
+                        onProfileClick = onProfileClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatSats(sats: Long): String {
+    return when {
+        sats >= 1_000_000 -> "${sats / 1_000_000}M sats"
+        sats >= 1_000 -> "${sats / 1_000}K sats"
+        else -> "$sats sats"
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -535,6 +535,12 @@ private fun FeedItem(
                 ?: pk.take(8) + "..."
         }
     }
+    val reactionDetails = remember(reactionVersion, event.id) {
+        viewModel.eventRepo.getReactionDetails(event.id)
+    }
+    val zapDetails = remember(zapVersion, event.id) {
+        viewModel.eventRepo.getZapDetails(event.id)
+    }
     PostCard(
         event = event,
         profile = profileData,
@@ -553,7 +559,10 @@ private fun FeedItem(
         isZapAnimating = isZapAnimating,
         eventRepo = viewModel.eventRepo,
         relayIcons = relayIcons,
-        repostedBy = repostedByName
+        repostedBy = repostedByName,
+        reactionDetails = reactionDetails,
+        zapDetails = zapDetails,
+        onNavigateToProfileFromDetails = onNavigateToProfile
     )
 }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
@@ -48,6 +48,7 @@ fun ThreadScreen(
     val flatThread by viewModel.flatThread.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val reactionVersion by eventRepo.reactionVersion.collectAsState()
+    val zapVersion by eventRepo.zapVersion.collectAsState()
 
     Scaffold(
         topBar = {
@@ -80,6 +81,8 @@ fun ThreadScreen(
                     val likeCount = reactionVersion.let { eventRepo.getReactionCount(event.id) }
                     val zapSats = eventRepo.getZapSats(event.id)
                     val userEmoji = reactionVersion.let { userPubkey?.let { eventRepo.getUserReactionEmoji(event.id, it) } }
+                    val reactionDetails = reactionVersion.let { eventRepo.getReactionDetails(event.id) }
+                    val zapDetailsList = zapVersion.let { eventRepo.getZapDetails(event.id) }
                     PostCard(
                         event = event,
                         profile = profileData,
@@ -94,6 +97,9 @@ fun ThreadScreen(
                         zapSats = zapSats,
                         isZapAnimating = event.id in zapAnimatingIds,
                         eventRepo = eventRepo,
+                        reactionDetails = reactionDetails,
+                        zapDetails = zapDetailsList,
+                        onNavigateToProfileFromDetails = onProfileClick,
                         modifier = Modifier.padding(start = (min(depth, 4) * 24).dp)
                     )
                 }


### PR DESCRIPTION
## Summary
- Add a toggle arrow below each note's action bar that expands to show individual zap amounts with avatars and reactions grouped by emoji with stacked profile pictures
- Fix event deduplication race condition that caused zaps to be double/triple/quadruple counted across relay threads — replaced racy LruCache check with atomic ConcurrentHashMap.newKeySet()
- Map blank/unknown reaction emoji to ❤️ instead of "+"

## Test plan
- [ ] Open feed, find a note with reactions/zaps
- [ ] Tap the down arrow — verify zaps appear on top with avatars and amounts, reactions grouped by emoji below
- [ ] Tap an avatar — verify navigation to user profile
- [ ] Collapse — verify smooth animation
- [ ] Verify zap counts are no longer inflated (compare with another client)
- [ ] Check thread view works the same way
- [ ] Verify "+" no longer appears in reaction details, replaced by ❤️