### PR TITLE
Add extended follows feed with network discovery

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionTracker.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionTracker.kt
@@ -12,7 +12,7 @@ class SubscriptionTracker {
     companion object {
         const val SOFT_CAP = 20
         private val PRIORITY_PREFIXES = listOf(
-            "dms", "notif", "feed", "self-data", "thread-", "engage", "user-engage"
+            "dms", "notif", "feed", "self-data", "thread-", "engage", "user-engage", "extnet-"
         )
     }
 

--- a/app/src/main/kotlin/com/wisp/app/repo/ExtendedNetworkRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/ExtendedNetworkRepository.kt
@@ -1,0 +1,377 @@
+package com.wisp.app.repo
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import com.wisp.app.nostr.ClientMessage
+import com.wisp.app.nostr.Filter
+import com.wisp.app.nostr.Nip02
+import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.relay.RelayConfig
+import com.wisp.app.relay.RelayPool
+import com.wisp.app.relay.SubscriptionManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class ExtendedNetworkCache(
+    val qualifiedPubkeys: Set<String>,
+    val firstDegreePubkeys: Set<String>,
+    val authorToRelay: Map<String, String>,
+    val scoredRelayUrls: List<String>,
+    val computedAtEpoch: Long,
+    val stats: NetworkStats
+)
+
+@Serializable
+data class NetworkStats(
+    val firstDegreeCount: Int,
+    val totalSecondDegree: Int,
+    val qualifiedCount: Int,
+    val relaysCovered: Int
+)
+
+sealed class DiscoveryState {
+    data object Idle : DiscoveryState()
+    data class FetchingFollowLists(val fetched: Int, val total: Int) : DiscoveryState()
+    data class ComputingNetwork(val uniqueUsers: Int) : DiscoveryState()
+    data class Filtering(val qualified: Int) : DiscoveryState()
+    data class FetchingRelayLists(val fetched: Int, val total: Int) : DiscoveryState()
+    data object BuildingRelayMap : DiscoveryState()
+    data class Complete(val stats: NetworkStats) : DiscoveryState()
+    data class Failed(val reason: String) : DiscoveryState()
+}
+
+class ExtendedNetworkRepository(
+    private val context: Context,
+    private val contactRepo: ContactRepository,
+    private val muteRepo: MuteRepository,
+    private val relayListRepo: RelayListRepository,
+    private val relayPool: RelayPool,
+    private val subManager: SubscriptionManager,
+    private val pubkeyHex: String?
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val _discoveryState = MutableStateFlow<DiscoveryState>(DiscoveryState.Idle)
+    val discoveryState: StateFlow<DiscoveryState> = _discoveryState
+
+    private val _cachedNetwork = MutableStateFlow<ExtendedNetworkCache?>(null)
+    val cachedNetwork: StateFlow<ExtendedNetworkCache?> = _cachedNetwork
+
+    // Temporary storage for kind 3 events received during discovery
+    private val pendingFollowLists = java.util.concurrent.ConcurrentHashMap<String, NostrEvent>()
+
+    companion object {
+        private const val TAG = "ExtendedNetworkRepo"
+        private const val THRESHOLD = 10
+        private const val MAX_RELAYS = 100
+        private const val WAVE_SIZE = 50
+        private const val WAVE_TIMEOUT_MS = 20_000L
+        private const val STALE_HOURS = 24
+        private const val STALE_DRIFT_THRESHOLD = 0.10
+
+        private fun prefsName(pubkeyHex: String?): String =
+            if (pubkeyHex != null) "wisp_extended_network_$pubkeyHex" else "wisp_extended_network"
+    }
+
+    private var prefs: SharedPreferences =
+        context.getSharedPreferences(prefsName(pubkeyHex), Context.MODE_PRIVATE)
+
+    init {
+        loadFromPrefs()
+    }
+
+    fun processFollowListEvent(event: NostrEvent) {
+        if (event.kind != 3) return
+        pendingFollowLists[event.pubkey] = event
+    }
+
+    fun isNetworkReady(): Boolean {
+        val cache = _cachedNetwork.value ?: return false
+        return !isCacheStale(cache)
+    }
+
+    fun isCacheStale(cache: ExtendedNetworkCache): Boolean {
+        val ageHours = (System.currentTimeMillis() / 1000 - cache.computedAtEpoch) / 3600
+        if (ageHours >= STALE_HOURS) return true
+
+        val currentFollows = contactRepo.getFollowList().map { it.pubkey }.toSet()
+        if (currentFollows.isEmpty()) return false
+
+        val cachedFollows = cache.firstDegreePubkeys
+        val symmetric = (currentFollows - cachedFollows).size + (cachedFollows - currentFollows).size
+        val driftRatio = symmetric.toDouble() / cachedFollows.size.coerceAtLeast(1)
+        return driftRatio > STALE_DRIFT_THRESHOLD
+    }
+
+    suspend fun discoverNetwork() {
+        try {
+            val myPubkey = pubkeyHex ?: run {
+                _discoveryState.value = DiscoveryState.Failed("No account logged in")
+                return
+            }
+
+            val firstDegree = contactRepo.getFollowList().map { it.pubkey }
+            if (firstDegree.isEmpty()) {
+                _discoveryState.value = DiscoveryState.Failed("Follow list is empty")
+                return
+            }
+
+            val firstDegreeSet = firstDegree.toSet()
+            pendingFollowLists.clear()
+
+            // Step 1: Fetch kind 3 events for all first-degree follows in waves
+            val waves = firstDegree.chunked(WAVE_SIZE)
+            var fetchedCount = 0
+            _discoveryState.value = DiscoveryState.FetchingFollowLists(0, firstDegree.size)
+
+            for ((i, wave) in waves.withIndex()) {
+                val subId = "extnet-k3-$i"
+                val filter = Filter(kinds = listOf(3), authors = wave, limit = wave.size)
+                relayPool.sendToAll(ClientMessage.req(subId, filter))
+
+                withTimeoutOrNull(WAVE_TIMEOUT_MS) {
+                    subManager.awaitEoseWithTimeout(subId, WAVE_TIMEOUT_MS)
+                }
+                subManager.closeSubscription(subId)
+
+                fetchedCount += wave.size
+                _discoveryState.value = DiscoveryState.FetchingFollowLists(
+                    fetched = pendingFollowLists.size,
+                    total = firstDegree.size
+                )
+            }
+
+            Log.d(TAG, "Fetched ${pendingFollowLists.size} follow lists from ${firstDegree.size} follows")
+
+            // Step 2: Parse follow lists and count 2nd-degree appearances
+            val followMaps = mutableMapOf<String, Set<String>>()
+            for ((pubkey, event) in pendingFollowLists) {
+                val follows = Nip02.parseFollowList(event).map { it.pubkey }.toSet()
+                followMaps[pubkey] = follows
+            }
+
+            val secondDegreeCount = mutableMapOf<String, Int>()
+            for ((_, follows) in followMaps) {
+                for (pk in follows) {
+                    if (pk != myPubkey && pk !in firstDegreeSet) {
+                        secondDegreeCount[pk] = (secondDegreeCount[pk] ?: 0) + 1
+                    }
+                }
+            }
+
+            _discoveryState.value = DiscoveryState.ComputingNetwork(secondDegreeCount.size)
+            Log.d(TAG, "Found ${secondDegreeCount.size} unique 2nd-degree follows")
+
+            // Step 3: Filter to qualified (threshold) and exclude muted
+            val qualified = withContext(Dispatchers.Default) {
+                secondDegreeCount
+                    .filter { it.value >= THRESHOLD }
+                    .filter { !muteRepo.isBlocked(it.key) }
+                    .keys
+            }
+
+            _discoveryState.value = DiscoveryState.Filtering(qualified.size)
+            Log.d(TAG, "Qualified ${qualified.size} pubkeys (threshold >= $THRESHOLD)")
+
+            if (qualified.isEmpty()) {
+                val stats = NetworkStats(
+                    firstDegreeCount = firstDegree.size,
+                    totalSecondDegree = secondDegreeCount.size,
+                    qualifiedCount = 0,
+                    relaysCovered = 0
+                )
+                _discoveryState.value = DiscoveryState.Complete(stats)
+                return
+            }
+
+            // Step 4: Fetch relay lists for qualified pubkeys missing from cache
+            val missingRelayLists = relayListRepo.getMissingPubkeys(qualified.toList())
+            if (missingRelayLists.isNotEmpty()) {
+                val rlWaves = missingRelayLists.chunked(WAVE_SIZE)
+                var rlFetched = 0
+                _discoveryState.value = DiscoveryState.FetchingRelayLists(0, missingRelayLists.size)
+
+                for ((i, wave) in rlWaves.withIndex()) {
+                    val subId = "extnet-rl-$i"
+                    val filter = Filter(kinds = listOf(10002), authors = wave, limit = wave.size)
+                    relayPool.sendToAll(ClientMessage.req(subId, filter))
+
+                    withTimeoutOrNull(WAVE_TIMEOUT_MS) {
+                        subManager.awaitEoseWithTimeout(subId, WAVE_TIMEOUT_MS)
+                    }
+                    subManager.closeSubscription(subId)
+
+                    rlFetched += wave.size
+                    _discoveryState.value = DiscoveryState.FetchingRelayLists(
+                        fetched = rlFetched.coerceAtMost(missingRelayLists.size),
+                        total = missingRelayLists.size
+                    )
+                }
+            }
+
+            // Step 5: Greedy set-cover algorithm to select optimal relays
+            _discoveryState.value = DiscoveryState.BuildingRelayMap
+
+            val (authorToRelay, scoredRelayUrls) = withContext(Dispatchers.Default) {
+                computeRelayMap(qualified)
+            }
+
+            val stats = NetworkStats(
+                firstDegreeCount = firstDegree.size,
+                totalSecondDegree = secondDegreeCount.size,
+                qualifiedCount = qualified.size,
+                relaysCovered = scoredRelayUrls.size
+            )
+
+            val cache = ExtendedNetworkCache(
+                qualifiedPubkeys = qualified,
+                firstDegreePubkeys = firstDegreeSet,
+                authorToRelay = authorToRelay,
+                scoredRelayUrls = scoredRelayUrls,
+                computedAtEpoch = System.currentTimeMillis() / 1000,
+                stats = stats
+            )
+
+            _cachedNetwork.value = cache
+            saveToPrefs(cache)
+            pendingFollowLists.clear()
+
+            Log.d(TAG, "Discovery complete: ${stats.qualifiedCount} qualified, ${stats.relaysCovered} relays")
+            _discoveryState.value = DiscoveryState.Complete(stats)
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Discovery failed", e)
+            _discoveryState.value = DiscoveryState.Failed(e.message ?: "Unknown error")
+        }
+    }
+
+    private fun computeRelayMap(qualified: Set<String>): Pair<Map<String, String>, List<String>> {
+        // Build relay -> authors mapping from relay list cache
+        val relayToAuthors = mutableMapOf<String, MutableSet<String>>()
+        for (pubkey in qualified) {
+            val writeRelays = relayListRepo.getWriteRelays(pubkey) ?: continue
+            for (url in writeRelays) {
+                relayToAuthors.getOrPut(url) { mutableSetOf() }.add(pubkey)
+            }
+        }
+
+        if (relayToAuthors.isEmpty()) {
+            return Pair(emptyMap(), emptyList())
+        }
+
+        // Greedy set-cover
+        val uncovered = qualified.toMutableSet()
+        val selectedRelays = mutableListOf<String>()
+        val remainingRelays = relayToAuthors.toMutableMap()
+        val inverseIndex = mutableMapOf<String, String>()
+
+        while (uncovered.isNotEmpty() && selectedRelays.size < MAX_RELAYS && remainingRelays.isNotEmpty()) {
+            var bestUrl: String? = null
+            var bestCover: Set<String> = emptySet()
+            for ((url, authors) in remainingRelays) {
+                val cover = authors.intersect(uncovered)
+                if (cover.size > bestCover.size) {
+                    bestUrl = url
+                    bestCover = cover
+                }
+            }
+            if (bestUrl == null || bestCover.isEmpty()) break
+
+            selectedRelays.add(bestUrl)
+            for (author in bestCover) {
+                if (author !in inverseIndex) {
+                    inverseIndex[author] = bestUrl
+                }
+            }
+            uncovered.removeAll(bestCover)
+            remainingRelays.remove(bestUrl)
+        }
+
+        return Pair(inverseIndex, selectedRelays)
+    }
+
+    /**
+     * Route subscriptions for extended network authors to their optimal relays.
+     * Groups authors using cached authorToRelay index. Uncovered authors fall back to sendToAll.
+     * Returns the set of relay URLs that received subscriptions.
+     */
+    fun subscribeByAuthors(
+        subId: String,
+        authors: List<String>,
+        vararg templateFilters: Filter
+    ): Set<String> {
+        val cache = _cachedNetwork.value ?: return emptySet()
+        val targetedRelays = mutableSetOf<String>()
+
+        // Group authors by their assigned relay
+        val relayToAuthors = mutableMapOf<String, MutableList<String>>()
+        val uncoveredAuthors = mutableListOf<String>()
+
+        for (author in authors) {
+            val relay = cache.authorToRelay[author]
+            if (relay != null) {
+                relayToAuthors.getOrPut(relay) { mutableListOf() }.add(author)
+            } else {
+                uncoveredAuthors.add(author)
+            }
+        }
+
+        for ((relayUrl, relayAuthors) in relayToAuthors) {
+            val filters = templateFilters.map { it.copy(authors = relayAuthors) }
+            val msg = if (filters.size == 1) ClientMessage.req(subId, filters[0])
+            else ClientMessage.req(subId, filters)
+            if (relayPool.sendToRelayOrEphemeral(relayUrl, msg)) {
+                targetedRelays.add(relayUrl)
+            }
+        }
+
+        if (uncoveredAuthors.isNotEmpty()) {
+            val filters = templateFilters.map { it.copy(authors = uncoveredAuthors) }
+            val msg = if (filters.size == 1) ClientMessage.req(subId, filters[0])
+            else ClientMessage.req(subId, filters)
+            relayPool.sendToAll(msg)
+            targetedRelays.addAll(relayPool.getRelayUrls())
+        }
+
+        return targetedRelays
+    }
+
+    fun clear() {
+        _cachedNetwork.value = null
+        _discoveryState.value = DiscoveryState.Idle
+        pendingFollowLists.clear()
+    }
+
+    fun reload(pubkeyHex: String?) {
+        clear()
+        prefs = context.getSharedPreferences(prefsName(pubkeyHex), Context.MODE_PRIVATE)
+        loadFromPrefs()
+    }
+
+    private fun saveToPrefs(cache: ExtendedNetworkCache) {
+        try {
+            val data = json.encodeToString(cache)
+            prefs.edit().putString("cache", data).apply()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to save cache", e)
+        }
+    }
+
+    private fun loadFromPrefs() {
+        try {
+            val data = prefs.getString("cache", null) ?: return
+            val cache = json.decodeFromString<ExtendedNetworkCache>(data)
+            _cachedNetwork.value = cache
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load cache", e)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NetworkDiscoveryScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NetworkDiscoveryScreen.kt
@@ -1,0 +1,163 @@
+package com.wisp.app.ui.screen
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.wisp.app.nostr.ProfileData
+import com.wisp.app.repo.DiscoveryState
+import com.wisp.app.ui.component.WispLogo
+
+@Composable
+fun NetworkDiscoveryScreen(
+    discoveryState: DiscoveryState,
+    profile: ProfileData?,
+    onCancel: () -> Unit,
+    onRetry: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier.padding(horizontal = 32.dp)
+            ) {
+                if (profile?.picture != null) {
+                    AsyncImage(
+                        model = profile.picture,
+                        contentDescription = "Profile picture",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
+                    )
+                } else {
+                    WispLogo(size = 80.dp)
+                }
+
+                Spacer(Modifier.height(24.dp))
+
+                Text(
+                    text = "Discovering Your Network",
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+
+                Spacer(Modifier.height(24.dp))
+
+                val progress = computeProgress(discoveryState)
+                LinearProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                AnimatedContent(
+                    targetState = getStatusText(discoveryState),
+                    transitionSpec = { fadeIn() togetherWith fadeOut() },
+                    label = "status"
+                ) { text ->
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
+
+                Spacer(Modifier.height(32.dp))
+
+                when (discoveryState) {
+                    is DiscoveryState.Failed -> {
+                        TextButton(onClick = onRetry) {
+                            Text("Retry")
+                        }
+                        TextButton(onClick = onCancel) {
+                            Text("Cancel")
+                        }
+                    }
+                    is DiscoveryState.Complete -> {
+                        // Auto-navigate handled by caller
+                    }
+                    else -> {
+                        TextButton(onClick = onCancel) {
+                            Text("Cancel")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun computeProgress(state: DiscoveryState): Float {
+    // Weighted 6-step progress: follow lists ~60%, compute ~5%, filter ~5%, relay lists ~20%, build ~5%, complete ~5%
+    return when (state) {
+        is DiscoveryState.Idle -> 0f
+        is DiscoveryState.FetchingFollowLists -> {
+            val frac = if (state.total > 0) state.fetched.toFloat() / state.total else 0f
+            0.0f + frac * 0.60f
+        }
+        is DiscoveryState.ComputingNetwork -> 0.60f
+        is DiscoveryState.Filtering -> 0.65f
+        is DiscoveryState.FetchingRelayLists -> {
+            val frac = if (state.total > 0) state.fetched.toFloat() / state.total else 0f
+            0.70f + frac * 0.20f
+        }
+        is DiscoveryState.BuildingRelayMap -> 0.90f
+        is DiscoveryState.Complete -> 1.0f
+        is DiscoveryState.Failed -> 0f
+    }
+}
+
+private fun getStatusText(state: DiscoveryState): String {
+    return when (state) {
+        is DiscoveryState.Idle -> "Preparing..."
+        is DiscoveryState.FetchingFollowLists -> "Fetching follow lists... ${state.fetched}/${state.total}"
+        is DiscoveryState.ComputingNetwork -> "Computing network... ${state.uniqueUsers} users found"
+        is DiscoveryState.Filtering -> "Filtering... ${state.qualified} qualified"
+        is DiscoveryState.FetchingRelayLists -> "Fetching relay lists... ${state.fetched}/${state.total}"
+        is DiscoveryState.BuildingRelayMap -> "Building relay map..."
+        is DiscoveryState.Complete -> "Found ${state.stats.qualifiedCount} people across ${state.stats.relaysCovered} relays"
+        is DiscoveryState.Failed -> "Discovery failed: ${state.reason}"
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new "Extended" feed type that expands the timeline to include 2nd-degree connections (friends-of-friends) filtered to those followed by at least 10 people in the user's network
- Full discovery flow with progress screen showing follow list fetching, network computation, relay list resolution, and greedy set-cover relay mapping
- Per-account caching with 24h staleness + follow list drift detection, so subsequent loads are instant
- Refresh button in the top bar when Extended feed is active to rebuild the network on demand

## New files
- `ExtendedNetworkRepository.kt` — discovery algorithm, caching, outbox-model relay routing
- `NetworkDiscoveryScreen.kt` — progress UI during discovery

## Modified files
- `FeedViewModel.kt` — EXTENDED_FOLLOWS feed type, event routing for extnet-* subs, resubscribe/loadMore branches
- `FeedScreen.kt` — "Extended" dropdown item, refresh button, empty state
- `Navigation.kt` — NETWORK_DISCOVERY route with auto-navigate on completion
- `SubscriptionTracker.kt` — extnet- priority prefix to bypass soft cap

## Test plan
- [ ] Log in with an account following 50+ people
- [ ] Tap feed picker → "Extended" → verify discovery screen with progress
- [ ] After completion, verify feed loads posts from 2nd-degree follows
- [ ] Kill and restart → tap "Extended" → loads from cache instantly
- [ ] Tap refresh button → re-runs discovery and updates cache
- [ ] Switch accounts → verify extended network is per-account