### PR TITLE
Smart relay backoff and refresh reliability fixes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -122,6 +123,7 @@ fun FeedScreen(
     val userProfile = profileVersion.let { userPubkey?.let { viewModel.eventRepo.getProfileData(it) } }
 
     val newNoteCount by viewModel.newNoteCount.collectAsState()
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
     val zapInProgress by viewModel.zapInProgress.collectAsState()
     val bookmarkedIds by viewModel.bookmarkRepo.bookmarkedIds.collectAsState()
     val pinnedIds by viewModel.pinRepo.pinnedIds.collectAsState()
@@ -475,7 +477,9 @@ fun FeedScreen(
                 }
             }
         ) { padding ->
-            Column(
+            PullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = { viewModel.refreshFeed() },
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)


### PR DESCRIPTION
## Summary
- **Connection attempt tracking**: Each relay tracks connect() calls in a sliding 60s window. After 20 attempts, the relay enters a 5-minute cooldown. Successful connections reset the counter.
- **Fix duplicate WebSocket connections on refresh**: `refreshFeed()` was calling `reconnectAll()` right after `updateRelays()` which already connects new relays, causing duplicate WebSocket handshakes for relays mid-connect. Removed the redundant call and added a `webSocket != null` guard in `connect()`.
- **DM relays included in connected count**: `updateConnectedCount()` was only counting persistent + ephemeral relays, missing DM relays entirely.
- **Count refreshed after reconnectAll()**: Explicitly recalculates after cleanup to avoid stale values.
- **PullToRefreshBox**: Native Material3 pull-to-refresh on the feed screen.
- **Adaptive feed time window**: Scales the `since` filter based on follow count (7 days for ≤20 follows down to 30 min for 700+).

## Test plan
- [ ] Pull-to-refresh on feed — counter should accurately reflect all connected relays (persistent + DM + ephemeral)
- [ ] Simulate a failing relay (bad URL) — verify it enters 5 min cooldown after repeated failures, visible in relay console
- [ ] Manual reconnect from relay screen should clear backoff and reconnect immediately
- [ ] Small follow list (<20) should show older posts; large list (700+) should show recent only