### PR TITLE
Thread performance, engagement reliability, and drawer improvements

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -351,7 +351,8 @@ fun WispNavHost() {
                     contactRepo = feedViewModel.contactRepo,
                     relayPool = feedViewModel.relayPool,
                     outboxRouter = feedViewModel.outboxRouter,
-                    relayListRepo = feedViewModel.relayListRepo
+                    relayListRepo = feedViewModel.relayListRepo,
+                    subManager = feedViewModel.subManager
                 )
             }
             val isBlockedState by feedViewModel.muteRepo.blockedPubkeys.collectAsState()
@@ -488,6 +489,7 @@ fun WispNavHost() {
             val eventId = backStackEntry.arguments?.getString("eventId") ?: return@composable
             val threadViewModel: ThreadViewModel = viewModel()
             LaunchedEffect(eventId) {
+                feedViewModel.pauseEngagement()
                 threadViewModel.loadThread(
                     eventId = eventId,
                     eventRepo = feedViewModel.eventRepo,
@@ -496,6 +498,9 @@ fun WispNavHost() {
                     queueProfileFetch = { pubkey -> feedViewModel.queueProfileFetch(pubkey) },
                     muteRepo = feedViewModel.muteRepo
                 )
+            }
+            androidx.compose.runtime.DisposableEffect(Unit) {
+                onDispose { feedViewModel.resumeEngagement() }
             }
             var threadZapTarget by remember { mutableStateOf<NostrEvent?>(null) }
             val threadZapInProgress by feedViewModel.zapInProgress.collectAsState()

--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionTracker.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionTracker.kt
@@ -10,8 +10,8 @@ class SubscriptionTracker {
     private val relaySubs = ConcurrentHashMap<String, MutableSet<String>>()
 
     companion object {
-        const val SOFT_CAP = 10
-        private val PRIORITY_PREFIXES = listOf("dms", "notif", "feed", "self-data")
+        const val SOFT_CAP = 15
+        private val PRIORITY_PREFIXES = listOf("dms", "notif", "feed", "self-data", "thread-")
     }
 
     fun track(relayUrl: String, subId: String) {

--- a/app/src/main/kotlin/com/wisp/app/ui/component/LightningQrDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/LightningQrDialog.kt
@@ -1,0 +1,119 @@
+package com.wisp.app.ui.component
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+
+@Composable
+fun LightningQrDialog(lud16: String, onDismiss: () -> Unit) {
+    val qrBitmap = remember(lud16) {
+        val writer = QRCodeWriter()
+        val matrix = writer.encode(lud16, BarcodeFormat.QR_CODE, 512, 512)
+        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
+        for (x in 0 until matrix.width) {
+            for (y in 0 until matrix.height) {
+                bitmap.setPixel(x, y, if (matrix.get(x, y)) Color.BLACK else Color.WHITE)
+            }
+        }
+        bitmap
+    }
+
+    val clipboardManager = LocalClipboardManager.current
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.surface,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(24.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, "Close")
+                    }
+                }
+
+                Image(
+                    bitmap = qrBitmap.asImageBitmap(),
+                    contentDescription = "Lightning QR Code",
+                    modifier = Modifier
+                        .size(256.dp)
+                        .background(androidx.compose.ui.graphics.Color.White)
+                        .padding(8.dp)
+                )
+
+                Spacer(Modifier.height(20.dp))
+
+                Text(
+                    text = "Lightning Address",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = lud16,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = {
+                        clipboardManager.setText(AnnotatedString(lud16))
+                    }) {
+                        Icon(
+                            Icons.Default.ContentCopy,
+                            contentDescription = "Copy lightning address",
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -1,10 +1,13 @@
 package com.wisp.app.ui.component
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -17,11 +20,13 @@ import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.FormatListBulleted
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.QrCode2
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.NavigationDrawerItem
@@ -32,6 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -59,15 +65,50 @@ fun WispDrawerContent(
         drawerContainerColor = MaterialTheme.colorScheme.surface
     ) {
         Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+        var showQrDialog by remember { mutableStateOf(false) }
+        var showLightningDialog by remember { mutableStateOf(false) }
+
         Column(modifier = Modifier.padding(16.dp)) {
-            ProfilePicture(url = profile?.picture, size = 64)
-            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.padding(bottom = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                ProfilePicture(url = profile?.picture, size = 64)
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = { showQrDialog = true }) {
+                    Icon(
+                        Icons.Outlined.QrCode2,
+                        contentDescription = "Show QR code",
+                        modifier = Modifier.size(24.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (profile?.lud16 != null) {
+                    IconButton(onClick = { showLightningDialog = true }) {
+                        Icon(
+                            Icons.Outlined.CurrencyBitcoin,
+                            contentDescription = "Lightning address",
+                            modifier = Modifier.size(24.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
             Text(
                 text = profile?.displayString ?: "Anonymous",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            if (pubkey != null) {
+            if (!profile?.nip05.isNullOrBlank()) {
+                Text(
+                    text = profile!!.nip05!!,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            } else if (pubkey != null) {
                 Text(
                     text = pubkey.take(16) + "...",
                     style = MaterialTheme.typography.bodySmall,
@@ -76,6 +117,13 @@ fun WispDrawerContent(
                     overflow = TextOverflow.Ellipsis
                 )
             }
+        }
+
+        if (showQrDialog && pubkey != null) {
+            QrCodeDialog(pubkeyHex = pubkey, onDismiss = { showQrDialog = false })
+        }
+        if (showLightningDialog && profile?.lud16 != null) {
+            LightningQrDialog(lud16 = profile.lud16, onDismiss = { showLightningDialog = false })
         }
 
         Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Summary

- **Thread reaction loading is dramatically faster**: reduced reply EOSE timeout from 20s to 1.5s (relays deliver replies well within this window), merged reaction + zap filters into a single subscription per batch (halving sub count), and feed engagement subs are now paused while a thread is open to free subscription capacity
- **Subscription capacity no longer silently drops thread requests**: `thread-` added to priority prefixes in SubscriptionTracker and soft cap raised from 10 to 15
- **Engagement data now appears on user profile posts**: UserProfileViewModel subscribes for reactions, zaps, and reply counts after posts load
- **Feed loading is faster and more reliable**: 24h `since` filter on initial feed subscription with automatic backfill for low-activity feeds, engagement subs stay open for live updates, and loadMore now subscribes engagement for newly loaded events
- **Thread-safety fixes in EventRepository**: ConcurrentHashMap for reaction counts/details, synchronized lists for zap details, per-target dedup sets that evict with their count caches, and reply count dedup moved into `addReplyCount()`
- **Navigation drawer improvements**: QR code and Lightning address buttons, NIP-05 display when available, new LightningQrDialog component

## Test plan

- [ ] Open a thread with many replies — reactions/zaps should appear within ~2s of replies loading, not 20s+
- [ ] Verify reaction counts, zap amounts, and reply counts are correct (no double-counting)
- [ ] Navigate back from thread to feed — engagement data should reappear on feed posts
- [ ] Open a user profile — posts should show reaction/zap/reply counts
- [ ] Check feed loads quickly on first launch and backfills if < 10 posts in 24h window
- [ ] Verify QR code and Lightning buttons in navigation drawer work correctly
- [ ] Test with multiple relays to confirm subscription capacity isn't exhausted