### PR TITLE
Fix feed contamination, notification persistence, relay reconnection, and wallet reliability

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -123,7 +123,6 @@ fun WispNavHost() {
     if (authViewModel.isLoggedIn && startDestination == Routes.FEED) {
         LaunchedEffect(Unit) {
             feedViewModel.initRelays()
-            feedViewModel.initNwc()
         }
     }
 
@@ -195,7 +194,6 @@ fun WispNavHost() {
                     } else {
                         feedViewModel.reloadForNewAccount()
                         feedViewModel.initRelays()
-                        feedViewModel.initNwc()
                         walletViewModel.refreshState()
                         authViewModel.keyRepo.markOnboardingComplete()
                         navController.navigate(Routes.FEED) {
@@ -732,7 +730,6 @@ fun WispNavHost() {
                     )
                     feedViewModel.reloadForNewAccount()
                     feedViewModel.initRelays()
-                    feedViewModel.initNwc()
                     walletViewModel.refreshState()
                     navController.navigate(Routes.FEED) {
                         popUpTo(0) { inclusive = true }

--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -137,6 +137,7 @@ class Relay(
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 Log.d("Relay", "Closed ${config.url}: $reason")
                 isConnected = false
+                this@Relay.webSocket = null
                 _connectionState.tryEmit(false)
                 if (code != 1000) {
                     _connectionErrors.tryEmit(ConsoleLogEntry(
@@ -144,6 +145,7 @@ class Relay(
                         type = ConsoleLogType.CONN_CLOSED,
                         message = "Code $code: $reason"
                     ))
+                    reconnect()
                 }
             }
         })

--- a/app/src/main/kotlin/com/wisp/app/repo/NwcRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NwcRepository.kt
@@ -90,13 +90,13 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
         // Drop matching relay from the pool to avoid duplicate connections
         relayPool?.disconnectRelay(conn.relayUrl)
 
-        val client = Relay.createClient()
-        val r = Relay(RelayConfig(conn.relayUrl), client)
-        relay = r
-
         scope?.cancel()
         val newScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         scope = newScope
+
+        val client = Relay.createClient()
+        val r = Relay(RelayConfig(conn.relayUrl), client, scope = newScope)
+        relay = r
 
         emitStatus("Connecting to relay ${conn.relayUrl}...")
 


### PR DESCRIPTION
## Summary

- **Fix feed contamination**: Events from user profile, thread, and bookmark subscriptions were being added to the follow feed via `addEvent()` in the catch-all else block of `processRelayEvent`. This caused posts from non-followed users to appear in the feed after viewing their profiles, and inflated the "new posts" counter (the count included every post loaded on profile screens). Now only feed-related subscriptions (`feed`, `loadmore`, `feed-backfill`) call `addEvent()` — everything else uses `cacheEvent()` which stores events for lookups without inserting into the feed list.

- **Fix UserProfileViewModel feed leakage**: The profile screen was also calling `eventRepo.addEvent()` for kind 0/1/6 events, which inserted viewed users' posts into the global feed. Changed to `cacheEvent()` since the profile screen maintains its own local lists. Also chunked follow-profile requests into batches of 50 with proper subscription cleanup.

- **Persist notification read state**: Unread notification badge now survives app restarts by persisting the last-read timestamp in SharedPreferences (per account). Notifications are only marked unread if they're newer than the stored timestamp.

- **Fix relay reconnection**: WebSocket `onClosed` with non-normal close codes (anything other than 1000) now triggers reconnection. The socket reference is also nulled on close to prevent sends to dead connections.

- **Improve wallet connection reliability**: Rewrote the NWC connection flow — initial connect uses a proper coroutine timeout, then a persistent monitor handles disconnect/reconnect state transitions. The NWC relay now receives a coroutine scope for proper lifecycle management. Removed `initNwc()` since wallet connects lazily when the tab is opened or on-demand when sending a zap.

## Test plan

- [ ] Pull to refresh the feed — verify the "new posts" counter starts at 0 and only counts genuinely new streaming events
- [ ] Visit a non-followed user's profile, navigate back to feed — verify their posts don't appear in the follow feed
- [ ] View notifications, restart app — verify unread badge reflects actual unread state
- [ ] Disconnect from network briefly, reconnect — verify relays reconnect and feed resumes
- [ ] Connect NWC wallet, navigate away and back — verify wallet stays connected and shows balance
- [ ] Send a zap without visiting the wallet tab first — verify NWC connects on demand