### PR TITLE
fix: disable WebSocket compression to prevent OkHttp deflater crashes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -42,6 +42,17 @@ class Relay(
         fun createClient(): OkHttpClient = OkHttpClient.Builder()
             .pingInterval(30, TimeUnit.SECONDS)
             .readTimeout(0, TimeUnit.MILLISECONDS) // No read timeout for WebSocket
+            // Disable WebSocket permessage-deflate compression.
+            // OkHttp's MessageDeflater is not thread-safe — concurrent send/close/failWebSocket
+            // calls cause FATAL NPE and "Failed requirement" crashes in the deflater.
+            // Stripping the extension header from server responses prevents OkHttp from
+            // activating compression. Negligible bandwidth impact for small Nostr JSON messages.
+            .addNetworkInterceptor { chain ->
+                val response = chain.proceed(chain.request())
+                response.newBuilder()
+                    .removeHeader("Sec-WebSocket-Extensions")
+                    .build()
+            }
             .build()
     }
 


### PR DESCRIPTION
## Summary

Eliminate all OkHttp `MessageDeflater` crashes by disabling WebSocket compression entirely.

## Problem

OkHttp's `MessageDeflater` (permessage-deflate) has multiple threading bugs:

1. **Concurrent `ws.send()`** → `Failed requirement` in `deflate()` (PR #32 fixed with `sendLock`)
2. **Concurrent `failWebSocket`/`close`** → NPE in `Buffer.write()` during `DeflaterSink` cleanup

Case 2 happens in OkHttp's internal cleanup path (`failWebSocket` → `WebSocketWriter.close` → `MessageDeflater.close`) which we **cannot** synchronize — it's on OkHttp's dispatcher thread.

```
FATAL EXCEPTION: OkHttp Dispatcher
java.lang.NullPointerException
    at okio.Buffer.write(Buffer.kt:1509)
    at okio.DeflaterSink.deflate(DeflaterSink.kt:78)
    at okio.DeflaterSink.finishDeflate$okio(DeflaterSink.kt:98)
    at okhttp3.internal.ws.MessageDeflater.close(MessageDeflater.kt:62)
    at okhttp3.internal.ws.RealWebSocket.failWebSocket(RealWebSocket.kt:596)
```

## Fix

Strip `Sec-WebSocket-Extensions` header from server responses via a network interceptor. OkHttp checks this header after the 101 upgrade — if absent, it never activates the `MessageDeflater`.

For Nostr's small JSON messages (~0.5-5KB), compression savings are negligible compared to crash-free operation. The `sendLock` from PR #32 is retained as defense-in-depth.

## Testing
- Verify app no longer crashes with deflater-related exceptions
- Verify relays connect and receive events normally (no compression needed)
- Monitor bandwidth — should be negligible difference