### PR TITLE
Notifications: follow badges, inline replies, scroll-to-top, and misc fixes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -112,6 +112,7 @@ fun WispNavHost() {
 
     var replyTarget by remember { mutableStateOf<NostrEvent?>(null) }
     var quoteTarget by remember { mutableStateOf<NostrEvent?>(null) }
+    var scrollToTopTrigger by remember { mutableStateOf(0) }
 
     val startDestination = when {
         !authViewModel.isLoggedIn -> Routes.AUTH
@@ -134,7 +135,7 @@ fun WispNavHost() {
 
     // Initialize notifications viewmodel with shared repos
     LaunchedEffect(Unit) {
-        notificationsViewModel.init(feedViewModel.notifRepo, feedViewModel.eventRepo)
+        notificationsViewModel.init(feedViewModel.notifRepo, feedViewModel.eventRepo, feedViewModel.contactRepo)
     }
 
     // Process incoming gift wraps for DMs
@@ -168,10 +169,10 @@ fun WispNavHost() {
                     hasUnreadMessages = hasUnreadDms,
                     hasUnreadNotifications = hasUnreadNotifications,
                     onTabSelected = { tab ->
+                        scrollToTopTrigger++
                         navController.navigate(tab.route) {
-                            popUpTo(Routes.FEED) { saveState = true }
+                            popUpTo(Routes.FEED) { inclusive = false }
                             launchSingleTop = true
-                            restoreState = true
                         }
                     }
                 )
@@ -209,6 +210,7 @@ fun WispNavHost() {
         composable(Routes.FEED) {
             FeedScreen(
                 viewModel = feedViewModel,
+                scrollToTopTrigger = scrollToTopTrigger,
                 onCompose = {
                     replyTarget = null
                     quoteTarget = null
@@ -749,6 +751,7 @@ fun WispNavHost() {
             }
             NotificationsScreen(
                 viewModel = notificationsViewModel,
+                scrollToTopTrigger = scrollToTopTrigger,
                 onNoteClick = { eventId ->
                     navController.navigate("thread/$eventId")
                 },

--- a/app/src/main/kotlin/com/wisp/app/nostr/ProfileData.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/ProfileData.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
+private fun String?.takeUnlessBlank(): String? = this?.ifBlank { null }
+
 @Serializable
 data class ProfileData(
     val pubkey: String,
@@ -18,7 +20,9 @@ data class ProfileData(
     val updatedAt: Long
 ) {
     val displayString: String
-        get() = displayName ?: name ?: "${pubkey.take(8)}...${pubkey.takeLast(4)}"
+        get() = displayName.takeUnlessBlank()
+            ?: name.takeUnlessBlank()
+            ?: "${pubkey.take(8)}...${pubkey.takeLast(4)}"
 
     companion object {
         private val json = Json { ignoreUnknownKeys = true }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
@@ -32,6 +32,7 @@ fun StackedAvatarRow(
     resolveProfile: (String) -> ProfileData?,
     onProfileClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    isFollowing: ((String) -> Boolean)? = null,
     maxAvatars: Int = 5
 ) {
     val displayed = if (pubkeys.size <= maxAvatars) pubkeys else pubkeys.take(maxAvatars)
@@ -46,16 +47,17 @@ fun StackedAvatarRow(
                 val profile = resolveProfile(pubkey)
                 ProfilePicture(
                     url = profile?.picture,
-                    size = 24,
+                    size = 36,
+                    showFollowBadge = isFollowing?.invoke(pubkey) ?: false,
                     modifier = Modifier
                         .zIndex((displayed.size - index).toFloat())
-                        .offset(x = (18 * index).dp)
+                        .offset(x = (27 * index).dp)
                         .clickable { onProfileClick(pubkey) }
                 )
             }
         }
         // Account for the stacked width
-        Spacer(Modifier.width((18 * (displayed.size - 1) + 24).dp))
+        Spacer(Modifier.width((27 * (displayed.size - 1) + 36).dp))
         if (overflow > 0) {
             Spacer(Modifier.width(4.dp))
             Text(

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -63,7 +63,7 @@ fun WispDrawerContent(
             ProfilePicture(url = profile?.picture, size = 64)
             Spacer(modifier = Modifier.height(12.dp))
             Text(
-                text = profile?.displayName ?: profile?.name ?: "Anonymous",
+                text = profile?.displayString ?: "Anonymous",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface
             )

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -90,7 +90,8 @@ fun FeedScreen(
     onLists: () -> Unit = {},
     onSafety: () -> Unit = {},
     onConsole: () -> Unit = {},
-    onKeys: () -> Unit = {}
+    onKeys: () -> Unit = {},
+    scrollToTopTrigger: Int = 0
 ) {
     val feed by viewModel.feed.collectAsState()
     val feedType by viewModel.feedType.collectAsState()
@@ -104,6 +105,9 @@ fun FeedScreen(
     val nip05Version by viewModel.nip05Repo.version.collectAsState()
     val connectedCount by viewModel.relayPool.connectedCount.collectAsState()
     val listState = rememberLazyListState()
+    LaunchedEffect(scrollToTopTrigger) {
+        if (scrollToTopTrigger > 0) listState.animateScrollToItem(0)
+    }
     val userPubkey = viewModel.getUserPubkey()
     val selectedList by viewModel.selectedList.collectAsState()
     val ownLists by viewModel.listRepo.ownLists.collectAsState()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyScreen.kt
@@ -212,7 +212,7 @@ private fun MutedUsersTab(
                     Spacer(Modifier.width(12.dp))
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            text = profile?.displayName ?: profile?.name ?: pubkey.take(16) + "...",
+                            text = profile?.displayString ?: (pubkey.take(16) + "..."),
                             style = MaterialTheme.typography.bodyLarge,
                             color = MaterialTheme.colorScheme.onSurface,
                             maxLines = 1,

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -309,7 +309,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
                 val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
                 if (rootId != null) eventRepo.addReplyCount(rootId)
             }
-        } else if (subscriptionId.startsWith("zap-count-") || subscriptionId.startsWith("zaps") || subscriptionId.startsWith("zap-receipt-")) {
+        } else if (subscriptionId.startsWith("zap-count-") || subscriptionId.startsWith("zaps") || subscriptionId.startsWith("zap-rcpt-")) {
             if (event.kind == 9735) {
                 eventRepo.addEvent(event)
                 val zapperPubkey = Nip57.getZapperPubkey(event)
@@ -528,7 +528,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
      * Returns the subscription ID so the caller can close it early on failure.
      */
     private fun subscribeZapReceipt(eventId: String): String {
-        val subId = "zap-receipt-$eventId"
+        val subId = "zap-rcpt-${eventId.take(12)}"
         val filter = Filter(kinds = listOf(9735), eTags = listOf(eventId))
         relayPool.sendToReadRelays(ClientMessage.req(subId, filter))
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import com.wisp.app.nostr.NotificationGroup
 import com.wisp.app.nostr.ProfileData
+import com.wisp.app.repo.ContactRepository
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.NotificationRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,10 +23,16 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
 
     private var notifRepo: NotificationRepository? = null
     private var eventRepo: EventRepository? = null
+    private var contactRepo: ContactRepository? = null
 
-    fun init(notificationRepository: NotificationRepository, eventRepository: EventRepository) {
+    fun init(notificationRepository: NotificationRepository, eventRepository: EventRepository, contactRepository: ContactRepository) {
         notifRepo = notificationRepository
         eventRepo = eventRepository
+        contactRepo = contactRepository
+    }
+
+    fun isFollowing(pubkey: String): Boolean {
+        return contactRepo?.isFollowing(pubkey) ?: false
     }
 
     fun markRead() {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ProfileViewModel.kt
@@ -93,7 +93,7 @@ class ProfileViewModel(app: Application) : AndroidViewModel(app) {
         // Load from cache immediately
         val profile = eventRepo.getProfileData(pubkeyHex)
         if (profile != null) {
-            _name.value = profile.name ?: ""
+            _name.value = profile.displayName?.ifBlank { null } ?: profile.name ?: ""
             _about.value = profile.about ?: ""
             _picture.value = profile.picture ?: ""
             _nip05.value = profile.nip05 ?: ""
@@ -115,7 +115,7 @@ class ProfileViewModel(app: Application) : AndroidViewModel(app) {
                 if (event.kind == 0 && event.pubkey == pubkeyHex) {
                     eventRepo.addEvent(event)
                     val updated = eventRepo.getProfileData(pubkeyHex) ?: return@collect
-                    _name.value = updated.name ?: ""
+                    _name.value = updated.displayName?.ifBlank { null } ?: updated.name ?: ""
                     _about.value = updated.about ?: ""
                     _picture.value = updated.picture ?: ""
                     _nip05.value = updated.nip05 ?: ""
@@ -136,7 +136,10 @@ class ProfileViewModel(app: Application) : AndroidViewModel(app) {
         return try {
             _publishing.value = true
             val content = buildJsonObject {
-                if (_name.value.isNotBlank()) put("name", JsonPrimitive(_name.value))
+                if (_name.value.isNotBlank()) {
+                    put("display_name", JsonPrimitive(_name.value))
+                    put("name", JsonPrimitive(_name.value))
+                }
                 if (_about.value.isNotBlank()) put("about", JsonPrimitive(_about.value))
                 if (_picture.value.isNotBlank()) put("picture", JsonPrimitive(_picture.value))
                 if (_nip05.value.isNotBlank()) put("nip05", JsonPrimitive(_nip05.value))


### PR DESCRIPTION
## Summary
- Add follow badge dot indicator to all notification profile avatars (reactions, zaps, replies, quotes, mentions)
- Fix reply notifications not rendering content inline — adds on-demand event fetching and resolves profile directly from sender pubkey
- Enlarge stacked avatars on reaction/zap rows (24dp → 36dp) for easier tapping
- Add scroll-to-top on tab re-selection for Feed and Notifications screens
- Fix navigation to not use saveState/restoreState (prevents stale screen state)
- Shorten zap-receipt subscription IDs to avoid relay message length issues
- Fix ProfileData.displayString to skip blank display_name/name values; use consistently in drawer and safety screen
- Fix profile editor to prefer display_name and publish both display_name and name fields
- Reduce persistent relay reconnect cooldown for network/DNS failures to 5s (fixes "0 relays" after phone sleep)

## Test plan
- [ ] Verify follow badge dots appear on notification avatars for followed users
- [ ] Verify reply notifications render the reply content inline
- [ ] Verify tapping a tab scrolls the list to top
- [ ] Verify profile editing saves and displays correctly with display_name
- [ ] Verify relay reconnection works quickly after phone resume from sleep