### PR TITLE
Relay outbox/inbox refactor

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -262,7 +262,8 @@ fun WispNavHost() {
                 relayPool = feedViewModel.relayPool,
                 replyTo = replyTarget,
                 quoteTo = quoteTarget,
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                outboxRouter = feedViewModel.outboxRouter
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayScoreBoard.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayScoreBoard.kt
@@ -1,0 +1,143 @@
+package com.wisp.app.relay
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import com.wisp.app.repo.ContactRepository
+import com.wisp.app.repo.RelayListRepository
+
+data class ScoredRelay(val url: String, val coverCount: Int, val authors: Set<String>)
+
+class RelayScoreBoard(
+    context: Context,
+    private val relayListRepo: RelayListRepository,
+    private val contactRepo: ContactRepository
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("wisp_relay_scores", Context.MODE_PRIVATE)
+
+    private var scoredRelays: List<ScoredRelay> = emptyList()
+    private var scoredRelayUrls: Set<String> = emptySet()
+    // relay URL -> set of authors covered by that relay
+    private var relayAuthorsMap: Map<String, Set<String>> = emptyMap()
+
+    companion object {
+        private const val TAG = "RelayScoreBoard"
+        const val MAX_SCORED_RELAYS = 75
+    }
+
+    init {
+        loadFromPrefs()
+    }
+
+    /**
+     * Recompute the optimal relay set using greedy set-cover over followed users' write relays.
+     */
+    fun recompute() {
+        val follows = contactRepo.getFollowList().map { it.pubkey }
+        if (follows.isEmpty()) {
+            scoredRelays = emptyList()
+            scoredRelayUrls = emptySet()
+            relayAuthorsMap = emptyMap()
+            return
+        }
+
+        // Build relay -> authors mapping from known relay lists
+        val relayToAuthors = mutableMapOf<String, MutableSet<String>>()
+        var knownCount = 0
+        for (pubkey in follows) {
+            val writeRelays = relayListRepo.getWriteRelays(pubkey) ?: continue
+            knownCount++
+            for (url in writeRelays) {
+                relayToAuthors.getOrPut(url) { mutableSetOf() }.add(pubkey)
+            }
+        }
+
+        if (relayToAuthors.isEmpty()) {
+            scoredRelays = emptyList()
+            scoredRelayUrls = emptySet()
+            relayAuthorsMap = emptyMap()
+            Log.d(TAG, "No relay lists known for $knownCount/${follows.size} follows")
+            return
+        }
+
+        // Greedy set-cover: pick relay covering most uncovered follows, repeat
+        val uncovered = follows.toMutableSet()
+        val result = mutableListOf<ScoredRelay>()
+        val remainingRelays = relayToAuthors.toMutableMap()
+
+        while (uncovered.isNotEmpty() && result.size < MAX_SCORED_RELAYS && remainingRelays.isNotEmpty()) {
+            // Find relay that covers the most uncovered authors
+            var bestUrl: String? = null
+            var bestCover: Set<String> = emptySet()
+            for ((url, authors) in remainingRelays) {
+                val cover = authors.intersect(uncovered)
+                if (cover.size > bestCover.size) {
+                    bestUrl = url
+                    bestCover = cover
+                }
+            }
+            if (bestUrl == null || bestCover.isEmpty()) break
+
+            result.add(ScoredRelay(bestUrl, bestCover.size, bestCover))
+            uncovered.removeAll(bestCover)
+            remainingRelays.remove(bestUrl)
+        }
+
+        scoredRelays = result
+        scoredRelayUrls = result.map { it.url }.toSet()
+        relayAuthorsMap = result.associate { it.url to it.authors }
+
+        Log.d(TAG, "Scored ${result.size} relays covering ${follows.size - uncovered.size}/${follows.size} follows " +
+                "(${uncovered.size} uncovered, $knownCount with relay lists)")
+
+        saveToPrefs()
+    }
+
+    /**
+     * Returns relay→authors grouping constrained to scored relays only.
+     * Authors not covered by any scored relay are returned under the empty-string key
+     * (caller should fall back to sendToAll for those).
+     */
+    fun getRelaysForAuthors(authors: List<String>): Map<String, List<String>> {
+        if (scoredRelays.isEmpty()) return emptyMap()
+
+        val result = mutableMapOf<String, MutableList<String>>()
+        val covered = mutableSetOf<String>()
+
+        for ((url, relayAuthors) in relayAuthorsMap) {
+            val overlap = authors.filter { it in relayAuthors }
+            if (overlap.isNotEmpty()) {
+                result[url] = overlap.toMutableList()
+                covered.addAll(overlap)
+            }
+        }
+
+        // Authors not in any scored relay → returned under "" key for fallback
+        val uncovered = authors.filter { it !in covered }
+        if (uncovered.isNotEmpty()) {
+            result[""] = uncovered.toMutableList()
+        }
+
+        return result
+    }
+
+    fun getScoredRelays(): List<ScoredRelay> = scoredRelays
+
+    fun getScoredRelayConfigs(): List<RelayConfig> =
+        scoredRelays.map { RelayConfig(it.url, read = true, write = false) }
+
+    fun hasScoredRelays(): Boolean = scoredRelays.isNotEmpty()
+
+    private fun saveToPrefs() {
+        val urls = scoredRelays.joinToString(",") { it.url }
+        prefs.edit().putString("scored_urls", urls).apply()
+    }
+
+    private fun loadFromPrefs() {
+        val urls = prefs.getString("scored_urls", null) ?: return
+        if (urls.isBlank()) return
+        // Restore just URLs — full recompute will happen on next refresh
+        scoredRelayUrls = urls.split(",").toSet()
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
@@ -1,0 +1,53 @@
+package com.wisp.app.relay
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+class SubscriptionManager(private val relayPool: RelayPool) {
+
+    /**
+     * Await a specific EOSE signal by subscription ID. One-shot, no lingering collector.
+     */
+    suspend fun awaitEose(targetSubId: String) {
+        relayPool.eoseSignals.first { it == targetSubId }
+    }
+
+    /**
+     * Await EOSE with a timeout. Returns true if EOSE was received, false on timeout.
+     */
+    suspend fun awaitEoseWithTimeout(targetSubId: String, timeoutMs: Long = 15_000): Boolean {
+        return withTimeoutOrNull(timeoutMs) {
+            relayPool.eoseSignals.first { it == targetSubId }
+            true
+        } ?: false
+    }
+
+    /**
+     * Await count-based EOSE: wait until [expectedCount] EOSE signals arrive for [targetSubId],
+     * or until [timeoutMs] elapses.
+     * Returns the number of EOSE signals actually received.
+     */
+    suspend fun awaitEoseCount(
+        targetSubId: String,
+        expectedCount: Int,
+        timeoutMs: Long = 15_000
+    ): Int {
+        if (expectedCount <= 0) return 0
+        var eoseCount = 0
+        withTimeoutOrNull(timeoutMs) {
+            relayPool.eoseSignals.collect { subId ->
+                if (subId == targetSubId && ++eoseCount >= expectedCount) {
+                    return@collect
+                }
+            }
+        }
+        return eoseCount
+    }
+
+    /**
+     * Close a subscription on all relays (including ephemeral).
+     */
+    fun closeSubscription(subscriptionId: String) {
+        relayPool.closeOnAllRelays(subscriptionId)
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/repo/ContactRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/ContactRepository.kt
@@ -41,8 +41,10 @@ class ContactRepository(context: Context) {
 
     private fun saveToPrefs(entries: List<Nip02.FollowEntry>) {
         val serializable = entries.map { SerializableFollow(it.pubkey, it.relayHint, it.petname) }
-        prefs.edit().putString("follows", json.encodeToString(serializable)).apply()
-        prefs.edit().putLong("follows_updated", lastUpdated).apply()
+        prefs.edit()
+            .putString("follows", json.encodeToString(serializable))
+            .putLong("follows_updated", lastUpdated)
+            .apply()
     }
 
     private fun loadFromPrefs() {

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -282,6 +282,14 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         feedDirty.trySend(Unit)
     }
 
+    fun trimSeenEvents(maxSize: Int = 50_000) {
+        if (seenEventIds.size > maxSize) {
+            seenEventIds.clear()
+            // Re-add current feed IDs so they stay deduped
+            synchronized(feedList) { feedIds.forEach { seenEventIds.add(it) } }
+        }
+    }
+
     fun clearFeed() {
         synchronized(feedList) {
             feedList.clear()

--- a/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
@@ -1,0 +1,211 @@
+package com.wisp.app.repo
+
+import com.wisp.app.nostr.ClientMessage
+import com.wisp.app.nostr.Filter
+import com.wisp.app.nostr.Nip19
+import com.wisp.app.nostr.NostrUriData
+import com.wisp.app.relay.OutboxRouter
+import com.wisp.app.relay.RelayPool
+import com.wisp.app.relay.SubscriptionManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Handles batched fetching of profiles, reply counts, zap counts, and quoted events.
+ * Extracted from FeedViewModel to reduce its size.
+ */
+class MetadataFetcher(
+    private val relayPool: RelayPool,
+    private val outboxRouter: OutboxRouter,
+    private val subManager: SubscriptionManager,
+    private val profileRepo: ProfileRepository,
+    private val eventRepo: EventRepository,
+    private val scope: CoroutineScope,
+    private val processingContext: CoroutineContext
+) {
+    // Batched profile fetching
+    private val pendingProfilePubkeys = mutableSetOf<String>()
+    private var profileBatchJob: Job? = null
+    private var metaBatchCounter = 0
+    private val profileAttempts = mutableMapOf<String, Int>()
+
+    // Batched reply count fetching
+    private val pendingReplyCountIds = mutableSetOf<String>()
+    private var replyCountBatchJob: Job? = null
+    private var replyCountBatchCounter = 0
+
+    // Batched zap count fetching
+    private val pendingZapCountIds = mutableSetOf<String>()
+    private var zapCountBatchJob: Job? = null
+    private var zapCountBatchCounter = 0
+
+    // Quoted event fetching
+    private val pendingQuoteFetches = mutableSetOf<String>()
+    private val nostrNoteUriRegex = Regex("""nostr:(note1|nevent1)[a-z0-9]+""")
+
+    companion object {
+        private const val MAX_PROFILE_ATTEMPTS = 3
+    }
+
+    fun queueProfileFetch(pubkey: String) = addToPendingProfiles(pubkey)
+
+    fun addToPendingProfiles(pubkey: String) {
+        synchronized(pendingProfilePubkeys) {
+            if (profileRepo.has(pubkey)) return
+            val attempts = profileAttempts[pubkey] ?: 0
+            if (attempts >= MAX_PROFILE_ATTEMPTS) return
+            if (pubkey in pendingProfilePubkeys) return
+            pendingProfilePubkeys.add(pubkey)
+            val shouldFlushNow = pendingProfilePubkeys.size >= 20
+            if (shouldFlushNow) {
+                profileBatchJob?.cancel()
+                flushProfileBatch()
+            } else if (profileBatchJob == null || profileBatchJob?.isActive != true) {
+                profileBatchJob = scope.launch(processingContext) {
+                    delay(100)
+                    synchronized(pendingProfilePubkeys) { flushProfileBatch() }
+                }
+            }
+        }
+    }
+
+    fun addToPendingReplyCounts(eventId: String) {
+        synchronized(pendingReplyCountIds) {
+            pendingReplyCountIds.add(eventId)
+            val shouldFlushNow = pendingReplyCountIds.size >= 20
+            if (shouldFlushNow) {
+                replyCountBatchJob?.cancel()
+                flushReplyCountBatch()
+            } else if (replyCountBatchJob == null || replyCountBatchJob?.isActive != true) {
+                replyCountBatchJob = scope.launch(processingContext) {
+                    delay(500)
+                    synchronized(pendingReplyCountIds) { flushReplyCountBatch() }
+                }
+            }
+        }
+    }
+
+    fun addToPendingZapCounts(eventId: String) {
+        synchronized(pendingZapCountIds) {
+            pendingZapCountIds.add(eventId)
+            val shouldFlushNow = pendingZapCountIds.size >= 20
+            if (shouldFlushNow) {
+                zapCountBatchJob?.cancel()
+                flushZapCountBatch()
+            } else if (zapCountBatchJob == null || zapCountBatchJob?.isActive != true) {
+                zapCountBatchJob = scope.launch(processingContext) {
+                    delay(500)
+                    synchronized(pendingZapCountIds) { flushZapCountBatch() }
+                }
+            }
+        }
+    }
+
+    fun fetchQuotedEvents(event: com.wisp.app.nostr.NostrEvent) {
+        val ids = mutableSetOf<String>()
+        event.tags.filter { it.size >= 2 && it[0] == "q" }.forEach { ids.add(it[1]) }
+        for (match in nostrNoteUriRegex.findAll(event.content)) {
+            val decoded = Nip19.decodeNostrUri(match.value)
+            if (decoded is NostrUriData.NoteRef) ids.add(decoded.eventId)
+        }
+        val toFetch = ids.filter { id -> eventRepo.getEvent(id) == null && id !in pendingQuoteFetches }
+        if (toFetch.isEmpty()) return
+        pendingQuoteFetches.addAll(toFetch)
+        val subId = "quote-${toFetch.hashCode()}"
+        relayPool.sendToAll(ClientMessage.req(subId, Filter(ids = toFetch)))
+        scope.launch {
+            subManager.awaitEoseWithTimeout(subId)
+            subManager.closeSubscription(subId)
+            toFetch.forEach { pendingQuoteFetches.remove(it) }
+        }
+    }
+
+    fun fetchProfilesForFollows(follows: List<String>) {
+        if (follows.isEmpty()) return
+        val missing = follows.filter { !profileRepo.has(it) }
+        if (missing.isEmpty()) return
+        missing.forEach { profileAttempts[it] = (profileAttempts[it] ?: 0) + 1 }
+        missing.chunked(20).forEachIndexed { index, batch ->
+            val subId = "follow-profiles-$index"
+            outboxRouter.requestProfiles(subId, batch)
+            scope.launch {
+                subManager.awaitEoseWithTimeout(subId)
+                subManager.closeSubscription(subId)
+            }
+        }
+    }
+
+    fun sweepMissingProfiles() {
+        val currentFeed = eventRepo.feed.value
+        for (event in currentFeed) {
+            if (eventRepo.getProfileData(event.pubkey) == null) {
+                addToPendingProfiles(event.pubkey)
+            }
+            val reposter = eventRepo.getRepostAuthor(event.id)
+            if (reposter != null && eventRepo.getProfileData(reposter) == null) {
+                addToPendingProfiles(reposter)
+            }
+            if (event.kind == 1) {
+                fetchQuotedEvents(event)
+            }
+        }
+    }
+
+    /** Must be called while holding pendingProfilePubkeys lock */
+    private fun flushProfileBatch() {
+        if (pendingProfilePubkeys.isEmpty()) return
+        val subId = "meta-batch-${metaBatchCounter++}"
+        val pubkeys = pendingProfilePubkeys.toList()
+        pendingProfilePubkeys.clear()
+
+        pubkeys.forEach { profileAttempts[it] = (profileAttempts[it] ?: 0) + 1 }
+
+        val maxAttempt = pubkeys.maxOf { profileAttempts[it] ?: 1 }
+        if (maxAttempt <= 1) {
+            outboxRouter.requestProfiles(subId, pubkeys)
+        } else {
+            val filter = Filter(kinds = listOf(0), authors = pubkeys, limit = pubkeys.size)
+            relayPool.sendToAll(ClientMessage.req(subId, filter))
+        }
+
+        scope.launch(processingContext) {
+            subManager.awaitEoseWithTimeout(subId)
+            subManager.closeSubscription(subId)
+            delay(3_000)
+            for (pk in pubkeys) {
+                if (!profileRepo.has(pk)) {
+                    addToPendingProfiles(pk)
+                }
+            }
+        }
+    }
+
+    private fun flushReplyCountBatch() {
+        if (pendingReplyCountIds.isEmpty()) return
+        val subId = "reply-count-${replyCountBatchCounter++}"
+        val eventIds = pendingReplyCountIds.toList()
+        pendingReplyCountIds.clear()
+        val filter = Filter(kinds = listOf(1), eTags = eventIds)
+        relayPool.sendToAll(ClientMessage.req(subId, filter))
+        scope.launch {
+            subManager.awaitEoseWithTimeout(subId)
+            subManager.closeSubscription(subId)
+        }
+    }
+
+    private fun flushZapCountBatch() {
+        if (pendingZapCountIds.isEmpty()) return
+        val subId = "zap-count-${zapCountBatchCounter++}"
+        val eventIds = pendingZapCountIds.toList()
+        pendingZapCountIds.clear()
+        val filter = Filter(kinds = listOf(9735), eTags = eventIds)
+        relayPool.sendToAll(ClientMessage.req(subId, filter))
+        scope.launch {
+            subManager.awaitEoseWithTimeout(subId)
+            subManager.closeSubscription(subId)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -51,7 +51,8 @@ fun ComposeScreen(
     relayPool: RelayPool,
     replyTo: NostrEvent?,
     quoteTo: NostrEvent? = null,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    outboxRouter: com.wisp.app.relay.OutboxRouter? = null
 ) {
     val content by viewModel.content.collectAsState()
     val publishing by viewModel.publishing.collectAsState()
@@ -217,7 +218,8 @@ fun ComposeScreen(
                         replyTo = replyTo,
                         quoteTo = quoteTo,
                         contentResolver = context.contentResolver,
-                        onSuccess = { onBack() }
+                        onSuccess = { onBack() },
+                        outboxRouter = outboxRouter
                     )
                 },
                 enabled = !publishing,

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
@@ -8,6 +8,7 @@ import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.relay.OutboxRouter
 import com.wisp.app.relay.RelayPool
+import com.wisp.app.relay.SubscriptionManager
 import com.wisp.app.repo.EventRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow


### PR DESCRIPTION
## Summary
- **RelayScoreBoard**: Auto-derives optimal relay set (max 75) from followed users' NIP-65 write relays using greedy set-cover, merged with user's pinned relays
- **Inbox-aware publishing**: Replies, reactions, and reposts now sent to target user's read (inbox) relays via `OutboxRouter.publishToInbox()`
- **Efficiency fixes**: Count-based EOSE for feed subscriptions, bounded `seenEventIds` with periodic trimming, removed notification dedup bypass, batched SharedPreferences writes, capped persistent (50) and ephemeral (30) relay connections
- **Code extraction**: `SubscriptionManager` and `MetadataFetcher` extracted from FeedViewModel (874→634 lines)

## Test plan
- [ ] Verify feed loads correctly with scoreboard-derived relays (check logcat for `RelayScoreBoard` output showing relay coverage)
- [ ] Publish a reply → confirm events sent to both own write relays AND target's read relays in console log
- [ ] Publish a reaction/repost → same inbox routing check
- [ ] Publish a root note → should only go to own write relays
- [ ] Leave app running 30+ min, verify ephemeral relay count stays bounded (< 30)
- [x] Test with 0 manually-configured relays (only defaults) — feed should still work
- [ ] Verify no duplicate notifications
- [ ] Check thread view, DMs, and compose flows still work end-to-end