### PR TITLE
Add relay seen-on section with letter avatar fallback

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -59,7 +59,8 @@ fun PostCard(
     zapSats: Long = 0,
     isZapAnimating: Boolean = false,
     eventRepo: EventRepository? = null,
-    relayIcons: List<String> = emptyList(),
+    relayIcons: List<Pair<String, String?>> = emptyList(),
+    onRelayClick: (String) -> Unit = {},
     repostedBy: String? = null,
     reactionDetails: Map<String, List<String>> = emptyMap(),
     zapDetails: List<Pair<String, Long>> = emptyList(),
@@ -80,7 +81,8 @@ fun PostCard(
         if (relayIcons.size <= 5) relayIcons else relayIcons.take(5)
     }
 
-    val hasDetails = reactionDetails.isNotEmpty() || zapDetails.isNotEmpty()
+    val hasReactionDetails = reactionDetails.isNotEmpty() || zapDetails.isNotEmpty()
+    val hasDetails = hasReactionDetails || displayIcons.isNotEmpty()
     var expandedDetails by remember { mutableStateOf(false) }
 
     Column(
@@ -162,8 +164,9 @@ fun PostCard(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { expandedDetails = !expandedDetails },
-                contentAlignment = Alignment.Center
+                    .clickable { expandedDetails = !expandedDetails }
+                    .padding(vertical = 2.dp),
+                contentAlignment = Alignment.CenterEnd
             ) {
                 Icon(
                     imageVector = if (expandedDetails) Icons.Filled.KeyboardArrowUp
@@ -182,27 +185,17 @@ fun PostCard(
                     eventRepo?.getProfileData(pubkey)
                 }
                 val navToProfile = onNavigateToProfileFromDetails ?: onNavigateToProfile ?: {}
-                ReactionDetailsSection(
-                    reactionDetails = reactionDetails,
-                    zapDetails = zapDetails,
-                    resolveProfile = profileResolver,
-                    onProfileClick = navToProfile
-                )
-            }
-        }
-        if (displayIcons.isNotEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-                contentAlignment = Alignment.CenterEnd
-            ) {
-                Row {
-                    displayIcons.forEachIndexed { index, iconUrl ->
-                        RelayIcon(
-                            url = iconUrl,
-                            modifier = Modifier
-                                .zIndex((displayIcons.size - index).toFloat())
-                                .offset(x = (-8 * index).dp)
+                Column {
+                    if (hasReactionDetails) {
+                        ReactionDetailsSection(
+                            reactionDetails = reactionDetails,
+                            zapDetails = zapDetails,
+                            resolveProfile = profileResolver,
+                            onProfileClick = navToProfile
                         )
+                    }
+                    if (displayIcons.isNotEmpty()) {
+                        SeenOnSection(relayIcons = displayIcons, onRelayClick = onRelayClick)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
@@ -168,6 +168,60 @@ fun ReactionDetailsSection(
     }
 }
 
+@Composable
+fun SeenOnSection(
+    relayIcons: List<Pair<String, String?>>,
+    onRelayClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    maxIcons: Int = 5
+) {
+    val displayed = if (relayIcons.size <= maxIcons) relayIcons else relayIcons.take(maxIcons)
+    val overflow = relayIcons.size - displayed.size
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Seen on",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.width(8.dp))
+            Box {
+                displayed.forEachIndexed { index, (relayUrl, iconUrl) ->
+                    RelayIcon(
+                        iconUrl = iconUrl,
+                        relayUrl = relayUrl,
+                        size = 24.dp,
+                        modifier = Modifier
+                            .zIndex((displayed.size - index).toFloat())
+                            .offset(x = (18 * index).dp)
+                            .clickable { onRelayClick(relayUrl) }
+                    )
+                }
+            }
+            Spacer(Modifier.width((18 * (displayed.size - 1) + 24).dp))
+            if (overflow > 0) {
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = "+$overflow",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
 private fun formatSats(sats: Long): String {
     return when {
         sats >= 1_000_000 -> "${sats / 1_000_000}M sats"

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RelayIcon.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RelayIcon.kt
@@ -2,31 +2,86 @@ package com.wisp.app.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+
+/**
+ * Extracts a single letter from a relay URL for the fallback avatar.
+ * e.g. "wss://relay.damus.io" → "D", "wss://nos.lol" → "N"
+ */
+private fun relayLetter(relayUrl: String): String {
+    val domain = relayUrl
+        .removePrefix("wss://")
+        .removePrefix("ws://")
+        .trimEnd('/')
+        .split("/").first()
+    // Use the first meaningful segment: skip "relay." prefix if present
+    val label = if (domain.startsWith("relay.")) {
+        domain.removePrefix("relay.")
+    } else {
+        domain
+    }
+    return label.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+}
 
 @Composable
 fun RelayIcon(
-    url: String?,
+    iconUrl: String?,
+    relayUrl: String,
     modifier: Modifier = Modifier,
     size: Dp = 14.dp
 ) {
-    AsyncImage(
-        model = url,
-        contentDescription = "Relay icon",
-        contentScale = ContentScale.Crop,
-        modifier = modifier
-            .size(size)
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
-            .border(0.5.dp, MaterialTheme.colorScheme.outline, CircleShape)
-    )
+    val letter = remember(relayUrl) { relayLetter(relayUrl) }
+    var showFallback by remember(iconUrl) { mutableStateOf(iconUrl == null) }
+
+    val baseModifier = modifier
+        .size(size)
+        .clip(CircleShape)
+        .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
+        .border(0.5.dp, MaterialTheme.colorScheme.outline, CircleShape)
+
+    if (showFallback) {
+        Box(
+            modifier = baseModifier,
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = letter,
+                fontSize = (size.value * 0.55f).sp,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1
+            )
+        }
+    } else {
+        AsyncImage(
+            model = iconUrl,
+            contentDescription = "Relay icon",
+            contentScale = ContentScale.Crop,
+            onState = { state ->
+                if (state is AsyncImagePainter.State.Error) {
+                    showFallback = true
+                }
+            },
+            modifier = baseModifier
+        )
+    }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -457,7 +457,11 @@ fun FeedScreen(
                                     onReact = { emoji -> onReact(event, emoji) },
                                     onRepost = { onRepost(event) },
                                     onQuote = { onQuote(event) },
-                                    onZap = { zapTargetEvent = event }
+                                    onZap = { zapTargetEvent = event },
+                                    onRelayClick = { url ->
+                                        viewModel.setSelectedRelay(url)
+                                        viewModel.setFeedType(FeedType.RELAY)
+                                    }
                                 )
                             }
                         }
@@ -504,7 +508,8 @@ private fun FeedItem(
     onReact: (String) -> Unit,
     onRepost: () -> Unit,
     onQuote: () -> Unit,
-    onZap: () -> Unit
+    onZap: () -> Unit,
+    onRelayClick: (String) -> Unit = {}
 ) {
     val profileData = remember(profileVersion, event.pubkey) {
         viewModel.eventRepo.getProfileData(event.pubkey)
@@ -522,8 +527,8 @@ private fun FeedItem(
         userPubkey?.let { viewModel.eventRepo.getUserReactionEmoji(event.id, it) }
     }
     val relayIcons = remember(relaySourceVersion, event.id) {
-        viewModel.eventRepo.getEventRelays(event.id).mapNotNull { url ->
-            viewModel.relayInfoRepo.getIconUrl(url)
+        viewModel.eventRepo.getEventRelays(event.id).map { url ->
+            url to viewModel.relayInfoRepo.getIconUrl(url)
         }
     }
     val repostAuthorPubkey = remember(event.id) {
@@ -562,7 +567,8 @@ private fun FeedItem(
         repostedBy = repostedByName,
         reactionDetails = reactionDetails,
         zapDetails = zapDetails,
-        onNavigateToProfileFromDetails = onNavigateToProfile
+        onNavigateToProfileFromDetails = onNavigateToProfile,
+        onRelayClick = onRelayClick
     )
 }
 


### PR DESCRIPTION
## Summary
- Relay icons moved from the note surface into the expandable details section as a "Seen on" row with 24dp icons (matching user avatar size)
- Expand/collapse arrow moved to right-aligned and now also triggers when relay icons are present (even without reactions/zaps)
- `RelayIcon` shows a letter avatar fallback (first letter of relay domain) when the icon URL is missing or fails to load
- Clicking a relay icon in "Seen on" switches the feed to that relay's feed

## Test plan
- [ ] Verify notes no longer show relay icons inline — only visible when expanding
- [ ] Verify expand arrow appears on the right side
- [ ] Verify expanding shows "Seen on" row with relay icons at same size as user avatars
- [ ] Verify letter fallback renders for relays without icons
- [ ] Verify clicking a relay icon switches feed to that relay