### PR TITLE
Refactor subscription & request management

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionTracker.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionTracker.kt
@@ -1,0 +1,38 @@
+package com.wisp.app.relay
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Tracks active subscription IDs per relay URL to prevent subscription explosion.
+ * Enforces a soft cap per relay; priority subscriptions bypass the cap.
+ */
+class SubscriptionTracker {
+    private val relaySubs = ConcurrentHashMap<String, MutableSet<String>>()
+
+    companion object {
+        const val SOFT_CAP = 10
+        private val PRIORITY_PREFIXES = listOf("dms", "notif", "feed", "self-data")
+    }
+
+    fun track(relayUrl: String, subId: String) {
+        relaySubs.getOrPut(relayUrl) { ConcurrentHashMap.newKeySet() }.add(subId)
+    }
+
+    fun untrackAll(subId: String) {
+        for (subs in relaySubs.values) {
+            subs.remove(subId)
+        }
+    }
+
+    fun hasCapacity(relayUrl: String, subId: String): Boolean {
+        if (PRIORITY_PREFIXES.any { subId.startsWith(it) }) return true
+        val count = relaySubs[relayUrl]?.size ?: 0
+        return count < SOFT_CAP
+    }
+
+    fun getCount(relayUrl: String): Int = relaySubs[relayUrl]?.size ?: 0
+
+    fun clear() {
+        relaySubs.clear()
+    }
+}


### PR DESCRIPTION
## Summary
- **Message queuing**: Relay now queues messages (cap 50) when disconnected and drains on reconnection, preventing silently dropped messages during reconnect windows
- **Smarter reconnection**: Replaced `Thread.sleep` with coroutine `delay` in Relay, added `awaitAnyConnected()` to RelayPool replacing hardcoded `delay(2000)` in `onAppResume()`
- **Combined engagement subs**: Merged separate reaction/zap/reply-count subscriptions into single per-chunk engagement subscription (~14 subs → ~2 per feed load)
- **Unified quote resolution**: All quote fetching routes through one batched queue with cross-event dedup, 300ms debounce with flush-at-20 threshold, and failed fetch tracking to prevent infinite retries
- **Per-relay subscription tracking**: New `SubscriptionTracker` enforces soft cap of 10 subs per relay (priority subs like feed/dms/notif bypass), integrated into all RelayPool send methods

## Test plan
- [ ] Launch app → feed loads → reactions, zaps, and reply counts appear on notes
- [ ] Background app for 30s → foreground → feed refreshes without "0 relays connected"
- [ ] Scroll feed → quoted notes render (both q-tag and nostr: URI quotes)
- [ ] Check Relays screen: subscription count per relay stays under 10
- [ ] Monitor logcat for RelayPool tags: no "Cooldown" entries from 429 rate limiting