### PR TITLE
Relay layer refactor: inbox-routed engagement and performance optimizations

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionTracker.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionTracker.kt
@@ -10,8 +10,10 @@ class SubscriptionTracker {
     private val relaySubs = ConcurrentHashMap<String, MutableSet<String>>()
 
     companion object {
-        const val SOFT_CAP = 15
-        private val PRIORITY_PREFIXES = listOf("dms", "notif", "feed", "self-data", "thread-")
+        const val SOFT_CAP = 20
+        private val PRIORITY_PREFIXES = listOf(
+            "dms", "notif", "feed", "self-data", "thread-", "engage", "user-engage"
+        )
     }
 
     fun track(relayUrl: String, subId: String) {
@@ -22,6 +24,10 @@ class SubscriptionTracker {
         for (subs in relaySubs.values) {
             subs.remove(subId)
         }
+    }
+
+    fun untrackRelay(relayUrl: String) {
+        relaySubs.remove(relayUrl)
     }
 
     fun hasCapacity(relayUrl: String, subId: String): Boolean {


### PR DESCRIPTION
## Summary

- **Inbox-routed engagement queries (NIP-65)**: Reactions, zaps, and reply counts are now fetched from each post author's read (inbox) relays instead of only our own read relays. Per NIP-65, reactors publish to the author's inbox — we were looking in the wrong place and missing most engagement data.
- **Subscription lifecycle fixes**: Engagement subs are now priority-prefixed so they aren't silently dropped at the soft cap, stale `engage-more-N` subs are closed after EOSE, and the subscription tracker is cleaned up on relay disconnect to prevent phantom counts.
- **Performance optimizations**: O(1) relay URL lookups via a centralized index (replacing 3 linear scans per call), O(n) author→relay grouping in the scoreboard (replacing O(authors × relays)), and proper coroutine lifecycle management with cancellable parent jobs per relay.

## Changes

| File | What changed |
|------|-------------|
| `OutboxRouter.kt` | New `subscribeEngagementByAuthors()` — groups events by author, queries each author's inbox relays, falls back to our read relays for unknown authors |
| `RelayPool.kt` | Relay URL index (`ConcurrentHashMap`), configurable dedup bypass set, DM relay cap (10), per-relay parent `Job` tracking with cancellation, subscription tracker cleanup on disconnect |
| `RelayScoreBoard.kt` | Inverse `authorToRelay` index built during `recompute()`, `getRelaysForAuthors()` rewritten as O(n) group-by |
| `SubscriptionTracker.kt` | Added `engage`/`user-engage` to priority prefixes, raised soft cap 15→20, added `untrackRelay()` |
| `FeedViewModel.kt` | Engagement subscriptions routed through `outboxRouter.subscribeEngagementByAuthors()`, stale load-more engagement subs closed after EOSE |
| `UserProfileViewModel.kt` | Profile engagement routed to target user's inbox relays via `outboxRouter` |

## Test plan

- [ ] Open app, verify feed loads with reactions, zap counts, and reply counts — should see **more** engagement data than before
- [ ] Tap a note, verify thread loads with all replies and metadata
- [ ] Tap a user profile, verify their posts and engagement data loads
- [ ] Open DM conversation, verify messages send/receive normally
- [ ] Log out, log in with different account, verify clean state
- [ ] Background the app, return, verify feed reloads correctly
- [ ] Check relay screen console for any new errors
- [ ] Load more (scroll down), verify engagement appears on older posts and subs are cleaned up