### PR TITLE
Wallet send/receive, reaction toggle, NWC encryption, and relay feed fix

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -248,7 +248,7 @@ fun WispNavHost() {
                     navController.navigate(Routes.DM_LIST)
                 },
                 onReact = { event, emoji ->
-                    feedViewModel.sendReaction(event, emoji)
+                    feedViewModel.toggleReaction(event, emoji)
                 },
                 onNoteClick = { event ->
                     navController.navigate("thread/${event.id}")
@@ -385,7 +385,7 @@ fun WispNavHost() {
                 onUnblockUser = { feedViewModel.unblockUser(pubkey) },
                 onNoteClick = { event -> navController.navigate("thread/${event.id}") },
                 onQuotedNoteClick = { eventId -> navController.navigate("thread/$eventId") },
-                onReact = { event, emoji -> feedViewModel.sendReaction(event, emoji) },
+                onReact = { event, emoji -> feedViewModel.toggleReaction(event, emoji) },
                 onZap = { event, amountMsats, message -> feedViewModel.sendZap(event, amountMsats, message) },
                 userPubkey = feedViewModel.getUserPubkey(),
                 isWalletConnected = feedViewModel.nwcRepo.hasConnection(),
@@ -430,7 +430,7 @@ fun WispNavHost() {
                     navController.navigate(Routes.COMPOSE)
                 },
                 onReact = { event, emoji ->
-                    feedViewModel.sendReaction(event, emoji)
+                    feedViewModel.toggleReaction(event, emoji)
                 },
                 onListClick = { list ->
                     navController.navigate("list/${list.pubkey}/${list.dTag}")
@@ -552,7 +552,7 @@ fun WispNavHost() {
                     navController.navigate("thread/$eventId")
                 },
                 onReact = { event, emoji ->
-                    feedViewModel.sendReaction(event, emoji)
+                    feedViewModel.toggleReaction(event, emoji)
                 },
                 onRepost = { event ->
                     feedViewModel.sendRepost(event)
@@ -671,7 +671,7 @@ fun WispNavHost() {
                     composeViewModel.clear()
                     navController.navigate(Routes.COMPOSE)
                 },
-                onReact = { event, emoji -> feedViewModel.sendReaction(event, emoji) },
+                onReact = { event, emoji -> feedViewModel.toggleReaction(event, emoji) },
                 onProfileClick = { pubkey -> navController.navigate("profile/$pubkey") },
                 onToggleBookmark = { eventId -> feedViewModel.toggleBookmark(eventId) },
                 onToggleFollow = { pubkey -> feedViewModel.toggleFollow(pubkey) },
@@ -798,7 +798,7 @@ fun WispNavHost() {
                     navController.navigate(Routes.COMPOSE)
                 },
                 onReact = { event, emoji ->
-                    feedViewModel.sendReaction(event, emoji)
+                    feedViewModel.toggleReaction(event, emoji)
                 },
                 onRepost = { event ->
                     feedViewModel.sendRepost(event)

--- a/app/src/main/kotlin/com/wisp/app/nostr/Bolt11.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Bolt11.kt
@@ -1,0 +1,126 @@
+package com.wisp.app.nostr
+
+object Bolt11 {
+    private val bech32Charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+    private val hrpAmountRegex = Regex("""ln\w+?(\d+)([munp]?)$""")
+
+    data class DecodedInvoice(
+        val amountSats: Long?,
+        val paymentHash: String?,
+        val description: String?,
+        val expiry: Long,
+        val timestamp: Long
+    ) {
+        fun isExpired(): Boolean {
+            val now = System.currentTimeMillis() / 1000
+            return now > timestamp + expiry
+        }
+    }
+
+    fun decode(invoice: String): DecodedInvoice? {
+        val lower = invoice.lowercase().removePrefix("lightning:")
+        val pos = lower.lastIndexOf('1')
+        if (pos < 1) return null
+
+        val hrp = lower.substring(0, pos)
+        val dataStr = lower.substring(pos + 1)
+        if (dataStr.length < 7 + 104) return null // timestamp(7) + signature(104) minimum
+
+        // Decode bech32 data characters to 5-bit values
+        val data5 = IntArray(dataStr.length)
+        for (i in dataStr.indices) {
+            val idx = bech32Charset.indexOf(dataStr[i])
+            if (idx < 0) return null
+            data5[i] = idx
+        }
+
+        // Remove 6-char bech32 checksum from end
+        val dataLen = data5.size - 6
+        if (dataLen < 7 + 104) return null
+
+        // Parse amount from HRP
+        val amountSats = parseHrpAmount(hrp)
+
+        // Timestamp: first 7 x 5-bit values = 35-bit big-endian unix timestamp
+        var timestamp = 0L
+        for (i in 0 until 7) {
+            timestamp = (timestamp shl 5) or data5[i].toLong()
+        }
+
+        // Parse tagged fields (between timestamp and signature)
+        val sigStart = dataLen - 104
+        var offset = 7
+        var paymentHash: String? = null
+        var description: String? = null
+        var expiry = 3600L // default 1 hour
+
+        while (offset < sigStart) {
+            if (offset + 3 > sigStart) break
+            val tag = data5[offset]
+            val dataLength = (data5[offset + 1] shl 5) or data5[offset + 2]
+            offset += 3
+
+            if (offset + dataLength > sigStart) break
+
+            when (tag) {
+                1 -> { // payment hash: 52 x 5-bit = 260 bits = 32 bytes + 4 padding bits
+                    if (dataLength == 52) {
+                        paymentHash = convert5to8(data5, offset, dataLength)?.toHex()
+                    }
+                }
+                13 -> { // description: variable length UTF-8
+                    val bytes = convert5to8(data5, offset, dataLength)
+                    if (bytes != null) {
+                        description = String(bytes, Charsets.UTF_8)
+                    }
+                }
+                6 -> { // expiry: variable length integer
+                    var exp = 0L
+                    for (i in 0 until dataLength) {
+                        exp = (exp shl 5) or data5[offset + i].toLong()
+                    }
+                    expiry = exp
+                }
+            }
+            offset += dataLength
+        }
+
+        return DecodedInvoice(
+            amountSats = amountSats,
+            paymentHash = paymentHash,
+            description = description,
+            expiry = expiry,
+            timestamp = timestamp
+        )
+    }
+
+    private fun parseHrpAmount(hrp: String): Long? {
+        val match = hrpAmountRegex.find(hrp) ?: return null
+        val amount = match.groupValues[1].toLongOrNull() ?: return null
+        val multiplier = match.groupValues[2]
+        return when (multiplier) {
+            "m" -> amount * 100_000
+            "u" -> amount * 100
+            "n" -> amount / 10
+            "p" -> amount / 10_000
+            "" -> amount * 100_000_000
+            else -> null
+        }
+    }
+
+    /** Convert 5-bit values to 8-bit byte array (bech32 to bytes) */
+    private fun convert5to8(data: IntArray, offset: Int, length: Int): ByteArray? {
+        var acc = 0
+        var bits = 0
+        val result = mutableListOf<Byte>()
+        for (i in 0 until length) {
+            acc = (acc shl 5) or data[offset + i]
+            bits += 5
+            while (bits >= 8) {
+                bits -= 8
+                result.add(((acc shr bits) and 0xFF).toByte())
+            }
+        }
+        return result.toByteArray()
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip09.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip09.kt
@@ -1,0 +1,10 @@
+package com.wisp.app.nostr
+
+object Nip09 {
+    fun buildDeletionTags(eventId: String, kind: Int): List<List<String>> {
+        return listOf(
+            listOf("e", eventId),
+            listOf("k", kind.toString())
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip47.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip47.kt
@@ -1,28 +1,42 @@
 package com.wisp.app.nostr
 
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import java.net.URI
 import java.net.URLDecoder
+import java.net.URLEncoder
 
 object Nip47 {
     private val json = Json { ignoreUnknownKeys = true }
 
+    enum class NwcEncryption { NIP04, NIP44 }
+
     data class NwcConnection(
         val walletServicePubkey: ByteArray,
         val relayUrl: String,
-        val clientSecret: ByteArray
+        val clientSecret: ByteArray,
+        val encryption: NwcEncryption = NwcEncryption.NIP04
     ) {
         val clientPubkey: ByteArray get() = Keys.xOnlyPubkey(clientSecret)
 
-        /** Precomputed NIP-04 shared secret for encrypting/decrypting NWC messages */
+        /** Precomputed NIP-04 shared secret */
         val sharedSecret: ByteArray by lazy {
             Nip04.computeSharedSecret(clientSecret, walletServicePubkey)
         }
+
+        /** Precomputed NIP-44 conversation key */
+        val conversationKey: ByteArray by lazy {
+            Nip44.getConversationKey(clientSecret, walletServicePubkey)
+        }
+
+        fun withEncryption(enc: NwcEncryption) = copy(encryption = enc)
 
         override fun equals(other: Any?) =
             other is NwcConnection && walletServicePubkey.contentEquals(other.walletServicePubkey)
@@ -34,18 +48,46 @@ object Nip47 {
         object GetBalance : NwcRequest()
         data class PayInvoice(val invoice: String) : NwcRequest()
         data class MakeInvoice(val amountMsats: Long, val description: String) : NwcRequest()
+        data class ListTransactions(val limit: Int = 50, val offset: Int = 0) : NwcRequest()
     }
+
+    data class Transaction(
+        val type: String,
+        val description: String?,
+        val paymentHash: String,
+        val amount: Long,
+        val createdAt: Long,
+        val settledAt: Long?
+    )
 
     sealed class NwcResponse {
         data class Balance(val balanceMsats: Long) : NwcResponse()
         data class PayInvoiceResult(val preimage: String) : NwcResponse()
         data class MakeInvoiceResult(val invoice: String, val paymentHash: String) : NwcResponse()
+        data class ListTransactionsResult(val transactions: List<Transaction>) : NwcResponse()
         data class Error(val code: String, val message: String) : NwcResponse()
+    }
+
+    /**
+     * Parse the wallet service's info event (kind 13194) to determine supported
+     * encryption schemes. Returns the best encryption to use (NIP-44 preferred).
+     */
+    fun parseInfoEncryption(event: NostrEvent): NwcEncryption {
+        val encTag = event.tags.firstOrNull { it.size >= 2 && it[0] == "encryption" }
+        if (encTag != null) {
+            // Tag value is space-separated list of supported schemes
+            val schemes = encTag[1].split(" ").map { it.trim().lowercase() }
+            if ("nip44_v2" in schemes) return NwcEncryption.NIP44
+        }
+        // Absent tag = NIP-04 only (backwards compatibility per spec)
+        return NwcEncryption.NIP04
     }
 
     fun parseConnectionString(uri: String): NwcConnection? {
         return try {
-            val normalized = uri.trim().replace("nostr+walletconnect://", "nwc://")
+            val normalized = encodeRelayParam(
+                uri.trim().replace("nostr+walletconnect://", "nwc://")
+            )
             val parsed = URI(normalized)
             val pubkeyHex = parsed.host ?: return null
             val params = parseQueryParams(parsed.rawQuery ?: return null)
@@ -61,11 +103,38 @@ object Nip47 {
         }
     }
 
+    /**
+     * Detect unencoded relay URLs in the query string and URL-encode them.
+     * Users sometimes paste URIs with relay=wss://... instead of relay=wss%3A%2F%2F...
+     * Handles multiple relay= params and trims whitespace.
+     */
+    private fun encodeRelayParam(uri: String): String {
+        val qIdx = uri.indexOf('?')
+        if (qIdx < 0) return uri
+
+        val base = uri.substring(0, qIdx + 1)
+        val query = uri.substring(qIdx + 1)
+
+        val newQuery = Regex("""relay=([^&]+)""").replace(query) { match ->
+            val relayValue = match.groupValues[1].trim()
+            if (!relayValue.contains("%3A", ignoreCase = true) &&
+                !relayValue.contains("%2F", ignoreCase = true)) {
+                val encoded = URLEncoder.encode(
+                    URLDecoder.decode(relayValue, "UTF-8").trim(), "UTF-8"
+                )
+                "relay=$encoded"
+            } else {
+                match.value
+            }
+        }
+        return base + newQuery
+    }
+
     private fun parseQueryParams(query: String): Map<String, String> {
         return query.split("&").mapNotNull { param ->
             val parts = param.split("=", limit = 2)
             if (parts.size == 2) {
-                URLDecoder.decode(parts[0], "UTF-8") to URLDecoder.decode(parts[1], "UTF-8")
+                URLDecoder.decode(parts[0], "UTF-8").trim() to URLDecoder.decode(parts[1], "UTF-8").trim()
             } else null
         }.toMap()
     }
@@ -88,47 +157,62 @@ object Nip47 {
                     put("description", request.description)
                 })
             }
+            is NwcRequest.ListTransactions -> buildJsonObject {
+                put("method", "list_transactions")
+                put("params", buildJsonObject {
+                    put("limit", request.limit)
+                    put("offset", request.offset)
+                })
+            }
         }
 
-        // NIP-47 uses NIP-04 encryption
-        val encrypted = Nip04.encrypt(content.toString(), connection.sharedSecret)
+        val plaintext = content.toString()
         val wsPubkeyHex = connection.walletServicePubkey.toHex()
+
+        val encrypted: String
+        val tags: List<List<String>>
+
+        when (connection.encryption) {
+            NwcEncryption.NIP44 -> {
+                encrypted = Nip44.encrypt(plaintext, connection.conversationKey)
+                tags = listOf(
+                    listOf("p", wsPubkeyHex),
+                    listOf("encryption", "nip44_v2")
+                )
+            }
+            NwcEncryption.NIP04 -> {
+                encrypted = Nip04.encrypt(plaintext, connection.sharedSecret)
+                tags = listOf(listOf("p", wsPubkeyHex))
+            }
+        }
 
         return NostrEvent.create(
             privkey = connection.clientSecret,
             pubkey = connection.clientPubkey,
             kind = 23194,
             content = encrypted,
-            tags = listOf(listOf("p", wsPubkeyHex))
+            tags = tags
         )
     }
 
     fun parseResponse(connection: NwcConnection, event: NostrEvent): NwcResponse {
-        // NIP-47 uses NIP-04 encryption
-        // The response may come from the wallet service pubkey, so we need to handle
-        // both cases: shared secret with wallet pubkey or with actual event pubkey
-        val decrypted = try {
-            Nip04.decrypt(event.content, connection.sharedSecret)
-        } catch (_: Exception) {
-            // Fallback: compute shared secret with actual response event pubkey
-            val responsePubkey = event.pubkey.hexToByteArray()
-            val fallbackSecret = Nip04.computeSharedSecret(connection.clientSecret, responsePubkey)
-            Nip04.decrypt(event.content, fallbackSecret)
-        }
+        val decrypted = decryptContent(connection, event.content)
 
         val obj = json.parseToJsonElement(decrypted).jsonObject
 
         val resultType = obj["result_type"]?.jsonPrimitive?.content
-        val error = obj["error"]?.jsonObject
-
-        if (error != null) {
+        val errorElement = obj["error"]
+        if (errorElement != null && errorElement !is JsonNull) {
+            val error = errorElement.jsonObject
             return NwcResponse.Error(
                 code = error["code"]?.jsonPrimitive?.content ?: "UNKNOWN",
                 message = error["message"]?.jsonPrimitive?.content ?: "Unknown error"
             )
         }
 
-        val result = obj["result"]?.jsonObject ?: return NwcResponse.Error("PARSE_ERROR", "No result")
+        val resultElement = obj["result"]
+        val result = if (resultElement != null && resultElement !is JsonNull) resultElement.jsonObject
+            else return NwcResponse.Error("PARSE_ERROR", "No result")
 
         return when (resultType) {
             "get_balance" -> NwcResponse.Balance(
@@ -141,7 +225,47 @@ object Nip47 {
                 invoice = result["invoice"]?.jsonPrimitive?.content ?: "",
                 paymentHash = result["payment_hash"]?.jsonPrimitive?.content ?: ""
             )
+            "list_transactions" -> {
+                val txArray = result["transactions"]?.jsonArray ?: return NwcResponse.ListTransactionsResult(emptyList())
+                val transactions = txArray.map { elem ->
+                    val tx = elem.jsonObject
+                    Transaction(
+                        type = tx["type"]?.jsonPrimitive?.content ?: "outgoing",
+                        description = tx["description"]?.jsonPrimitive?.content,
+                        paymentHash = tx["payment_hash"]?.jsonPrimitive?.content ?: "",
+                        amount = tx["amount"]?.jsonPrimitive?.longOrNull ?: 0,
+                        createdAt = tx["created_at"]?.jsonPrimitive?.longOrNull ?: 0,
+                        settledAt = tx["settled_at"]?.jsonPrimitive?.longOrNull
+                    )
+                }
+                NwcResponse.ListTransactionsResult(transactions)
+            }
             else -> NwcResponse.Error("UNKNOWN_METHOD", "Unknown result_type: $resultType")
+        }
+    }
+
+    /**
+     * Auto-detect encryption format and decrypt.
+     * NIP-04 content contains "?iv=", NIP-44 is a plain base64 blob.
+     * Tries the connection's negotiated encryption first, falls back to the other.
+     */
+    private fun decryptContent(connection: NwcConnection, content: String): String {
+        val looksLikeNip04 = content.contains("?iv=")
+
+        return if (looksLikeNip04) {
+            try {
+                Nip04.decrypt(content, connection.sharedSecret)
+            } catch (_: Exception) {
+                // Fallback: maybe it's actually NIP-44 with a coincidental "?iv=" in base64
+                Nip44.decrypt(content, connection.conversationKey)
+            }
+        } else {
+            try {
+                Nip44.decrypt(content, connection.conversationKey)
+            } catch (_: Exception) {
+                // Fallback: try NIP-04 in case format detection was wrong
+                Nip04.decrypt(content, connection.sharedSecret)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip57.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip57.kt
@@ -122,6 +122,27 @@ object Nip57 {
         )
     }
 
+    suspend fun fetchSimpleInvoice(
+        callbackUrl: String,
+        amountMsats: Long,
+        httpClient: OkHttpClient
+    ): String? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val separator = if (callbackUrl.contains("?")) "&" else "?"
+                val url = "${callbackUrl}${separator}amount=$amountMsats"
+                val request = Request.Builder().url(url).build()
+                val response = httpClient.newCall(request).execute()
+                if (!response.isSuccessful) return@withContext null
+                val body = response.body?.string() ?: return@withContext null
+                val obj = json.parseToJsonElement(body).jsonObject
+                obj["pr"]?.jsonPrimitive?.content
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+
     suspend fun fetchInvoice(
         callbackUrl: String,
         amountMsats: Long,

--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -25,7 +25,7 @@ class Relay(
     private val scope: CoroutineScope? = null
 ) {
     private var webSocket: WebSocket? = null
-    var isConnected = false
+    @Volatile var isConnected = false
         private set
     var autoReconnect = true
     @Volatile var cooldownUntil: Long = 0L

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -418,6 +418,22 @@ class RelayPool {
         }
     }
 
+    fun disconnectRelay(url: String) {
+        relays.find { it.config.url == url }?.let {
+            it.disconnect()
+            relays.remove(it)
+        }
+        dmRelays.find { it.config.url == url }?.let {
+            it.disconnect()
+            dmRelays.remove(it)
+        }
+        ephemeralRelays.remove(url)?.let {
+            it.disconnect()
+            ephemeralLastUsed.remove(url)
+        }
+        updateConnectedCount()
+    }
+
     fun getRelayUrls(): List<String> = relays.map { it.config.url }
 
     fun getDmRelayUrls(): List<String> = dmRelays.map { it.config.url }

--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
@@ -1,6 +1,8 @@
 package com.wisp.app.relay
 
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.withTimeoutOrNull
 
 class SubscriptionManager(private val relayPool: RelayPool) {
@@ -35,11 +37,10 @@ class SubscriptionManager(private val relayPool: RelayPool) {
         if (expectedCount <= 0) return 0
         var eoseCount = 0
         withTimeoutOrNull(timeoutMs) {
-            relayPool.eoseSignals.collect { subId ->
-                if (subId == targetSubId && ++eoseCount >= expectedCount) {
-                    return@collect
-                }
-            }
+            relayPool.eoseSignals
+                .filter { it == targetSubId }
+                .take(expectedCount)
+                .collect { eoseCount++ }
         }
         return eoseCount
     }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.window.PopupProperties
 fun ActionBar(
     onReply: () -> Unit,
     onReact: (String) -> Unit = {},
-    userReactionEmoji: String? = null,
+    userReactionEmojis: Set<String> = emptySet(),
     onRepost: () -> Unit = {},
     onQuote: () -> Unit = {},
     hasUserReposted: Boolean = false,
@@ -87,12 +87,11 @@ fun ActionBar(
         }
         Spacer(Modifier.width(8.dp))
         Box {
-            IconButton(onClick = {
-                if (userReactionEmoji == null) showEmojiPicker = true
-            }) {
-                if (userReactionEmoji != null) {
+            IconButton(onClick = { showEmojiPicker = true }) {
+                val displayEmoji = userReactionEmojis.firstOrNull()
+                if (displayEmoji != null) {
                     Text(
-                        text = userReactionEmoji,
+                        text = displayEmoji,
                         fontSize = 20.sp
                     )
                 } else {
@@ -107,7 +106,8 @@ fun ActionBar(
             if (showEmojiPicker) {
                 EmojiReactionPopup(
                     onSelect = onReact,
-                    onDismiss = { showEmojiPicker = false }
+                    onDismiss = { showEmojiPicker = false },
+                    selectedEmojis = userReactionEmojis
                 )
             }
         }
@@ -115,7 +115,7 @@ fun ActionBar(
             Text(
                 text = likeCount.toString(),
                 style = MaterialTheme.typography.labelSmall,
-                color = if (userReactionEmoji != null) Color(0xFFFF9800) else MaterialTheme.colorScheme.onSurfaceVariant
+                color = if (userReactionEmojis.isNotEmpty()) Color(0xFFFF9800) else MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
         Spacer(Modifier.width(8.dp))

--- a/app/src/main/kotlin/com/wisp/app/ui/component/EmojiPicker.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/EmojiPicker.kt
@@ -1,5 +1,6 @@
 package com.wisp.app.ui.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -32,7 +33,8 @@ import com.wisp.app.repo.ReactionPreferences
 @Composable
 fun EmojiReactionPopup(
     onSelect: (String) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    selectedEmojis: Set<String> = emptySet()
 ) {
     val context = LocalContext.current
     var emojis by remember { mutableStateOf(ReactionPreferences(context).getReactionSet()) }
@@ -58,10 +60,17 @@ fun EmojiReactionPopup(
                 verticalArrangement = Arrangement.Center
             ) {
                 emojis.forEach { emoji ->
-                    TextButton(onClick = {
-                        onSelect(emoji)
-                        onDismiss()
-                    }) {
+                    val isSelected = emoji in selectedEmojis
+                    TextButton(
+                        onClick = {
+                            onSelect(emoji)
+                            onDismiss()
+                        },
+                        modifier = if (isSelected) Modifier.background(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+                            RoundedCornerShape(12.dp)
+                        ) else Modifier
+                    ) {
                         Text(emoji, fontSize = 24.sp)
                     }
                 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -65,7 +65,7 @@ fun PostCard(
     onNavigateToProfile: ((String) -> Unit)? = null,
     onNoteClick: () -> Unit = {},
     onReact: (String) -> Unit = {},
-    userReactionEmoji: String? = null,
+    userReactionEmojis: Set<String> = emptySet(),
     onRepost: () -> Unit = {},
     onQuote: () -> Unit = {},
     hasUserReposted: Boolean = false,
@@ -295,7 +295,7 @@ fun PostCard(
             ActionBar(
                 onReply = onReply,
                 onReact = onReact,
-                userReactionEmoji = userReactionEmoji,
+                userReactionEmojis = userReactionEmojis,
                 onRepost = onRepost,
                 onQuote = onQuote,
                 hasUserReposted = hasUserReposted,

--- a/app/src/main/kotlin/com/wisp/app/ui/component/SatsNumpad.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/SatsNumpad.kt
@@ -1,0 +1,116 @@
+package com.wisp.app.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Backspace
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SatsNumpad(
+    amount: String,
+    onDigit: (Char) -> Unit,
+    onBackspace: () -> Unit,
+    onConfirm: () -> Unit,
+    confirmEnabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Amount display
+        val displayAmount = if (amount.isEmpty()) "0" else "%,d".format(amount.toLongOrNull() ?: 0)
+        Text(
+            text = displayAmount,
+            style = MaterialTheme.typography.displayMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = "sats",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(Modifier.height(32.dp))
+
+        // 4x3 grid
+        val rows = listOf(
+            listOf("1", "2", "3"),
+            listOf("4", "5", "6"),
+            listOf("7", "8", "9"),
+            listOf("⌫", "0", "✓")
+        )
+
+        rows.forEach { row ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                row.forEach { key ->
+                    when (key) {
+                        "⌫" -> {
+                            FilledTonalButton(
+                                onClick = onBackspace,
+                                modifier = Modifier.size(72.dp),
+                                shape = CircleShape
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.Backspace,
+                                    contentDescription = "Backspace",
+                                    modifier = Modifier.size(24.dp)
+                                )
+                            }
+                        }
+                        "✓" -> {
+                            Button(
+                                onClick = onConfirm,
+                                modifier = Modifier.size(72.dp),
+                                shape = CircleShape,
+                                enabled = confirmEnabled
+                            ) {
+                                Icon(
+                                    Icons.Default.Check,
+                                    contentDescription = "Confirm",
+                                    modifier = Modifier.size(24.dp)
+                                )
+                            }
+                        }
+                        else -> {
+                            FilledTonalButton(
+                                onClick = { onDigit(key[0]) },
+                                modifier = Modifier.size(72.dp),
+                                shape = CircleShape
+                            ) {
+                                Text(
+                                    key,
+                                    style = MaterialTheme.typography.headlineSmall
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/BookmarksScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/BookmarksScreen.kt
@@ -84,8 +84,8 @@ fun BookmarksScreen(
                 items(items = bookmarkedEvents, key = { it.id }) { event ->
                     val profile = eventRepo.getProfileData(event.pubkey)
                     val likeCount = reactionVersion.let { eventRepo.getReactionCount(event.id) }
-                    val userEmoji = reactionVersion.let {
-                        userPubkey?.let { eventRepo.getUserReactionEmoji(event.id, it) }
+                    val userEmojis = reactionVersion.let {
+                        userPubkey?.let { eventRepo.getUserReactionEmojis(event.id, it) } ?: emptySet()
                     }
                     PostCard(
                         event = event,
@@ -96,7 +96,7 @@ fun BookmarksScreen(
                         onNoteClick = { onNoteClick(event) },
                         onQuotedNoteClick = onQuotedNoteClick,
                         onReact = { emoji -> onReact(event, emoji) },
-                        userReactionEmoji = userEmoji,
+                        userReactionEmojis = userEmojis,
                         likeCount = likeCount,
                         eventRepo = eventRepo,
                         onBookmark = { onToggleBookmark(event.id) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -634,8 +634,8 @@ private fun FeedItem(
     val zapSats = remember(zapVersion, event.id) {
         viewModel.eventRepo.getZapSats(event.id)
     }
-    val userEmoji = remember(reactionVersion, event.id, userPubkey) {
-        userPubkey?.let { viewModel.eventRepo.getUserReactionEmoji(event.id, it) }
+    val userEmojis = remember(reactionVersion, event.id, userPubkey) {
+        userPubkey?.let { viewModel.eventRepo.getUserReactionEmojis(event.id, it) } ?: emptySet()
     }
     val relayIcons = remember(relaySourceVersion, event.id) {
         viewModel.eventRepo.getEventRelays(event.id).map { url ->
@@ -677,7 +677,7 @@ private fun FeedItem(
         onNavigateToProfile = onNavigateToProfile,
         onNoteClick = onNoteClick,
         onReact = onReact,
-        userReactionEmoji = userEmoji,
+        userReactionEmojis = userEmojis,
         onRepost = onRepost,
         onQuote = onQuote,
         hasUserReposted = hasUserReposted,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -413,8 +413,8 @@ private fun ReplyPostCard(
     val zapSats = remember(zapVersion, event.id) {
         eventRepo.getZapSats(event.id)
     }
-    val userEmoji = remember(reactionVersion, event.id, userPubkey) {
-        userPubkey?.let { eventRepo.getUserReactionEmoji(event.id, it) }
+    val userEmojis = remember(reactionVersion, event.id, userPubkey) {
+        userPubkey?.let { eventRepo.getUserReactionEmojis(event.id, it) } ?: emptySet()
     }
     val reactionDetails = remember(reactionVersion, event.id) {
         eventRepo.getReactionDetails(event.id)
@@ -469,7 +469,7 @@ private fun ReplyPostCard(
         onNavigateToProfile = onProfileClick,
         onNoteClick = { onNoteClick(event.id) },
         onReact = { emoji -> onReact(event, emoji) },
-        userReactionEmoji = userEmoji,
+        userReactionEmojis = userEmojis,
         onRepost = { onRepost(event) },
         onQuote = { onQuote(event) },
         hasUserReposted = hasUserReposted,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
@@ -110,7 +110,7 @@ fun ThreadScreen(
                     val likeCount = reactionVersion.let { eventRepo.getReactionCount(event.id) }
                     val replyCount = replyCountVersion.let { eventRepo.getReplyCount(event.id) }
                     val zapSats = zapVersion.let { eventRepo.getZapSats(event.id) }
-                    val userEmoji = reactionVersion.let { userPubkey?.let { eventRepo.getUserReactionEmoji(event.id, it) } }
+                    val userEmojis = reactionVersion.let { userPubkey?.let { eventRepo.getUserReactionEmojis(event.id, it) } ?: emptySet() }
                     val reactionDetails = reactionVersion.let { eventRepo.getReactionDetails(event.id) }
                     val zapDetailsList = zapVersion.let { eventRepo.getZapDetails(event.id) }
                     val repostCount = repostVersion.let { eventRepo.getRepostCount(event.id) }
@@ -124,7 +124,7 @@ fun ThreadScreen(
                         onNavigateToProfile = onProfileClick,
                         onNoteClick = { onNoteClick(event) },
                         onReact = { emoji -> onReact(event, emoji) },
-                        userReactionEmoji = userEmoji,
+                        userReactionEmojis = userEmojis,
                         onRepost = { onRepost(event) },
                         onQuote = { onQuote(event) },
                         hasUserReposted = hasUserReposted,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -368,7 +368,7 @@ fun UserProfileScreen(
                             val likeCount = reactionVersion.let { eventRepo?.getReactionCount(event.id) ?: 0 }
                             val replyCount = replyCountVersion.let { eventRepo?.getReplyCount(event.id) ?: 0 }
                             val zapSats = zapVersion.let { eventRepo?.getZapSats(event.id) ?: 0L }
-                            val userEmoji = reactionVersion.let { userPubkey?.let { eventRepo?.getUserReactionEmoji(event.id, it) } }
+                            val userEmojis = reactionVersion.let { userPubkey?.let { eventRepo?.getUserReactionEmojis(event.id, it) } ?: emptySet() }
                             val reactionDetails = remember(reactionVersion, event.id) {
                                 eventRepo?.getReactionDetails(event.id) ?: emptyMap()
                             }
@@ -395,7 +395,7 @@ fun UserProfileScreen(
                                 onNoteClick = { onNoteClick(event) },
                                 onQuotedNoteClick = onQuotedNoteClick,
                                 onReact = { emoji -> onReact(event, emoji) },
-                                userReactionEmoji = userEmoji,
+                                userReactionEmojis = userEmojis,
                                 hasUserReposted = hasUserReposted,
                                 onZap = { zapTargetEvent = event },
                                 hasUserZapped = hasUserZapped,
@@ -431,7 +431,7 @@ fun UserProfileScreen(
                             val likeCount = reactionVersion.let { eventRepo?.getReactionCount(event.id) ?: 0 }
                             val replyCount = replyCountVersion.let { eventRepo?.getReplyCount(event.id) ?: 0 }
                             val zapSats = zapVersion.let { eventRepo?.getZapSats(event.id) ?: 0L }
-                            val userEmoji = reactionVersion.let { userPubkey?.let { eventRepo?.getUserReactionEmoji(event.id, it) } }
+                            val userEmojis = reactionVersion.let { userPubkey?.let { eventRepo?.getUserReactionEmojis(event.id, it) } ?: emptySet() }
                             val reactionDetails = remember(reactionVersion, event.id) {
                                 eventRepo?.getReactionDetails(event.id) ?: emptyMap()
                             }
@@ -453,7 +453,7 @@ fun UserProfileScreen(
                                 onNoteClick = { onNoteClick(event) },
                                 onQuotedNoteClick = onQuotedNoteClick,
                                 onReact = { emoji -> onReact(event, emoji) },
-                                userReactionEmoji = userEmoji,
+                                userReactionEmojis = userEmojis,
                                 hasUserReposted = hasUserReposted2,
                                 onZap = { zapTargetEvent = event },
                                 hasUserZapped = hasUserZapped2,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -4,9 +4,23 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
 import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,20 +30,29 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.ContentPaste
+import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -37,22 +60,31 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+import com.wisp.app.nostr.Nip47
+import com.wisp.app.ui.component.SatsNumpad
+import com.wisp.app.viewmodel.WalletPage
 import com.wisp.app.viewmodel.WalletState
 import com.wisp.app.viewmodel.WalletViewModel
 
@@ -63,15 +95,20 @@ fun WalletScreen(
     onBack: () -> Unit
 ) {
     val walletState by viewModel.walletState.collectAsState()
-    val connectionString by viewModel.connectionString.collectAsState()
-    val generatedInvoice by viewModel.generatedInvoice.collectAsState()
+    val currentPage by viewModel.currentPage.collectAsState()
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Wallet") },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = {
+                        if (walletState !is WalletState.Connected || viewModel.isOnHome) {
+                            onBack()
+                        } else {
+                            viewModel.navigateBack()
+                        }
+                    }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
@@ -81,38 +118,115 @@ fun WalletScreen(
             )
         }
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState())
-        ) {
-            when (walletState) {
-                is WalletState.NotConnected, is WalletState.Error -> {
-                    NotConnectedContent(
+        when (walletState) {
+            is WalletState.NotConnected,
+            is WalletState.Connecting,
+            is WalletState.Error -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .padding(horizontal = 16.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    WalletConnectionContent(
                         walletState = walletState,
-                        connectionString = connectionString,
+                        connectionString = viewModel.connectionString.collectAsState().value,
+                        statusLines = viewModel.statusLines.collectAsState().value,
                         onConnectionStringChange = { viewModel.updateConnectionString(it) },
-                        onConnect = { viewModel.connectWallet() }
-                    )
-                }
-                is WalletState.Connecting -> {
-                    Spacer(Modifier.height(32.dp))
-                    Text(
-                        "Connecting to wallet...",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                is WalletState.Connected -> {
-                    ConnectedContent(
-                        balanceMsats = (walletState as WalletState.Connected).balanceMsats,
-                        generatedInvoice = generatedInvoice,
-                        onRefresh = { viewModel.refreshBalance() },
-                        onGenerateInvoice = { amount, desc -> viewModel.generateInvoice(amount, desc) },
-                        onClearInvoice = { viewModel.clearInvoice() },
+                        onConnect = { viewModel.connectWallet() },
                         onDisconnect = { viewModel.disconnectWallet() }
+                    )
+                }
+            }
+            is WalletState.Connected -> {
+                val balanceMsats = (walletState as WalletState.Connected).balanceMsats
+                when (currentPage) {
+                    is WalletPage.Home -> WalletHomeContent(
+                        balanceMsats = balanceMsats,
+                        onSend = { viewModel.navigateTo(WalletPage.SendInput) },
+                        onReceive = {
+                            viewModel.navigateTo(WalletPage.ReceiveAmount)
+                        },
+                        onTransactions = {
+                            viewModel.loadTransactions()
+                            viewModel.navigateTo(WalletPage.Transactions)
+                        },
+                        onRefresh = { viewModel.refreshBalance() },
+                        onDisconnect = { viewModel.disconnectWallet() },
+                        modifier = Modifier.padding(padding)
+                    )
+                    is WalletPage.SendInput -> SendInputContent(
+                        input = viewModel.sendInput.collectAsState().value,
+                        error = viewModel.sendError.collectAsState().value,
+                        onInputChange = { viewModel.updateSendInput(it) },
+                        onNext = { viewModel.processInput() },
+                        modifier = Modifier.padding(padding)
+                    )
+                    is WalletPage.SendAmount -> {
+                        val page = currentPage as WalletPage.SendAmount
+                        SendAmountContent(
+                            address = page.address,
+                            amount = viewModel.sendAmount.collectAsState().value,
+                            error = viewModel.sendError.collectAsState().value,
+                            isLoading = viewModel.isLoading.collectAsState().value,
+                            onDigit = { viewModel.updateSendAmount(it) },
+                            onBackspace = { viewModel.sendAmountBackspace() },
+                            onConfirm = {
+                                val sats = viewModel.sendAmount.value.toLongOrNull() ?: return@SendAmountContent
+                                viewModel.resolveLightningAddress(page.address, sats)
+                            },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
+                    is WalletPage.SendConfirm -> {
+                        val page = currentPage as WalletPage.SendConfirm
+                        SendConfirmContent(
+                            amountSats = page.amountSats,
+                            paymentHash = page.paymentHash,
+                            description = page.description,
+                            onPay = { viewModel.payInvoice(page.invoice) },
+                            onCancel = { viewModel.navigateBack() },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
+                    is WalletPage.Sending -> SendingContent(
+                        modifier = Modifier.padding(padding)
+                    )
+                    is WalletPage.SendResult -> {
+                        val page = currentPage as WalletPage.SendResult
+                        SendResultContent(
+                            success = page.success,
+                            message = page.message,
+                            onDone = { viewModel.navigateHome() },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
+                    is WalletPage.ReceiveAmount -> ReceiveAmountContent(
+                        amount = viewModel.receiveAmount.collectAsState().value,
+                        isLoading = viewModel.isLoading.collectAsState().value,
+                        onDigit = { viewModel.updateReceiveAmount(it) },
+                        onBackspace = { viewModel.receiveAmountBackspace() },
+                        onConfirm = {
+                            val sats = viewModel.receiveAmount.value.toLongOrNull() ?: return@ReceiveAmountContent
+                            viewModel.generateInvoice(sats)
+                        },
+                        modifier = Modifier.padding(padding)
+                    )
+                    is WalletPage.ReceiveInvoice -> {
+                        val page = currentPage as WalletPage.ReceiveInvoice
+                        ReceiveInvoiceContent(
+                            invoice = page.invoice,
+                            amountSats = page.amountSats,
+                            onDone = { viewModel.navigateHome() },
+                            modifier = Modifier.padding(padding)
+                        )
+                    }
+                    is WalletPage.Transactions -> TransactionHistoryContent(
+                        transactions = viewModel.transactions.collectAsState().value,
+                        error = viewModel.transactionsError.collectAsState().value,
+                        isLoading = viewModel.isLoading.collectAsState().value,
+                        modifier = Modifier.padding(padding)
                     )
                 }
             }
@@ -120,14 +234,19 @@ fun WalletScreen(
     }
 }
 
+// --- Connection UI (not connected / connecting / error) ---
+
 @Composable
-private fun NotConnectedContent(
+private fun WalletConnectionContent(
     walletState: WalletState,
     connectionString: String,
+    statusLines: List<String>,
     onConnectionStringChange: (String) -> Unit,
-    onConnect: () -> Unit
+    onConnect: () -> Unit,
+    onDisconnect: () -> Unit
 ) {
     val context = LocalContext.current
+    val isConnecting = walletState is WalletState.Connecting
 
     Spacer(Modifier.height(16.dp))
 
@@ -138,7 +257,7 @@ private fun NotConnectedContent(
     )
     Spacer(Modifier.height(8.dp))
     Text(
-        "Connect a Lightning wallet to send and receive zaps. Paste a NWC connection string from your wallet provider.",
+        "Connect a Lightning wallet to send and receive sats. Paste a NWC connection string from your wallet provider.",
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )
@@ -155,7 +274,9 @@ private fun NotConnectedContent(
     val wallets = listOf(
         "rizful.com" to "Rizful",
         "coinos.io" to "Coinos",
-        "getalby.com" to "Alby"
+        "getalby.com" to "Alby",
+        "cashu.me" to "Cashu.me",
+        "minibits.cash" to "Minibits"
     )
 
     wallets.forEach { (domain, name) ->
@@ -201,13 +322,14 @@ private fun NotConnectedContent(
         placeholder = { Text("nostr+walletconnect://...") },
         modifier = Modifier.fillMaxWidth(),
         singleLine = false,
-        maxLines = 3
+        maxLines = 3,
+        enabled = !isConnecting
     )
 
     if (walletState is WalletState.Error) {
         Spacer(Modifier.height(8.dp))
         Text(
-            (walletState as WalletState.Error).message,
+            walletState.message,
             color = MaterialTheme.colorScheme.error,
             style = MaterialTheme.typography.bodySmall
         )
@@ -218,167 +340,756 @@ private fun NotConnectedContent(
     Button(
         onClick = onConnect,
         modifier = Modifier.fillMaxWidth(),
-        enabled = connectionString.isNotBlank()
+        enabled = connectionString.isNotBlank() && !isConnecting
     ) {
-        Text("Connect")
+        if (isConnecting) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                color = MaterialTheme.colorScheme.onPrimary,
+                strokeWidth = 2.dp
+            )
+            Spacer(Modifier.width(8.dp))
+            Text("Connecting...")
+        } else {
+            Text("Connect")
+        }
     }
 
-    Spacer(Modifier.height(32.dp))
-}
-
-@Composable
-private fun ConnectedContent(
-    balanceMsats: Long,
-    generatedInvoice: String?,
-    onRefresh: () -> Unit,
-    onGenerateInvoice: (Long, String) -> Unit,
-    onClearInvoice: () -> Unit,
-    onDisconnect: () -> Unit
-) {
-    val context = LocalContext.current
-    val balanceSats = balanceMsats / 1000
-
-    Spacer(Modifier.height(16.dp))
-
-    // Balance card
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer
-        ),
-        shape = RoundedCornerShape(16.dp)
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                "Balance",
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
-            )
-            Spacer(Modifier.height(8.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
+    if (statusLines.isNotEmpty()) {
+        Spacer(Modifier.height(12.dp))
+        Column(modifier = Modifier.fillMaxWidth()) {
+            statusLines.forEach { line ->
                 Text(
-                    "%,d".format(balanceSats),
-                    style = MaterialTheme.typography.headlineLarge,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    "sats",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-            Spacer(Modifier.height(8.dp))
-            IconButton(onClick = onRefresh) {
-                Icon(
-                    Icons.Default.Refresh,
-                    contentDescription = "Refresh balance",
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    line,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
     }
 
-    Spacer(Modifier.height(24.dp))
-
-    // Receive section
-    Text(
-        "Receive",
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.onSurface
-    )
-    Spacer(Modifier.height(12.dp))
-
-    var invoiceAmount by remember { mutableStateOf("") }
-    var invoiceDescription by remember { mutableStateOf("") }
-
-    OutlinedTextField(
-        value = invoiceAmount,
-        onValueChange = { invoiceAmount = it.filter { c -> c.isDigit() } },
-        label = { Text("Amount (sats)") },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true
-    )
-    Spacer(Modifier.height(8.dp))
-    OutlinedTextField(
-        value = invoiceDescription,
-        onValueChange = { invoiceDescription = it },
-        label = { Text("Description (optional)") },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true
-    )
-    Spacer(Modifier.height(12.dp))
-
-    Button(
-        onClick = {
-            val amount = invoiceAmount.toLongOrNull() ?: return@Button
-            onGenerateInvoice(amount, invoiceDescription)
-        },
-        modifier = Modifier.fillMaxWidth(),
-        enabled = invoiceAmount.isNotBlank()
-    ) {
-        Text("Generate Invoice")
+    if (isConnecting) {
+        Spacer(Modifier.height(12.dp))
+        OutlinedButton(
+            onClick = onDisconnect,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Cancel")
+        }
     }
 
-    if (generatedInvoice != null) {
+    Spacer(Modifier.height(32.dp))
+}
+
+// --- Home screen ---
+
+@Composable
+private fun WalletHomeContent(
+    balanceMsats: Long,
+    onSend: () -> Unit,
+    onReceive: () -> Unit,
+    onTransactions: () -> Unit,
+    onRefresh: () -> Unit,
+    onDisconnect: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val balanceSats = balanceMsats / 1000
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(48.dp))
+
+        // Bitcoin icon
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .background(MaterialTheme.colorScheme.primary, CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                "₿",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        // Balance
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                "%,d".format(balanceSats),
+                style = MaterialTheme.typography.displaySmall,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                "sats",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+        }
+
+        IconButton(onClick = onRefresh) {
+            Icon(
+                Icons.Default.Refresh,
+                contentDescription = "Refresh balance",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(Modifier.height(40.dp))
+
+        // Send / Receive buttons
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Button(
+                onClick = onSend,
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("Send")
+            }
+            Button(
+                onClick = onReceive,
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(Icons.Default.ArrowDownward, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("Receive")
+            }
+        }
+
         Spacer(Modifier.height(16.dp))
+
+        TextButton(onClick = onTransactions) {
+            Text("Transaction History")
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        TextButton(
+            onClick = onDisconnect,
+            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+        ) {
+            Text("Disconnect")
+        }
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+// --- Send input ---
+
+@Composable
+private fun SendInputContent(
+    input: String,
+    error: String?,
+    onInputChange: (String) -> Unit,
+    onNext: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val clipboardManager = LocalClipboardManager.current
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(32.dp))
+
+        Text(
+            "Send",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        OutlinedTextField(
+            value = input,
+            onValueChange = onInputChange,
+            label = { Text("Lightning address or invoice") },
+            placeholder = { Text("user@domain.com or lnbc...") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = false,
+            maxLines = 4,
+            trailingIcon = {
+                IconButton(onClick = {
+                    clipboardManager.getText()?.text?.let { onInputChange(it) }
+                }) {
+                    Icon(Icons.Default.ContentPaste, contentDescription = "Paste")
+                }
+            }
+        )
+
+        if (error != null) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Button(
+            onClick = onNext,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = input.isNotBlank()
+        ) {
+            Text("Next")
+        }
+    }
+}
+
+// --- Send amount (for lightning addresses) ---
+
+@Composable
+private fun SendAmountContent(
+    address: String,
+    amount: String,
+    error: String?,
+    isLoading: Boolean,
+    onDigit: (Char) -> Unit,
+    onBackspace: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            "Send to",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            address,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        if (isLoading) {
+            CircularProgressIndicator()
+            Spacer(Modifier.height(8.dp))
+            Text("Resolving...", style = MaterialTheme.typography.bodyMedium)
+        } else {
+            SatsNumpad(
+                amount = amount,
+                onDigit = onDigit,
+                onBackspace = onBackspace,
+                onConfirm = onConfirm,
+                confirmEnabled = amount.isNotEmpty() && (amount.toLongOrNull() ?: 0) > 0
+            )
+        }
+
+        if (error != null) {
+            Spacer(Modifier.height(12.dp))
+            Text(
+                error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}
+
+// --- Send confirm ---
+
+@Composable
+private fun SendConfirmContent(
+    amountSats: Long?,
+    paymentHash: String?,
+    description: String?,
+    onPay: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(32.dp))
+
+        Text(
+            "Confirm Payment",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(Modifier.height(24.dp))
+
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant
             )
         ) {
-            Column(modifier = Modifier.padding(12.dp)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                if (amountSats != null) {
                     Text(
-                        "Invoice",
-                        style = MaterialTheme.typography.labelMedium,
+                        "%,d sats".format(amountSats),
+                        style = MaterialTheme.typography.headlineLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(Modifier.height(16.dp))
+                }
+
+                if (paymentHash != null) {
+                    Text(
+                        "Payment Hash",
+                        style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    IconButton(
-                        onClick = {
-                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                            clipboard.setPrimaryClip(ClipData.newPlainText("Invoice", generatedInvoice))
-                        }
-                    ) {
-                        Icon(
-                            Icons.Outlined.ContentCopy,
-                            contentDescription = "Copy",
-                            modifier = Modifier.size(18.dp)
-                        )
-                    }
-                }
-                SelectionContainer {
                     Text(
-                        generatedInvoice,
+                        paymentHash.take(16) + "..." + paymentHash.takeLast(16),
                         style = MaterialTheme.typography.bodySmall,
-                        maxLines = 4,
-                        overflow = TextOverflow.Ellipsis
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(Modifier.height(12.dp))
+                }
+
+                if (description != null) {
+                    Text(
+                        "Description",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
                 }
             }
         }
+
+        Spacer(Modifier.height(24.dp))
+
+        Button(
+            onClick = onPay,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(Icons.Default.ElectricBolt, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("Pay")
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        OutlinedButton(
+            onClick = onCancel,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Cancel")
+        }
     }
+}
 
-    Spacer(Modifier.height(32.dp))
+// --- Sending animation ---
 
-    OutlinedButton(
-        onClick = onDisconnect,
-        modifier = Modifier.fillMaxWidth(),
-        colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
+@Composable
+private fun SendingContent(modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition(label = "sending")
+    val scale by infiniteTransition.animateFloat(
+        initialValue = 0.8f,
+        targetValue = 1.3f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(600),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "scale"
+    )
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 0.5f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(600),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "alpha"
+    )
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        Text("Disconnect Wallet")
+        Icon(
+            Icons.Default.ElectricBolt,
+            contentDescription = null,
+            modifier = Modifier
+                .size(80.dp)
+                .scale(scale),
+            tint = MaterialTheme.colorScheme.primary.copy(alpha = alpha)
+        )
+        Spacer(Modifier.height(24.dp))
+        CircularProgressIndicator()
+        Spacer(Modifier.height(16.dp))
+        Text(
+            "Sending payment...",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+// --- Send result ---
+
+@Composable
+private fun SendResultContent(
+    success: Boolean,
+    message: String,
+    onDone: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(80.dp)
+                .background(
+                    if (success) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error,
+                    CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                if (success) Icons.Default.Check else Icons.Default.Close,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = Color.White
+            )
+        }
+        Spacer(Modifier.height(24.dp))
+        Text(
+            message,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 32.dp)
+        )
+        Spacer(Modifier.height(32.dp))
+        Button(onClick = onDone) {
+            Text("Done")
+        }
+    }
+}
+
+// --- Receive amount ---
+
+@Composable
+private fun ReceiveAmountContent(
+    amount: String,
+    isLoading: Boolean,
+    onDigit: (Char) -> Unit,
+    onBackspace: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            "Receive",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        if (isLoading) {
+            CircularProgressIndicator()
+            Spacer(Modifier.height(8.dp))
+            Text("Creating invoice...", style = MaterialTheme.typography.bodyMedium)
+        } else {
+            SatsNumpad(
+                amount = amount,
+                onDigit = onDigit,
+                onBackspace = onBackspace,
+                onConfirm = onConfirm,
+                confirmEnabled = amount.isNotEmpty() && (amount.toLongOrNull() ?: 0) > 0
+            )
+        }
+    }
+}
+
+// --- Receive invoice (QR code) ---
+
+@Composable
+private fun ReceiveInvoiceContent(
+    invoice: String,
+    amountSats: Long,
+    onDone: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val clipboardManager = LocalClipboardManager.current
+
+    val qrBitmap = remember(invoice) {
+        val writer = QRCodeWriter()
+        val data = "lightning:$invoice"
+        val matrix = writer.encode(data, BarcodeFormat.QR_CODE, 512, 512)
+        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
+        for (x in 0 until matrix.width) {
+            for (y in 0 until matrix.height) {
+                bitmap.setPixel(x, y, if (matrix.get(x, y)) android.graphics.Color.BLACK else android.graphics.Color.WHITE)
+            }
+        }
+        bitmap
     }
 
-    Spacer(Modifier.height(32.dp))
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            "%,d sats".format(amountSats),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        Image(
+            bitmap = qrBitmap.asImageBitmap(),
+            contentDescription = "Invoice QR Code",
+            modifier = Modifier
+                .size(280.dp)
+                .background(Color.White, RoundedCornerShape(12.dp))
+                .padding(12.dp)
+        )
+
+        Spacer(Modifier.height(20.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    invoice,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = {
+                    clipboardManager.setText(AnnotatedString(invoice))
+                }) {
+                    Icon(
+                        Icons.Default.ContentCopy,
+                        contentDescription = "Copy invoice",
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Button(onClick = onDone) {
+            Text("Done")
+        }
+
+        Spacer(Modifier.height(32.dp))
+    }
+}
+
+// --- Transaction History ---
+
+@Composable
+private fun TransactionHistoryContent(
+    transactions: List<Nip47.Transaction>,
+    error: String?,
+    isLoading: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize()
+    ) {
+        Text(
+            "Transactions",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)
+        )
+
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            error != null -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        if (error.contains("NOT_IMPLEMENTED", ignoreCase = true) ||
+                            error.contains("not supported", ignoreCase = true))
+                            "Not supported by your wallet"
+                        else error,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+            transactions.isEmpty() -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        "No transactions yet",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            else -> {
+                LazyColumn {
+                    items(transactions) { tx ->
+                        TransactionRow(tx)
+                        HorizontalDivider(
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            color = MaterialTheme.colorScheme.outlineVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TransactionRow(tx: Nip47.Transaction) {
+    val isIncoming = tx.type == "incoming"
+    val amountSats = tx.amount / 1000
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Direction icon
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .background(
+                    if (isIncoming) Color(0xFF2E7D32).copy(alpha = 0.1f)
+                    else MaterialTheme.colorScheme.error.copy(alpha = 0.1f),
+                    CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                if (isIncoming) Icons.Default.ArrowDownward else Icons.Default.ArrowUpward,
+                contentDescription = if (isIncoming) "Received" else "Sent",
+                tint = if (isIncoming) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+
+        Spacer(Modifier.width(12.dp))
+
+        // Description + time
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                tx.description?.takeIf { it.isNotBlank() } ?: if (isIncoming) "Received" else "Sent",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                formatRelativeTime(tx.settledAt ?: tx.createdAt),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        // Amount
+        Text(
+            "${if (isIncoming) "+" else "-"}%,d".format(amountSats),
+            style = MaterialTheme.typography.titleMedium,
+            color = if (isIncoming) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(
+            "sats",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+private fun formatRelativeTime(timestamp: Long): String {
+    val now = System.currentTimeMillis() / 1000
+    val diff = now - timestamp
+    return when {
+        diff < 60 -> "just now"
+        diff < 3600 -> "${diff / 60}m ago"
+        diff < 86400 -> "${diff / 3600}h ago"
+        diff < 604800 -> "${diff / 86400}d ago"
+        else -> {
+            val date = java.text.SimpleDateFormat("MMM d", java.util.Locale.getDefault())
+            date.format(java.util.Date(timestamp * 1000))
+        }
+    }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
@@ -2,8 +2,12 @@ package com.wisp.app.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wisp.app.nostr.Bolt11
 import com.wisp.app.nostr.Nip47
+import com.wisp.app.nostr.Nip57
+import com.wisp.app.relay.Relay
 import com.wisp.app.repo.NwcRepository
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -13,6 +17,23 @@ sealed class WalletState {
     object Connecting : WalletState()
     data class Connected(val balanceMsats: Long) : WalletState()
     data class Error(val message: String) : WalletState()
+}
+
+sealed class WalletPage {
+    object Home : WalletPage()
+    object SendInput : WalletPage()
+    data class SendAmount(val address: String) : WalletPage()
+    data class SendConfirm(
+        val invoice: String,
+        val amountSats: Long?,
+        val paymentHash: String?,
+        val description: String?
+    ) : WalletPage()
+    data class Sending(val invoice: String) : WalletPage()
+    data class SendResult(val success: Boolean, val message: String) : WalletPage()
+    object ReceiveAmount : WalletPage()
+    data class ReceiveInvoice(val invoice: String, val amountSats: Long) : WalletPage()
+    object Transactions : WalletPage()
 }
 
 class WalletViewModel(val nwcRepo: NwcRepository) : ViewModel() {
@@ -25,14 +46,76 @@ class WalletViewModel(val nwcRepo: NwcRepository) : ViewModel() {
     private val _connectionString = MutableStateFlow("")
     val connectionString: StateFlow<String> = _connectionString
 
-    private val _generatedInvoice = MutableStateFlow<String?>(null)
-    val generatedInvoice: StateFlow<String?> = _generatedInvoice
+    /** Live status lines emitted during connection */
+    private val _statusLines = MutableStateFlow<List<String>>(emptyList())
+    val statusLines: StateFlow<List<String>> = _statusLines
+
+    // Page navigation
+    private val pageStack = mutableListOf<WalletPage>(WalletPage.Home)
+    private val _currentPage = MutableStateFlow<WalletPage>(WalletPage.Home)
+    val currentPage: StateFlow<WalletPage> = _currentPage
+
+    // Send flow
+    private val _sendInput = MutableStateFlow("")
+    val sendInput: StateFlow<String> = _sendInput
+
+    private val _sendAmount = MutableStateFlow("")
+    val sendAmount: StateFlow<String> = _sendAmount
+
+    private val _sendError = MutableStateFlow<String?>(null)
+    val sendError: StateFlow<String?> = _sendError
+
+    // Receive flow
+    private val _receiveAmount = MutableStateFlow("")
+    val receiveAmount: StateFlow<String> = _receiveAmount
+
+    // Transactions
+    private val _transactions = MutableStateFlow<List<Nip47.Transaction>>(emptyList())
+    val transactions: StateFlow<List<Nip47.Transaction>> = _transactions
+
+    private val _transactionsError = MutableStateFlow<String?>(null)
+    val transactionsError: StateFlow<String?> = _transactionsError
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private var connectJob: Job? = null
+    private var statusCollectJob: Job? = null
+    private val httpClient by lazy { Relay.createClient() }
 
     init {
         if (nwcRepo.hasConnection()) {
             connectWallet(nwcRepo.getConnectionString() ?: "")
         }
     }
+
+    // --- Navigation ---
+
+    fun navigateTo(page: WalletPage) {
+        pageStack.add(page)
+        _currentPage.value = page
+    }
+
+    fun navigateBack(): Boolean {
+        if (pageStack.size <= 1) return false
+        pageStack.removeAt(pageStack.lastIndex)
+        _currentPage.value = pageStack.last()
+        return true
+    }
+
+    fun navigateHome() {
+        pageStack.clear()
+        pageStack.add(WalletPage.Home)
+        _currentPage.value = WalletPage.Home
+        _sendInput.value = ""
+        _sendAmount.value = ""
+        _sendError.value = null
+        _receiveAmount.value = ""
+    }
+
+    val isOnHome: Boolean get() = pageStack.size <= 1
+
+    // --- Connection ---
 
     fun updateConnectionString(value: String) {
         _connectionString.value = value
@@ -48,17 +131,40 @@ class WalletViewModel(val nwcRepo: NwcRepository) : ViewModel() {
             return
         }
 
+        _statusLines.value = emptyList()
         _walletState.value = WalletState.Connecting
         nwcRepo.saveConnectionString(trimmed)
+
+        statusCollectJob?.cancel()
+        statusCollectJob = viewModelScope.launch {
+            nwcRepo.statusLog.collect { line ->
+                _statusLines.value = _statusLines.value + line
+            }
+        }
+
         nwcRepo.connect()
 
-        viewModelScope.launch {
-            // Wait for connection then fetch balance to validate
-            nwcRepo.isConnected.collect { connected ->
-                if (connected) {
-                    refreshBalance()
-                    return@collect
+        connectJob?.cancel()
+        connectJob = viewModelScope.launch {
+            val connected = kotlinx.coroutines.withTimeoutOrNull(10_000) {
+                nwcRepo.isConnected.collect { connected ->
+                    if (connected) {
+                        val result = nwcRepo.fetchBalance()
+                        result.fold(
+                            onSuccess = { balanceMsats ->
+                                _walletState.value = WalletState.Connected(balanceMsats)
+                            },
+                            onFailure = { e ->
+                                _walletState.value = WalletState.Error(e.message ?: "Failed to fetch balance")
+                            }
+                        )
+                        return@collect
+                    }
                 }
+            }
+            if (connected == null && _walletState.value is WalletState.Connecting) {
+                _statusLines.value = _statusLines.value + "Connection timed out (10s)"
+                _walletState.value = WalletState.Error("Connection timed out")
             }
         }
     }
@@ -78,29 +184,17 @@ class WalletViewModel(val nwcRepo: NwcRepository) : ViewModel() {
     }
 
     fun disconnectWallet() {
+        connectJob?.cancel()
+        statusCollectJob?.cancel()
         nwcRepo.disconnect()
         nwcRepo.clearConnection()
         _walletState.value = WalletState.NotConnected
         _connectionString.value = ""
-        _generatedInvoice.value = null
-    }
-
-    fun generateInvoice(amountSats: Long, description: String) {
-        viewModelScope.launch {
-            val result = nwcRepo.makeInvoice(amountSats * 1000, description)
-            result.fold(
-                onSuccess = { invoice -> _generatedInvoice.value = invoice },
-                onFailure = { _generatedInvoice.value = null }
-            )
-        }
-    }
-
-    fun clearInvoice() {
-        _generatedInvoice.value = null
+        _statusLines.value = emptyList()
+        navigateHome()
     }
 
     fun refreshState() {
-        _generatedInvoice.value = null
         if (nwcRepo.hasConnection()) {
             if (nwcRepo.isConnected.value) {
                 refreshBalance()
@@ -111,6 +205,173 @@ class WalletViewModel(val nwcRepo: NwcRepository) : ViewModel() {
         } else {
             _walletState.value = WalletState.NotConnected
             _connectionString.value = ""
+        }
+    }
+
+    // --- Send flow ---
+
+    fun updateSendInput(value: String) {
+        _sendInput.value = value
+        _sendError.value = null
+    }
+
+    fun updateSendAmount(digit: Char) {
+        val current = _sendAmount.value
+        if (current.length < 10) {
+            _sendAmount.value = current + digit
+        }
+    }
+
+    fun sendAmountBackspace() {
+        val current = _sendAmount.value
+        if (current.isNotEmpty()) {
+            _sendAmount.value = current.dropLast(1)
+        }
+    }
+
+    fun processInput(input: String = _sendInput.value) {
+        val trimmed = input.trim().removePrefix("lightning:")
+        _sendError.value = null
+
+        when {
+            trimmed.lowercase().startsWith("lnbc") -> {
+                val decoded = Bolt11.decode(trimmed)
+                if (decoded == null) {
+                    _sendError.value = "Invalid BOLT11 invoice"
+                    return
+                }
+                if (decoded.isExpired()) {
+                    _sendError.value = "Invoice has expired"
+                    return
+                }
+                navigateTo(WalletPage.SendConfirm(
+                    invoice = trimmed,
+                    amountSats = decoded.amountSats,
+                    paymentHash = decoded.paymentHash,
+                    description = decoded.description
+                ))
+            }
+            trimmed.contains("@") && trimmed.contains(".") -> {
+                _sendAmount.value = ""
+                navigateTo(WalletPage.SendAmount(trimmed))
+            }
+            else -> {
+                _sendError.value = "Enter a lightning address (user@domain) or BOLT11 invoice"
+            }
+        }
+    }
+
+    fun resolveLightningAddress(address: String, amountSats: Long) {
+        _isLoading.value = true
+        viewModelScope.launch {
+            try {
+                val payInfo = Nip57.resolveLud16(address, httpClient)
+                if (payInfo == null) {
+                    _sendError.value = "Could not resolve lightning address"
+                    _isLoading.value = false
+                    return@launch
+                }
+
+                val amountMsats = amountSats * 1000
+                if (amountMsats < payInfo.minSendable || amountMsats > payInfo.maxSendable) {
+                    _sendError.value = "Amount out of range: ${payInfo.minSendable / 1000}-${payInfo.maxSendable / 1000} sats"
+                    _isLoading.value = false
+                    return@launch
+                }
+
+                val invoice = Nip57.fetchSimpleInvoice(payInfo.callback, amountMsats, httpClient)
+                if (invoice == null) {
+                    _sendError.value = "Failed to fetch invoice"
+                    _isLoading.value = false
+                    return@launch
+                }
+
+                val decoded = Bolt11.decode(invoice)
+                navigateTo(WalletPage.SendConfirm(
+                    invoice = invoice,
+                    amountSats = decoded?.amountSats ?: amountSats,
+                    paymentHash = decoded?.paymentHash,
+                    description = decoded?.description ?: address
+                ))
+            } catch (e: Exception) {
+                _sendError.value = e.message ?: "Failed to resolve address"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun payInvoice(invoice: String) {
+        navigateTo(WalletPage.Sending(invoice))
+        viewModelScope.launch {
+            val result = nwcRepo.payInvoice(invoice)
+            result.fold(
+                onSuccess = {
+                    // Replace Sending page with result
+                    pageStack.removeAt(pageStack.lastIndex)
+                    val resultPage = WalletPage.SendResult(true, "Payment sent!")
+                    pageStack.add(resultPage)
+                    _currentPage.value = resultPage
+                    refreshBalance()
+                },
+                onFailure = { e ->
+                    pageStack.removeAt(pageStack.lastIndex)
+                    val resultPage = WalletPage.SendResult(false, e.message ?: "Payment failed")
+                    pageStack.add(resultPage)
+                    _currentPage.value = resultPage
+                }
+            )
+        }
+    }
+
+    // --- Receive flow ---
+
+    fun updateReceiveAmount(digit: Char) {
+        val current = _receiveAmount.value
+        if (current.length < 10) {
+            _receiveAmount.value = current + digit
+        }
+    }
+
+    fun receiveAmountBackspace() {
+        val current = _receiveAmount.value
+        if (current.isNotEmpty()) {
+            _receiveAmount.value = current.dropLast(1)
+        }
+    }
+
+    fun generateInvoice(amountSats: Long) {
+        _isLoading.value = true
+        viewModelScope.launch {
+            val result = nwcRepo.makeInvoice(amountSats * 1000, "")
+            result.fold(
+                onSuccess = { invoice ->
+                    navigateTo(WalletPage.ReceiveInvoice(invoice, amountSats))
+                },
+                onFailure = { e ->
+                    _sendError.value = e.message ?: "Failed to create invoice"
+                }
+            )
+            _isLoading.value = false
+        }
+    }
+
+    // --- Transactions ---
+
+    fun loadTransactions() {
+        _isLoading.value = true
+        _transactionsError.value = null
+        viewModelScope.launch {
+            val result = nwcRepo.listTransactions()
+            result.fold(
+                onSuccess = { txs ->
+                    _transactions.value = txs
+                },
+                onFailure = { e ->
+                    _transactionsError.value = e.message ?: "Failed to load transactions"
+                }
+            )
+            _isLoading.value = false
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a full wallet send/receive flow, toggleable emoji reactions, NWC protocol improvements, and fixes relay feed loading.

## Wallet Overhaul

- **Send flow**: Multi-page navigation — enter a lightning address or paste a BOLT11 invoice, confirm amount/description, animated sending state, success/failure result screen
- **Receive flow**: Sats numpad for amount entry, generates invoice via NWC `make_invoice`, displays QR code and copyable invoice string
- **Transaction history**: Fetches via NWC `list_transactions`, displays with direction indicators, relative timestamps, and formatted amounts
- **BOLT11 decoder** (`Bolt11.kt`): Client-side bech32 invoice parser extracting amount, payment hash, description, expiry, and timestamp
- **Sats numpad** (`SatsNumpad.kt`): Reusable 4x3 numpad component used in both send and receive flows

## NWC (NIP-47) Improvements

- **NIP-44 encryption**: Negotiates encryption method with the wallet service via its kind 13194 info event; prefers `nip44_v2` when supported, falls back to NIP-04
- **Auto-detect decryption**: Detects NIP-04 vs NIP-44 encrypted content and decrypts accordingly
- **Simplified subscription model**: Replaced per-request subscribe-then-publish with a single persistent `nwc-responses` subscription; requests are just published directly
- **Connection robustness**: Handles unencoded relay URLs in NWC connection strings, null-safe JSON parsing for wallets returning `"error": null`
- **Status logging**: Granular status updates during connection flow displayed in the wallet UI
- **Relay dedup**: Disconnects matching relay URLs from the main pool on NWC connect to avoid duplicate WebSocket connections
- Added Cashu.me and Minibits to wallet provider list

## Reaction Toggle (NIP-09)

- Reactions are now toggleable — tapping an emoji you've already reacted with sends a NIP-09 deletion event (kind 5) and removes it locally
- Multi-emoji tracking per event via `ConcurrentHashMap<String, String>` (emoji → reaction event ID), replacing the single-emoji `LruCache`
- Emoji picker highlights already-selected emojis; emoji button remains clickable after reacting
- New `Nip09.kt` helper for building deletion event tags
- All screens updated: Navigation, Feed, Thread, UserProfile, Bookmarks, Notifications

## Relay Feed Fix

- Changed relay-specific feed subscriptions from `sendToRelay` to `sendToRelayOrEphemeral` in three places (subscribe, backfill, load-more)
- `sendToRelay` silently drops messages when the URL isn't in the permanent pool — this broke relay feeds when scored relays were removed during scoreboard recomputation or when users probed custom relay URLs
- `sendToRelayOrEphemeral` creates an ephemeral connection when needed, ensuring the subscription always reaches the relay

## EOSE Subscription Fix

- `awaitEoseCount` now uses `filter` + `take` flow operators instead of `return@collect`
- `return@collect` only returns from the lambda, not the `SharedFlow.collect` call, so it previously always waited the full 15s timeout regardless of how many EOSE signals arrived

## Test plan

- [ ] Open wallet, verify balance displays on home screen
- [ ] Send to a lightning address — confirm multi-step flow works end-to-end
- [ ] Send a BOLT11 invoice — confirm amount/description parsed correctly
- [ ] Receive sats — verify QR code generation and invoice copy
- [ ] View transaction history
- [ ] React to a post with an emoji, verify highlight appears
- [ ] Tap the same emoji again, verify reaction is removed (deletion event sent)
- [ ] Select a relay from the relay picker, verify feed loads
- [ ] Probe a custom relay URL, verify feed loads
- [ ] Verify follows feed still loads normally
- [ ] Verify EOSE-dependent loading feels faster (no unnecessary 15s waits)