### PR TITLE
Smart relay selection for list feeds

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -167,8 +167,8 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     // -- Manager classes --
     val feedSub: FeedSubscriptionManager = FeedSubscriptionManager(
         relayPool, outboxRouter, subManager, eventRepo, contactRepo, listRepo, notifRepo,
-        extendedNetworkRepo, keyRepo, healthTracker, metadataFetcher,
-        viewModelScope, processingDispatcher, pubkeyHex
+        extendedNetworkRepo, keyRepo, healthTracker, relayScoreBoard, profileRepo,
+        metadataFetcher, viewModelScope, processingDispatcher, pubkeyHex
     )
 
     val eventRouter: EventRouter = EventRouter(
@@ -314,7 +314,6 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
 
     fun setSelectedList(followSet: com.wisp.app.nostr.FollowSet) {
         listRepo.selectList(followSet)
-        outboxRouter.requestMissingRelayLists(followSet.members.toList())
     }
 
     override fun onCleared() {


### PR DESCRIPTION
## Summary
- Pre-fetch kind 10002 relay lists and profiles for list members before subscribing to their notes, so `subscribeByAuthors` can route to their actual write relays instead of falling back to pinned relays only
- Wait for multiple EOSEs on prefetch (not single) with dedicated sub IDs to avoid race conditions with startup and fast empty relays
- Widen list feed time window from 24h to 7 days for better coverage of infrequent posters
- Add top-5 scored relays as safety net for engagement queries (reactions, zaps, replies)

## Test plan
- [ ] Create a list with 5-10 npubs NOT in the follow list
- [ ] Select the list as feed — verify notes appear from all/most authors
- [ ] Check engagement stats (reactions, reposts, zaps) load for the notes
- [ ] Switch away from list feed and back — verify consistent results
- [ ] Verify follows feed is unaffected (still 24h window)
- [ ] Check logcat `[FeedSub]` logs for prefetch → feed subscribe flow