### PR TITLE
Fix feed startup, outbox routing, and engagement counts

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -415,7 +415,15 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
             if (muteRepo.isBlocked(event.pubkey)) return
             val myPubkey = getUserPubkey()
             if (myPubkey != null) {
-                eventRepo.cacheEvent(event)
+                when (event.kind) {
+                    7, 9735 -> eventRepo.addEvent(event)
+                    1 -> {
+                        eventRepo.cacheEvent(event)
+                        val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
+                        if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+                    }
+                    else -> eventRepo.cacheEvent(event)
+                }
                 notifRepo.addEvent(event, myPubkey)
                 if (eventRepo.getProfileData(event.pubkey) == null) {
                     metadataFetcher.addToPendingProfiles(event.pubkey)


### PR DESCRIPTION
## Summary
- Fix extended network discovery fetching too few follow lists
- Fix feed showing incomplete notes by waiting for full outbox routing
- Fix notification events not being counted for reaction/zap/reply totals on the user's own notes

## Test plan
- [ ] Log in and verify feed loads completely with correct note counts
- [ ] Check own notes show accurate reaction, zap, and reply counts
- [ ] Verify other users' notes still display correct counts
- [ ] Confirm notifications screen works correctly