### PR TITLE
fix: repost notifications and subscription lifecycle on reconnect

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
@@ -49,4 +49,12 @@ sealed class NotificationGroup {
         val eventId: String,
         override val latestTimestamp: Long
     ) : NotificationGroup()
+
+    data class RepostNotification(
+        override val groupId: String,
+        val senderPubkey: String,
+        val repostEventId: String,
+        val repostedEventId: String,
+        override val latestTimestamp: Long
+    ) : NotificationGroup()
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -323,6 +323,13 @@ private fun NotificationItem(
             onProfileClick = onProfileClick,
             postCardParams = postCardParams
         )
+        is NotificationGroup.RepostNotification -> RepostNotificationRow(
+            item = group,
+            resolveProfile = { viewModel.getProfileData(it) },
+            isFollowing = viewModel.isFollowing(group.senderPubkey),
+            onProfileClick = onProfileClick,
+            postCardParams = postCardParams
+        )
     }
 }
 
@@ -665,6 +672,62 @@ private fun MentionNotificationRow(
         // Mention event as full PostCard
         ReferencedNotePostCard(
             eventId = item.eventId,
+            params = postCardParams
+        )
+    }
+}
+
+// ── Repost Notification ──────────────────────────────────────────────────
+
+@Composable
+private fun RepostNotificationRow(
+    item: NotificationGroup.RepostNotification,
+    resolveProfile: (String) -> ProfileData?,
+    isFollowing: Boolean,
+    onProfileClick: (String) -> Unit,
+    postCardParams: NotifPostCardParams
+) {
+    val profile = resolveProfile(item.senderPubkey)
+    val displayName = profile?.displayString
+        ?: item.senderPubkey.take(8) + "..." + item.senderPubkey.takeLast(4)
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            ProfilePicture(
+                url = profile?.picture,
+                size = 34,
+                showFollowBadge = isFollowing,
+                modifier = Modifier.clickable { onProfileClick(item.senderPubkey) }
+            )
+            Spacer(Modifier.width(10.dp))
+            Text(
+                text = displayName,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "reposted",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = formatNotifTimestamp(item.latestTimestamp),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        ReferencedNotePostCard(
+            eventId = item.repostedEventId,
             params = postCardParams
         )
     }


### PR DESCRIPTION
## Summary

Fix missing repost notifications and subscription drops on reconnect/resume.

## Changes

### 1. Repost notifications (kind 6)
- Notification filter now includes kind 6 (was only 1, 7, 9735)
- New `RepostNotification` type in `NotificationGroup` sealed class
- `NotificationRepository.addEvent()` handles kind 6 → `mergeRepost()`
- `processRelayEvent()` routes kind 6 through `eventRepo.addEvent()`
- `NotificationsScreen` renders repost notifications with "{name} reposted" header + referenced PostCard
- `purgeUser()` and `getAllPostCardEventIds()` updated for new type

### 2. Engagement re-subscribe on soft resume
- `resumeSubscribeFeed()` now calls `subscribeEngagementForFeed()` after EOSE
- Previously, soft reconnect re-subscribed the feed but left engagement subs stale — reactions/zaps/reply counts stopped updating

### 3. Notification engagement restored on feed refresh
- `resubscribeFeed()` clears ALL engagement subs (including notification engagement) but only re-subscribed feed engagement
- Now also calls `subscribeNotifEngagement()` after EOSE so notification reaction/zap data stays live

### 4. DM/notification subs restored on force reconnect
- Extracted `subscribeDmsAndNotifications()` from `subscribeSelfData()`
- `onReconnected(force=true)` now calls it — previously `forceReconnectAll()` tore down all subscriptions but only feed was re-subscribed, leaving DMs and notifications dead

## Testing
- Verify repost notifications appear in notification tab
- Long-press home → return to app → verify engagement data (reactions, zaps, reply counts) still updates
- Pull-to-refresh feed → verify notification engagement still works
- Leave app backgrounded for >30s → return → verify DMs and notifications resume
