### PR TITLE
Fix feed showing incomplete notes on startup

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -420,6 +420,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         }
     }
 
+
     fun clearFeed() {
         synchronized(feedList) {
             feedList.clear()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NetworkDiscoveryScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NetworkDiscoveryScreen.kt
@@ -141,9 +141,8 @@ private fun computeProgress(state: DiscoveryState): Float {
         is DiscoveryState.Filtering -> 0.65f
         is DiscoveryState.FetchingRelayLists -> {
             val frac = if (state.total > 0) state.fetched.toFloat() / state.total else 0f
-            0.70f + frac * 0.20f
+            0.70f + frac * 0.30f
         }
-        is DiscoveryState.BuildingRelayMap -> 0.90f
         is DiscoveryState.Complete -> 1.0f
         is DiscoveryState.Failed -> 0f
     }
@@ -156,7 +155,6 @@ private fun getStatusText(state: DiscoveryState): String {
         is DiscoveryState.ComputingNetwork -> "Computing network... ${state.uniqueUsers} users found"
         is DiscoveryState.Filtering -> "Filtering... ${state.qualified} qualified"
         is DiscoveryState.FetchingRelayLists -> "Fetching relay lists... ${state.fetched}/${state.total}"
-        is DiscoveryState.BuildingRelayMap -> "Building relay map..."
         is DiscoveryState.Complete -> "Found ${state.stats.qualifiedCount} people across ${state.stats.relaysCovered} relays"
         is DiscoveryState.Failed -> "Discovery failed: ${state.reason}"
     }


### PR DESCRIPTION
## Summary
- Fix feed subscribing before the relay scoreboard is fully populated, causing outbox routing to fall back to broadcasting and showing sparse/inconsistent notes
- Persist the full relay scoreboard to SharedPreferences so subsequent app launches skip the expensive relay-list fetch when the follow list hasn't changed
- Add incremental scoreboard updates when following/unfollowing users mid-session (no full recompute needed)
- Add init loading overlay with animated progress bar showing each startup step
- Improve OutboxRouter to look up write relays directly for uncovered authors instead of broadcasting

## Test plan
- [ ] Fresh install: loading overlay shows progress through all steps, feed loads with full notes
- [ ] Subsequent launch (same follow list): feed loads near-instantly using cached scoreboard
- [ ] Follow a new user from profile → their notes appear in feed without full reload
- [ ] Unfollow a user → their notes stop appearing
- [ ] Pull-to-refresh: rebuilds scoreboard and shows current notes
- [ ] Check relay tab: all relays should show correct npub counts immediately after load
- [ ] Extended follows feed still works correctly