### PR TITLE
Full PostCard for reply notifications, NIP-05 impersonation detection, and reliability improvements

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip05.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip05.kt
@@ -8,6 +8,15 @@ import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
+enum class Nip05Result {
+    /** Pubkey matches the NIP-05 record. */
+    VERIFIED,
+    /** Server responded but pubkey does not match — possible impersonation. */
+    MISMATCH,
+    /** Could not reach server or parse response — temporary/unknown failure. */
+    ERROR
+}
+
 object Nip05 {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -15,30 +24,37 @@ object Nip05 {
      * Verify a NIP-05 identifier against a pubkey.
      * Parses "local@domain", fetches https://domain/.well-known/nostr.json?name=local,
      * and checks that names[local] matches the given pubkey hex.
+     *
+     * Returns [Nip05Result.VERIFIED] on match, [Nip05Result.MISMATCH] when the server
+     * responds with a different pubkey, or [Nip05Result.ERROR] on network/parse failures.
      */
-    suspend fun verify(identifier: String, pubkeyHex: String, httpClient: OkHttpClient): Boolean =
+    suspend fun verify(identifier: String, pubkeyHex: String, httpClient: OkHttpClient): Nip05Result =
         withContext(Dispatchers.IO) {
             try {
                 val parts = identifier.split("@", limit = 2)
-                if (parts.size != 2) return@withContext false
+                if (parts.size != 2) return@withContext Nip05Result.ERROR
 
-                val local = parts[0].ifEmpty { return@withContext false }
-                val domain = parts[1].ifEmpty { return@withContext false }
+                val local = parts[0].ifEmpty { return@withContext Nip05Result.ERROR }
+                val domain = parts[1].ifEmpty { return@withContext Nip05Result.ERROR }
 
                 val url = "https://$domain/.well-known/nostr.json?name=$local"
                 val request = Request.Builder().url(url).build()
                 val response = httpClient.newCall(request).execute()
 
-                if (!response.isSuccessful) return@withContext false
+                if (!response.isSuccessful) return@withContext Nip05Result.ERROR
 
-                val body = response.body?.string() ?: return@withContext false
+                val body = response.body?.string() ?: return@withContext Nip05Result.ERROR
                 val root = json.parseToJsonElement(body).jsonObject
-                val names = root["names"]?.jsonObject ?: return@withContext false
+                val names = root["names"]?.jsonObject ?: return@withContext Nip05Result.MISMATCH
                 val registeredPubkey = names[local]?.jsonPrimitive?.content
+                    ?: return@withContext Nip05Result.MISMATCH
 
-                registeredPubkey.equals(pubkeyHex, ignoreCase = true)
+                if (registeredPubkey.equals(pubkeyHex, ignoreCase = true))
+                    Nip05Result.VERIFIED
+                else
+                    Nip05Result.MISMATCH
             } catch (_: Exception) {
-                false
+                Nip05Result.ERROR
             }
         }
 }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayScoreBoard.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayScoreBoard.kt
@@ -32,6 +32,11 @@ class RelayScoreBoard(
 
     init {
         loadFromPrefs()
+        // Rebuild scored relays from cached URLs + persisted RelayListRepository data
+        // so the pool can be restored immediately after process restart
+        if (scoredRelayUrls.isNotEmpty() && scoredRelays.isEmpty()) {
+            recompute()
+        }
     }
 
     /**

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.zIndex
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Refresh
 import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.ProfileData
@@ -93,7 +94,8 @@ fun PostCard(
     onPin: () -> Unit = {},
     isPinned: Boolean = false,
     onQuotedNoteClick: ((String) -> Unit)? = null,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = true
 ) {
     val displayName = remember(event.pubkey, profile?.displayString) {
         profile?.displayString
@@ -156,12 +158,12 @@ fun PostCard(
                 profile?.nip05?.let { nip05 ->
                     nip05Repo?.checkOrFetch(event.pubkey, nip05)
                     val status = nip05Repo?.getStatus(event.pubkey)
-                    val isFailed = status == Nip05Status.FAILED
+                    val isImpersonator = status == Nip05Status.IMPERSONATOR
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = if (isFailed) "\u2715 $nip05" else nip05,
+                            text = if (isImpersonator) "\u2715 $nip05" else nip05,
                             style = MaterialTheme.typography.bodySmall,
-                            color = if (isFailed) Color.Red else MaterialTheme.colorScheme.primary,
+                            color = if (isImpersonator) Color.Red else MaterialTheme.colorScheme.primary,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f, fill = false)
@@ -173,6 +175,17 @@ fun PostCard(
                                 contentDescription = "Verified",
                                 tint = Color(0xFFFF8C00),
                                 modifier = Modifier.size(14.dp)
+                            )
+                        }
+                        if (status == Nip05Status.ERROR) {
+                            Spacer(Modifier.width(4.dp))
+                            Icon(
+                                Icons.Default.Refresh,
+                                contentDescription = "Retry verification",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .size(14.dp)
+                                    .clickable { nip05Repo?.retry(event.pubkey) }
                             )
                         }
                     }
@@ -335,7 +348,9 @@ fun PostCard(
                 }
             }
         }
-        HorizontalDivider(color = MaterialTheme.colorScheme.outline, thickness = 0.5.dp)
+        if (showDivider) {
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline, thickness = 0.5.dp)
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -246,12 +247,24 @@ fun QuotedNote(eventId: String, eventRepo: EventRepository, relayHints: List<Str
                 )
             }
         } else {
-            Text(
-                text = "Referenced note ${eventId.take(8)}...",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.padding(14.dp)
-            )
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .width(14.dp)
+                        .height(14.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "Loading note...",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.QrCode2
 import androidx.compose.material3.DropdownMenu
@@ -580,12 +581,12 @@ private fun ProfileHeader(
         profile?.nip05?.let { nip05 ->
             if (pubkey.isNotEmpty()) nip05Repo?.checkOrFetch(pubkey, nip05)
             val status = if (pubkey.isNotEmpty()) nip05Repo?.getStatus(pubkey) else null
-            val isFailed = status == Nip05Status.FAILED
+            val isImpersonator = status == Nip05Status.IMPERSONATOR
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = if (isFailed) "\u2715 $nip05" else nip05,
+                    text = if (isImpersonator) "\u2715 $nip05" else nip05,
                     style = MaterialTheme.typography.bodySmall,
-                    color = if (isFailed) Color.Red else MaterialTheme.colorScheme.primary
+                    color = if (isImpersonator) Color.Red else MaterialTheme.colorScheme.primary
                 )
                 if (status == Nip05Status.VERIFIED) {
                     Spacer(Modifier.width(4.dp))
@@ -594,6 +595,17 @@ private fun ProfileHeader(
                         contentDescription = "Verified",
                         tint = Color(0xFFFF8C00),
                         modifier = Modifier.size(14.dp)
+                    )
+                }
+                if (status == Nip05Status.ERROR) {
+                    Spacer(Modifier.width(4.dp))
+                    Icon(
+                        Icons.Default.Refresh,
+                        contentDescription = "Retry verification",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .size(14.dp)
+                            .clickable { nip05Repo?.retry(pubkey) }
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
@@ -21,6 +21,9 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
     val eventRepository: EventRepository?
         get() = eventRepo
 
+    val contactRepository: ContactRepository?
+        get() = contactRepo
+
     private var notifRepo: NotificationRepository? = null
     private var eventRepo: EventRepository? = null
     private var contactRepo: ContactRepository? = null


### PR DESCRIPTION
## Summary

- **Notification reply cards**: Reply notifications now render as full PostCards (same as the feed), so users can react, zap, repost, quote, and bookmark replies directly from the notifications tab. A clickable "reply to #note1abc..." label links back to the original note being replied to.
- **NIP-05 impersonation detection**: Distinguishes between server mismatch (impersonation — permanent red X) and network/parse errors (temporary — shows retry icon). Applies to PostCard and UserProfileScreen.
- **Relay reliability**: Removes cooldowns from persistent relays to avoid cascading delays on app resume. Merges cached scored relays with pinned relays on init so the pool starts with the full relay set immediately after process restart.
- **Event deduplication**: Adds dedup sets for reaction and zap counting to prevent double-counting when the seenEventIds LRU is trimmed and events are re-processed.
- **Quoted note improvements**: Shows a loading spinner while fetching referenced notes, retries failed fetches after 30s instead of permanently blacklisting, and sends quote requests to all relays.
- **Feed lifecycle fix**: Uses Activity lifecycle instead of NavBackStackEntry for resume detection, preventing duplicate re-subscriptions when switching tabs.

## Changed files

| File | Change |
|------|--------|
| `NotificationsScreen.kt` | Replace inline reply rendering with full PostCard; add "reply to" label; collect version flows for live stats |
| `Navigation.kt` | Wire up zap dialog, bookmark state, and all action callbacks for notification reply cards |
| `NotificationsViewModel.kt` | Expose `contactRepository` getter |
| `PostCard.kt` | Add `showDivider` param; NIP-05 impersonation vs error handling with retry icon |
| `Nip05.kt` | New `Nip05Result` enum (VERIFIED/MISMATCH/ERROR) replacing boolean return |
| `Nip05Repository.kt` | New `IMPERSONATOR` and `ERROR` statuses; `retry()` method; identifier caching |
| `UserProfileScreen.kt` | NIP-05 impersonation detection and retry icon |
| `RelayPool.kt` | Cooldowns only for ephemeral relays |
| `RelayScoreBoard.kt` | Rebuild scored relays from persisted data on init |
| `FeedViewModel.kt` | Merge cached scored relays with pinned on init |
| `EventRepository.kt` | Reaction/zap dedup sets to prevent double-counting |
| `MetadataFetcher.kt` | Retry failed quotes after 30s; send to all relays; evict by age |
| `RichContent.kt` | Loading spinner for unfetched quoted notes |
| `FeedScreen.kt` | Activity lifecycle for resume detection |

## Test plan

- [ ] Open notifications tab and verify reply notifications render as full note cards with action bar
- [ ] React/zap/repost a reply directly from notifications and confirm counts update
- [ ] Tap "reply to #note1abc..." label and verify navigation to the original note thread
- [ ] Verify NIP-05 verified users show orange checkmark, impersonators show red X, errors show retry icon
- [ ] Kill and restart app, verify relays reconnect quickly without long cooldown delays
- [ ] Verify reaction/zap counts remain accurate after extended use (no double-counting)
- [ ] Verify quoted notes show loading spinner then resolve correctly