### PR TITLE
feat: NIP-55 intent-based signing fallback

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/SignerIntentBridge.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/SignerIntentBridge.kt
@@ -1,0 +1,53 @@
+package com.wisp.app.nostr
+
+import android.content.Intent
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+sealed class SignResult {
+    data class Success(val result: String, val event: String? = null) : SignResult()
+    data object Rejected : SignResult()
+    data object Cancelled : SignResult()
+}
+
+data class SignRequest(
+    val intent: Intent,
+    val deferred: CompletableDeferred<SignResult>
+)
+
+/**
+ * Bridges the domain-layer RemoteSigner (which can't launch activities) with the
+ * Compose UI layer (which owns the ActivityResultLauncher). Concurrent signing
+ * requests are serialized by a mutex so only one Amber prompt is shown at a time.
+ */
+object SignerIntentBridge {
+    private val _pendingRequest = MutableStateFlow<SignRequest?>(null)
+    val pendingRequest: StateFlow<SignRequest?> = _pendingRequest
+
+    private val mutex = Mutex()
+
+    /**
+     * Posts an intent-based signing request and suspends until the UI delivers a result.
+     * Only one request is active at a time (mutex-serialized).
+     */
+    suspend fun requestSign(intent: Intent): SignResult = mutex.withLock {
+        val deferred = CompletableDeferred<SignResult>()
+        val request = SignRequest(intent, deferred)
+        _pendingRequest.value = request
+        try {
+            deferred.await()
+        } finally {
+            _pendingRequest.value = null
+        }
+    }
+
+    /**
+     * Called from the UI layer when the ActivityResultLauncher receives a result.
+     */
+    fun deliverResult(result: SignResult) {
+        _pendingRequest.value?.deferred?.complete(result)
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
@@ -1,5 +1,6 @@
 package com.wisp.app.ui.screen
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -56,6 +57,7 @@ fun DmConversationScreen(
     val messages by viewModel.messages.collectAsState()
     val messageText by viewModel.messageText.collectAsState()
     val sending by viewModel.sending.collectAsState()
+    val sendError by viewModel.sendError.collectAsState()
     val listState = rememberLazyListState()
 
     // Auto-scroll to bottom when new messages arrive
@@ -110,6 +112,23 @@ fun DmConversationScreen(
                         relayIcons = icons
                     )
                 }
+            }
+
+            // Error banner for signing failures
+            AnimatedVisibility(visible = sendError != null) {
+                Text(
+                    text = sendError ?: "",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 4.dp)
+                )
+            }
+
+            // Clear error when user starts typing again
+            LaunchedEffect(messageText) {
+                if (messageText.isNotBlank()) viewModel.clearSendError()
             }
 
             // Message input


### PR DESCRIPTION
## Summary
- Adds intent-based signing fallback for NIP-55 remote signers (Amber) when ContentResolver permissions aren't granted or signer is in "always ask" mode
- `RemoteSigner` now tries silent ContentResolver first, then falls back to launching the signer's approval UI via intents
- `SignerIntentBridge` singleton bridges the domain layer (RemoteSigner) and UI layer (ActivityResultLauncher) using `CompletableDeferred` with mutex serialization
- DM conversation screen now surfaces signing cancellation errors to the user

## Test plan
- [ ] Login with Amber with full permissions granted — signing should remain silent (ContentResolver path)
- [ ] Login with Amber in "always ask" mode — each sign/encrypt/decrypt should launch Amber's approval UI
- [ ] Cancel an Amber prompt (press back) — operation should fail gracefully with error message
- [ ] Send a DM with Amber in "always ask" mode — gift wrap creation triggers multiple signer calls, each prompts if needed
- [ ] Verify NIP-42 AUTH relay challenges prompt via Amber when needed