### PR TITLE
fix: use multi-filter REQ to avoid subscription explosion

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
@@ -9,27 +9,24 @@ class SubscriptionManager(private val relayPool: RelayPool) {
 
     /**
      * Await a specific EOSE signal by subscription ID. One-shot, no lingering collector.
-     * Also matches chunk variants (e.g., "feed:c1", "feed:c2") for the given base subId.
      */
     suspend fun awaitEose(targetSubId: String) {
-        relayPool.eoseSignals.first { it == targetSubId || it.startsWith("$targetSubId:c") }
+        relayPool.eoseSignals.first { it == targetSubId }
     }
 
     /**
      * Await EOSE with a timeout. Returns true if EOSE was received, false on timeout.
-     * Also matches chunk variants (e.g., "feed:c1", "feed:c2") for the given base subId.
      */
     suspend fun awaitEoseWithTimeout(targetSubId: String, timeoutMs: Long = 15_000): Boolean {
         return withTimeoutOrNull(timeoutMs) {
-            relayPool.eoseSignals.first { it == targetSubId || it.startsWith("$targetSubId:c") }
+            relayPool.eoseSignals.first { it == targetSubId }
             true
         } ?: false
     }
 
     /**
      * Await count-based EOSE: wait until [expectedCount] EOSE signals arrive for [targetSubId],
-     * or until [timeoutMs] elapses. Counts EOSE from both the base subId and any chunk
-     * variants (e.g., "feed:c1", "feed:c2").
+     * or until [timeoutMs] elapses.
      * Returns the number of EOSE signals actually received.
      */
     suspend fun awaitEoseCount(
@@ -41,7 +38,7 @@ class SubscriptionManager(private val relayPool: RelayPool) {
         var eoseCount = 0
         withTimeoutOrNull(timeoutMs) {
             relayPool.eoseSignals
-                .filter { it == targetSubId || it.startsWith("$targetSubId:c") }
+                .filter { it == targetSubId }
                 .take(expectedCount)
                 .collect { eoseCount++ }
         }
@@ -49,7 +46,7 @@ class SubscriptionManager(private val relayPool: RelayPool) {
     }
 
     /**
-     * Close a subscription on all relays (including ephemeral and chunk variants).
+     * Close a subscription on all relays (including ephemeral).
      */
     fun closeSubscription(subscriptionId: String) {
         relayPool.closeOnAllRelays(subscriptionId)


### PR DESCRIPTION
## Summary

Fix "too many concurrent REQs" errors caused by subscription explosion from filter chunking.

## Problem

PR #30 chunked large author lists into separate subscriptions (`feed`, `feed:c1`, `feed:c2`). This multiplied the subscription count per relay — with 500 follows and engagement subs, each relay had 15+ concurrent subscriptions. Relays with limits of 10-20 rejected the excess with "too many concurrent REQs".

## Fix

Pack all author chunks as **multiple filters within a single REQ** instead of multiple subscriptions:

```
Before: ["REQ","feed",{authors:[1..200]}] + ["REQ","feed:c1",{authors:[201..400]}] + ["REQ","feed:c2",{authors:[401..500]}]
After:  ["REQ","feed",{authors:[1..200]},{authors:[201..400]},{authors:[401..500]}]
```

One subscription ID, multiple filters. Each individual filter stays ≤200 authors (avoiding "total filter items too large"), but the relay only tracks one subscription.

## Changes

- **OutboxRouter**: `sendChunkedToAll()` now builds a single multi-filter REQ message
- **RelayPool**: `closeOnAllRelays()` reverted to simple (no chunk subId scanning needed)
- **SubscriptionManager**: EOSE matching reverted to exact subId match

Net result: -13 lines. Simpler code, fewer subscriptions.

## Testing
- Follow 500+ accounts → verify NO "too many concurrent REQs" errors
- Verify NO "total filter items too large" errors (individual filters still ≤200)
- Feed loads normally with all relays connected
