### PR TITLE
fix: chunk large author filters to avoid relay rejection

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -568,15 +568,26 @@ class RelayPool {
     }
 
     fun closeOnAllRelays(subscriptionId: String) {
-        subscriptionTracker.untrackAll(subscriptionId)
-        // Remove tracked subscription from all relays
+        // Collect all chunk subIds (e.g., "feed", "feed:c1", "feed:c2") in addition to the base.
+        // OutboxRouter uses ":c{N}" suffixes when chunking large author filters.
+        val chunkPrefix = "$subscriptionId:c"
+        val allSubIds = mutableListOf(subscriptionId)
         for (relayMap in activeSubscriptions.values) {
-            relayMap.remove(subscriptionId)
+            for (key in relayMap.keys) {
+                if (key.startsWith(chunkPrefix)) allSubIds.add(key)
+            }
         }
-        val msg = ClientMessage.close(subscriptionId)
-        for (relay in relays) relay.send(msg)
-        for (relay in dmRelays) relay.send(msg)
-        for (relay in ephemeralRelays.values) relay.send(msg)
+        val uniqueSubIds = allSubIds.distinct()
+        for (subId in uniqueSubIds) {
+            subscriptionTracker.untrackAll(subId)
+            for (relayMap in activeSubscriptions.values) {
+                relayMap.remove(subId)
+            }
+            val msg = ClientMessage.close(subId)
+            for (relay in relays) relay.send(msg)
+            for (relay in dmRelays) relay.send(msg)
+            for (relay in ephemeralRelays.values) relay.send(msg)
+        }
     }
 
     fun cleanupEphemeralRelays() {

--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
@@ -9,24 +9,27 @@ class SubscriptionManager(private val relayPool: RelayPool) {
 
     /**
      * Await a specific EOSE signal by subscription ID. One-shot, no lingering collector.
+     * Also matches chunk variants (e.g., "feed:c1", "feed:c2") for the given base subId.
      */
     suspend fun awaitEose(targetSubId: String) {
-        relayPool.eoseSignals.first { it == targetSubId }
+        relayPool.eoseSignals.first { it == targetSubId || it.startsWith("$targetSubId:c") }
     }
 
     /**
      * Await EOSE with a timeout. Returns true if EOSE was received, false on timeout.
+     * Also matches chunk variants (e.g., "feed:c1", "feed:c2") for the given base subId.
      */
     suspend fun awaitEoseWithTimeout(targetSubId: String, timeoutMs: Long = 15_000): Boolean {
         return withTimeoutOrNull(timeoutMs) {
-            relayPool.eoseSignals.first { it == targetSubId }
+            relayPool.eoseSignals.first { it == targetSubId || it.startsWith("$targetSubId:c") }
             true
         } ?: false
     }
 
     /**
      * Await count-based EOSE: wait until [expectedCount] EOSE signals arrive for [targetSubId],
-     * or until [timeoutMs] elapses.
+     * or until [timeoutMs] elapses. Counts EOSE from both the base subId and any chunk
+     * variants (e.g., "feed:c1", "feed:c2").
      * Returns the number of EOSE signals actually received.
      */
     suspend fun awaitEoseCount(
@@ -38,7 +41,7 @@ class SubscriptionManager(private val relayPool: RelayPool) {
         var eoseCount = 0
         withTimeoutOrNull(timeoutMs) {
             relayPool.eoseSignals
-                .filter { it == targetSubId }
+                .filter { it == targetSubId || it.startsWith("$targetSubId:c") }
                 .take(expectedCount)
                 .collect { eoseCount++ }
         }
@@ -46,7 +49,7 @@ class SubscriptionManager(private val relayPool: RelayPool) {
     }
 
     /**
-     * Close a subscription on all relays (including ephemeral).
+     * Close a subscription on all relays (including ephemeral and chunk variants).
      */
     fun closeSubscription(subscriptionId: String) {
         relayPool.closeOnAllRelays(subscriptionId)


### PR DESCRIPTION
## Summary

Fix "total filter items too large" errors from big relays (damus.io, nos.social) by chunking author filters to max 200 per REQ.

## Changes

### OutboxRouter
- `MAX_AUTHORS_PER_RELAY` (300) → `MAX_AUTHORS_PER_FILTER` (200)
- New `sendChunkedToAll()` splits large author lists into ≤200 per REQ
- Chunk subId convention: `{base}`, `{base}:c1`, `{base}:c2`
- Applied to all broadcast paths: `subscribeByAuthors` fallback, `requestProfiles` fallback, `requestMissingRelayLists`
- Per-relay outbox sends already capped at 200 by `groupAuthorsByWriteRelay`

### RelayPool
- `closeOnAllRelays()` scans `activeSubscriptions` for chunk variants and closes them all

### SubscriptionManager
- EOSE matching includes chunk subIds so `awaitEoseCount`/`awaitEoseWithTimeout` work correctly with chunked subscriptions

## Testing
- Follow 500+ accounts → verify no "filter items too large" errors in relay console
- Check relay console for chunked subscriptions (e.g., feed, feed:c1, feed:c2)
- Verify all chunks close when switching feeds or refreshing
- Verify feed loads normally on cold and warm start
