### PR TITLE
Fix initial feed load performance and relay timing

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -344,7 +344,7 @@ class RelayPool {
         // O(1) lookup in persistent/DM relay index
         relayIndex[url]?.let { existing ->
             // Don't use this path for ephemeral relays (they're in relayIndex too)
-            if (existing !in ephemeralRelays.values) {
+            if (!ephemeralRelays.containsKey(url)) {
                 existing.send(message)
                 return true
             }
@@ -424,6 +424,8 @@ class RelayPool {
         for (url in deadEphemerals) {
             ephemeralRelays.remove(url)?.disconnect()
             ephemeralLastUsed.remove(url)
+            relayIndex.remove(url)
+            cancelRelayJobs(url)
         }
         if (count > 0) Log.d("RelayPool", "reconnectAll: $count relays reconnecting")
         updateConnectedCount()


### PR DESCRIPTION
## Summary

- **Await relay connections before subscribing**: `subscribeFeed()` was firing immediately after `updateRelays()`, but WebSocket connections are async — `relay.send()` silently drops messages when not connected. Now waits for at least 3 relays (5s timeout).
- **Reduce per-relay limit 100→25**: With outbox routing to 30+ scored relays, `limit=100` per relay meant thousands of events flooding in simultaneously, each triggering processRelayEvent → addEvent → StateFlow → recompose. 25 per relay is plenty for the initial screen; `loadMore()` handles pagination.
- **Tighten adaptive time windows**: Previous windows were too aggressive for small follow counts (7 days for ≤20 follows). Now: 2d/12h/4h/1h/15m instead of 7d/48h/12h/3h/30m.
- **Fix stale relay index in reconnectAll()**: Dead ephemeral relays were removed from `ephemeralRelays` but not `relayIndex`, causing sends to dead relays on subsequent lookups.
- **Fix O(n) → O(1)**: Replace `!in ephemeralRelays.values` scan with `containsKey` lookup.

## Test plan

- [ ] Open app fresh — feed should load quickly with ~20-30 recent notes, no jank
- [ ] Scroll down to trigger loadMore — older notes should paginate in smoothly
- [ ] Switch to relay feed and back to follows — should show same notes
- [ ] Account with few follows (≤20) — should see recent posts, not week-old content
- [ ] Account with many follows (300+) — should load fast with tight 4h window
- [ ] Background and resume — feed should reload correctly