### PR TITLE
NIP-42 AUTH, DM reliability, relay picker, and profile enhancements

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -403,7 +403,8 @@ fun WispNavHost() {
                 bookmarkedIds = profileBookmarkedIds,
                 pinnedIds = profilePinnedIds,
                 onToggleBookmark = { eventId -> feedViewModel.toggleBookmark(eventId) },
-                onTogglePin = { eventId -> feedViewModel.togglePin(eventId) }
+                onTogglePin = { eventId -> feedViewModel.togglePin(eventId) },
+                onSendDm = if (!isOwnProfile) {{ navController.navigate("dm/$pubkey") }} else null
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/nostr/ClientMessage.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/ClientMessage.kt
@@ -29,6 +29,14 @@ object ClientMessage {
         }.toString()
     }
 
+    fun auth(event: NostrEvent): String {
+        val eventJson = Json.parseToJsonElement(event.toJson())
+        return buildJsonArray {
+            add(JsonPrimitive("AUTH"))
+            add(eventJson)
+        }.toString()
+    }
+
     fun close(subscriptionId: String): String {
         return buildJsonArray {
             add(JsonPrimitive("CLOSE"))

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip44.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip44.kt
@@ -19,10 +19,8 @@ object Nip44 {
     fun getConversationKey(privkey: ByteArray, pubkey: ByteArray): ByteArray {
         val compressed = Keys.pubkeyToCompressed(pubkey)
         val sharedSecret = Keys.ecdh(privkey, compressed)
-        // HKDF-Extract(salt=empty, ikm=sharedSecret) -> PRK
-        val prk = hkdfExtract(ByteArray(32), sharedSecret)
-        // HKDF-Expand(prk, info="nip44-v2", len=32) -> conversation key
-        return hkdfExpand(prk, "nip44-v2".toByteArray(Charsets.UTF_8), 32)
+        // HKDF-Extract(salt="nip44-v2", ikm=sharedSecret) -> conversation key
+        return hkdfExtract("nip44-v2".toByteArray(Charsets.UTF_8), sharedSecret)
     }
 
     /**
@@ -145,8 +143,8 @@ object Nip44 {
     }
 
     private fun deriveMessageKeys(conversationKey: ByteArray, nonce: ByteArray): ByteArray {
-        val prk = hkdfExtract(conversationKey, nonce)
-        return hkdfExpand(prk, "nip44-v2".toByteArray(Charsets.UTF_8), 76)
+        // HKDF-Expand(prk=conversationKey, info=nonce, len=76)
+        return hkdfExpand(conversationKey, nonce, 76)
     }
 
     // --- Crypto Primitives ---

--- a/app/src/main/kotlin/com/wisp/app/nostr/RelayMessage.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/RelayMessage.kt
@@ -10,6 +10,7 @@ sealed class RelayMessage {
     data class Eose(val subscriptionId: String) : RelayMessage()
     data class Ok(val eventId: String, val accepted: Boolean, val message: String) : RelayMessage()
     data class Notice(val message: String) : RelayMessage()
+    data class Auth(val challenge: String) : RelayMessage()
 
     companion object {
         private val json = Json { ignoreUnknownKeys = true }
@@ -35,6 +36,7 @@ sealed class RelayMessage {
                         message = if (array.size > 3) array[3].jsonPrimitive.content else ""
                     )
                     "NOTICE" -> Notice(array[1].jsonPrimitive.content)
+                    "AUTH" -> Auth(array[1].jsonPrimitive.content)
                     else -> null
                 }
             } catch (e: Exception) {

--- a/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class DmRepository {
+    private val lock = Any()
     private val conversations = LruCache<String, MutableList<DmMessage>>(100)
     private val conversationKeyCache = object : LruCache<String, ByteArray>(50) {
         override fun entryRemoved(evicted: Boolean, key: String?, oldValue: ByteArray?, newValue: ByteArray?) {
@@ -25,37 +26,47 @@ class DmRepository {
     val hasUnreadDms: StateFlow<Boolean> = _hasUnreadDms
 
     fun addMessage(msg: DmMessage, peerPubkey: String) {
-        val existingMsgId = seenGiftWraps.get(msg.giftWrapId)
-        if (existingMsgId != null) {
-            // Already seen — merge relay URLs into existing message
-            if (msg.relayUrls.isNotEmpty()) {
-                mergeRelayUrls(peerPubkey, existingMsgId, msg.relayUrls)
+        synchronized(lock) {
+            val existingMsgId = seenGiftWraps.get(msg.giftWrapId)
+            if (existingMsgId != null) {
+                if (msg.relayUrls.isNotEmpty()) {
+                    mergeRelayUrlsLocked(peerPubkey, existingMsgId, msg.relayUrls)
+                }
+                return
             }
-            return
-        }
-        seenGiftWraps.put(msg.giftWrapId, msg.id)
-        _hasUnreadDms.value = true
+            seenGiftWraps.put(msg.giftWrapId, msg.id)
+            _hasUnreadDms.value = true
 
-        val messages = conversations.get(peerPubkey) ?: mutableListOf<DmMessage>().also {
-            conversations.put(peerPubkey, it)
+            val messages = conversations.get(peerPubkey) ?: mutableListOf<DmMessage>().also {
+                conversations.put(peerPubkey, it)
+            }
+            messages.add(msg)
+            messages.sortBy { it.createdAt }
         }
-        messages.add(msg)
-        messages.sortBy { it.createdAt }
         updateConversationList()
     }
 
-    private fun mergeRelayUrls(peerPubkey: String, messageId: String, newUrls: Set<String>) {
+    /** Must be called while holding [lock]. */
+    private fun mergeRelayUrlsLocked(peerPubkey: String, messageId: String, newUrls: Set<String>) {
         val messages = conversations.get(peerPubkey) ?: return
         val idx = messages.indexOfFirst { it.id == messageId }
         if (idx >= 0) {
             val existing = messages[idx]
             messages[idx] = existing.copy(relayUrls = existing.relayUrls + newUrls)
-            updateConversationList()
+        }
+    }
+
+    /** Pre-register a gift wrap ID as seen so it gets deduped when received from relays. */
+    fun markGiftWrapSeen(giftWrapId: String, messageId: String) {
+        synchronized(lock) {
+            seenGiftWraps.put(giftWrapId, messageId)
         }
     }
 
     fun getConversation(peerPubkey: String): List<DmMessage> {
-        return conversations.get(peerPubkey)?.toList() ?: emptyList()
+        return synchronized(lock) {
+            conversations.get(peerPubkey)?.toList() ?: emptyList()
+        }
     }
 
     fun getCachedConversationKey(pubkeyHex: String): ByteArray? {
@@ -77,28 +88,34 @@ class DmRepository {
     fun getCachedDmRelays(pubkey: String): List<String>? = dmRelayCache.get(pubkey)
 
     fun purgeUser(pubkey: String) {
-        conversations.remove(pubkey)
-        conversationKeyCache.remove(pubkey)
+        synchronized(lock) {
+            conversations.remove(pubkey)
+            conversationKeyCache.remove(pubkey)
+        }
         updateConversationList()
     }
 
     fun clear() {
-        conversations.evictAll()
-        conversationKeyCache.evictAll()
-        seenGiftWraps.evictAll()
-        dmRelayCache.evictAll()
+        synchronized(lock) {
+            conversations.evictAll()
+            conversationKeyCache.evictAll()
+            seenGiftWraps.evictAll()
+            dmRelayCache.evictAll()
+        }
         _conversationList.value = emptyList()
         _hasUnreadDms.value = false
     }
 
     private fun updateConversationList() {
-        val snapshot = conversations.snapshot()
-        val list = snapshot.map { (peer, messages) ->
-            DmConversation(
-                peerPubkey = peer,
-                messages = messages.toList(),
-                lastMessageAt = messages.maxOfOrNull { it.createdAt } ?: 0
-            )
+        val list = synchronized(lock) {
+            val snapshot = conversations.snapshot()
+            snapshot.map { (peer, messages) ->
+                DmConversation(
+                    peerPubkey = peer,
+                    messages = messages.toList(),
+                    lastMessageAt = messages.maxOfOrNull { it.createdAt } ?: 0
+                )
+            }
         }.sortedByDescending { it.lastMessageAt }
         _conversationList.value = list
     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
@@ -3,6 +3,7 @@ package com.wisp.app.ui.screen
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -51,6 +53,7 @@ fun DmConversationScreen(
 ) {
     val messages by viewModel.messages.collectAsState()
     val messageText by viewModel.messageText.collectAsState()
+    val sending by viewModel.sending.collectAsState()
     val listState = rememberLazyListState()
 
     // Auto-scroll to bottom when new messages arrive
@@ -123,16 +126,24 @@ fun DmConversationScreen(
                     modifier = Modifier.weight(1f)
                 )
                 Spacer(Modifier.width(8.dp))
-                IconButton(
-                    onClick = { viewModel.sendMessage(relayPool) },
-                    enabled = messageText.isNotBlank()
-                ) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.Send,
-                        contentDescription = "Send",
-                        tint = if (messageText.isNotBlank()) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurfaceVariant
+                if (sending) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary
                     )
+                } else {
+                    IconButton(
+                        onClick = { viewModel.sendMessage(relayPool) },
+                        enabled = messageText.isNotBlank()
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Send",
+                            tint = if (messageText.isNotBlank()) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
@@ -13,33 +13,22 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.wisp.app.nostr.Nip19
-import com.wisp.app.nostr.hexToByteArray
-import com.wisp.app.nostr.toHex
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.viewmodel.DmListViewModel
@@ -56,8 +45,6 @@ fun DmListScreen(
     onConversation: (String) -> Unit
 ) {
     val conversations by viewModel.conversationList.collectAsState()
-    var showNewDmDialog by remember { mutableStateOf(false) }
-    var newDmInput by remember { mutableStateOf("") }
 
     Scaffold(
         topBar = {
@@ -74,14 +61,6 @@ fun DmListScreen(
                     containerColor = MaterialTheme.colorScheme.surface
                 )
             )
-        },
-        floatingActionButton = {
-            FloatingActionButton(
-                onClick = { showNewDmDialog = true },
-                containerColor = MaterialTheme.colorScheme.primary
-            ) {
-                Icon(Icons.Default.Add, contentDescription = "New message")
-            }
         }
     ) { padding ->
         if (conversations.isEmpty()) {
@@ -99,7 +78,7 @@ fun DmListScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    "Tap + to start a conversation",
+                    "Send a message from someone's profile",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -153,50 +132,6 @@ fun DmListScreen(
                 }
             }
         }
-    }
-
-    if (showNewDmDialog) {
-        AlertDialog(
-            onDismissRequest = { showNewDmDialog = false },
-            title = { Text("New Message") },
-            text = {
-                OutlinedTextField(
-                    value = newDmInput,
-                    onValueChange = { newDmInput = it },
-                    label = { Text("npub or hex pubkey") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            },
-            confirmButton = {
-                TextButton(onClick = {
-                    val pubkey = resolvePubkey(newDmInput.trim())
-                    if (pubkey != null) {
-                        showNewDmDialog = false
-                        newDmInput = ""
-                        onConversation(pubkey)
-                    }
-                }) { Text("Start") }
-            },
-            dismissButton = {
-                TextButton(onClick = {
-                    showNewDmDialog = false
-                    newDmInput = ""
-                }) { Text("Cancel") }
-            }
-        )
-    }
-}
-
-private fun resolvePubkey(input: String): String? {
-    return try {
-        if (input.startsWith("npub1")) {
-            Nip19.npubDecode(input).toHex()
-        } else if (input.length == 64 && input.all { it in '0'..'9' || it in 'a'..'f' }) {
-            input
-        } else null
-    } catch (_: Exception) {
-        null
     }
 }
 


### PR DESCRIPTION
## Summary
- **NIP-42 AUTH**: Full relay authentication flow — parse AUTH challenges, sign kind-22242 events, and automatically re-send DM subscriptions after auth completes
- **NIP-44 fix**: Correct HKDF key derivation to match spec (salt/ikm order in Extract, conversation key as PRK in Expand)
- **DM reliability**: Thread-safe DmRepository with synchronized access, gift wrap dedup for sent messages, send spinner UX, DM subscriptions sent to DM relays
- **Relay picker**: Replace flat list with scored relay board showing follow coverage counts, plus manual relay probe input with wss/ws fallback
- **Profile enhancements**: DM button on other users' profiles, lightning address display, rich content in bio, bare npub1 detection in RichContent
- **UX cleanup**: Remove new-DM FAB dialog in favor of profile-initiated conversations

## Test plan
- [ ] Verify AUTH handshake works with relays that require it (e.g. relay.nostr.band)
- [ ] Send and receive DMs — confirm no duplicate messages on send
- [ ] Open relay picker and verify scored relays appear with coverage counts
- [ ] Probe a custom relay domain in the picker
- [ ] Check DM button appears on other users' profiles and navigates correctly
- [ ] Verify lightning address shows on profiles that have one
- [ ] Confirm bare npub1 mentions render as profile links in notes and bios