### PR TITLE
Harden private key handling to prevent potential leaks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <application
         android:name=".WispApp"
+        android:allowBackup="false"
         android:label="Wisp"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.NoActionBar">

--- a/app/src/main/kotlin/com/wisp/app/nostr/Keys.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Keys.kt
@@ -9,7 +9,12 @@ object Keys {
 
     data class Keypair(val privkey: ByteArray, val pubkey: ByteArray) {
         override fun equals(other: Any?) = other is Keypair && privkey.contentEquals(other.privkey)
-        override fun hashCode() = privkey.contentHashCode()
+        override fun hashCode() = pubkey.contentHashCode()
+        override fun toString() = "Keypair(pubkey=${pubkey.toHex()})"
+
+        fun wipe() {
+            privkey.wipe()
+        }
     }
 
     fun generate(): Keypair {
@@ -57,3 +62,6 @@ object Keys {
         return sharedPoint.copyOfRange(1, 33)
     }
 }
+
+/** Zero out sensitive byte arrays to minimize key exposure in memory. */
+fun ByteArray.wipe() = fill(0)

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip17.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip17.kt
@@ -56,6 +56,7 @@ object Nip17 {
         // Layer 2: Seal (kind 13) — encrypt rumor with sender→recipient conversation key
         val senderRecipientKey = Nip44.getConversationKey(senderPrivkey, recipientPubkey)
         val encryptedRumor = Nip44.encrypt(rumorJson, senderRecipientKey)
+        senderRecipientKey.wipe()
         val sealTimestamp = randomizeTimestamp(now)
         val seal = NostrEvent.create(
             privkey = senderPrivkey,
@@ -79,6 +80,10 @@ object Nip17 {
             tags = listOf(listOf("p", recipientPubkeyHex)),
             createdAt = wrapTimestamp
         )
+
+        // Wipe throwaway private key — no reason for it to persist
+        throwaway.wipe()
+        throwawayRecipientKey.wipe()
 
         return giftWrap
     }

--- a/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
@@ -3,12 +3,17 @@ package com.wisp.app.repo
 import android.util.LruCache
 import com.wisp.app.nostr.DmConversation
 import com.wisp.app.nostr.DmMessage
+import com.wisp.app.nostr.wipe
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class DmRepository {
     private val conversations = LruCache<String, MutableList<DmMessage>>(100)
-    private val conversationKeyCache = LruCache<String, ByteArray>(50)
+    private val conversationKeyCache = object : LruCache<String, ByteArray>(50) {
+        override fun entryRemoved(evicted: Boolean, key: String?, oldValue: ByteArray?, newValue: ByteArray?) {
+            oldValue?.wipe()
+        }
+    }
     // Maps giftWrapId → messageId so we can merge relay URLs on duplicate receipt
     private val seenGiftWraps = LruCache<String, String>(2000)
     private val dmRelayCache = LruCache<String, List<String>>(200)


### PR DESCRIPTION
## Summary
- **Disable Android backup** (`allowBackup="false"`) to prevent EncryptedSharedPreferences from being extracted via adb backup or Auto Backup
- **Harden `Keypair` class** — redact privkey from `toString()`, derive `hashCode()` from pubkey only, add `wipe()` method
- **Add `ByteArray.wipe()` extension** and use it to zero throwaway keys and conversation keys after use in NIP-17 gift wrap creation
- **Clear nsec on dispose** — `DisposableEffect` nulls out the revealed nsec string when the KeysScreen composable leaves composition
- **Sensitive clipboard flag** — mark private key clipboard data as sensitive on API 33+ to hide it from clipboard previews
- **Secure LruCache eviction** — override `entryRemoved()` on conversation key cache to zero evicted byte arrays

## Test plan
- [ ] Build and run on device/emulator
- [ ] Login with nsec — verify key stored, app functional
- [ ] Reveal key on KeysScreen — verify biometric prompt, nsec displayed, cleared on back navigation
- [ ] Send/receive DMs — verify NIP-17 encryption still works after wipe() calls
- [ ] Verify `adb backup` produces empty/no backup
- [ ] Check logcat during all operations for any key leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)