### PR TITLE
feat: NIP-51 encrypted private lists

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -645,7 +645,7 @@ fun WispNavHost() {
                 ownLists = feedViewModel.listRepo.ownLists.collectAsState().value,
                 onAddToList = { dTag, pk -> feedViewModel.addToList(dTag, pk) },
                 onRemoveFromList = { dTag, pk -> feedViewModel.removeFromList(dTag, pk) },
-                onCreateList = { name -> feedViewModel.createList(name) },
+                onCreateList = { name, isPrivate -> feedViewModel.createList(name, isPrivate) },
                 profilePubkey = pubkey,
                 relayInfoRepo = feedViewModel.relayInfoRepo,
                 nip05Repo = feedViewModel.nip05Repo,
@@ -1054,8 +1054,8 @@ fun WispNavHost() {
                 onBookmarkSetDetail = { set ->
                     navController.navigate("bookmark_set/${set.pubkey}/${set.dTag}")
                 },
-                onCreateList = { name -> feedViewModel.createList(name) },
-                onCreateBookmarkSet = { name -> feedViewModel.createBookmarkSet(name) },
+                onCreateList = { name, isPrivate -> feedViewModel.createList(name, isPrivate) },
+                onCreateBookmarkSet = { name, isPrivate -> feedViewModel.createBookmarkSet(name, isPrivate) },
                 onDeleteList = { dTag -> feedViewModel.deleteList(dTag) },
                 onDeleteBookmarkSet = { dTag -> feedViewModel.deleteBookmarkSet(dTag) }
             )

--- a/app/src/main/kotlin/com/wisp/app/repo/BookmarkSetRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/BookmarkSetRepository.kt
@@ -35,8 +35,8 @@ class BookmarkSetRepository(private val context: Context, pubkeyHex: String? = n
         refreshOwnSets()
     }
 
-    fun updateFromEvent(event: NostrEvent) {
-        val set = Nip51.parseBookmarkSet(event) ?: return
+    fun updateFromEvent(event: NostrEvent, decryptedContent: String? = null) {
+        val set = Nip51.parseBookmarkSet(event, decryptedContent) ?: return
         val key = "${event.pubkey}:${set.dTag}"
         val existing = bookmarkSets[key]
         if (existing != null && existing.createdAt >= set.createdAt) return
@@ -85,7 +85,7 @@ class BookmarkSetRepository(private val context: Context, pubkeyHex: String? = n
             SerializableBookmarkSet(
                 it.pubkey, it.dTag, it.name,
                 it.eventIds.toList(), it.coordinates.toList(), it.hashtags.toList(),
-                it.createdAt
+                it.createdAt, it.isPrivate
             )
         }
         prefs.edit().putString("bookmark_sets", json.encodeToString(serializable)).apply()
@@ -99,7 +99,7 @@ class BookmarkSetRepository(private val context: Context, pubkeyHex: String? = n
                 val bs = BookmarkSet(
                     s.pubkey, s.dTag, s.name,
                     s.eventIds.toSet(), s.coordinates.toSet(), s.hashtags.toSet(),
-                    s.createdAt
+                    s.createdAt, s.isPrivate
                 )
                 bookmarkSets["${s.pubkey}:${s.dTag}"] = bs
             }
@@ -114,7 +114,8 @@ class BookmarkSetRepository(private val context: Context, pubkeyHex: String? = n
         val eventIds: List<String>,
         val coordinates: List<String>,
         val hashtags: List<String>,
-        val createdAt: Long
+        val createdAt: Long,
+        val isPrivate: Boolean = false
     )
 
     companion object {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Refresh
@@ -117,7 +118,7 @@ fun UserProfileScreen(
     ownLists: List<FollowSet> = emptyList(),
     onAddToList: ((String, String) -> Unit)? = null,
     onRemoveFromList: ((String, String) -> Unit)? = null,
-    onCreateList: ((String) -> Unit)? = null,
+    onCreateList: ((String, Boolean) -> Unit)? = null,
     profilePubkey: String = "",
     relayInfoRepo: RelayInfoRepository? = null,
     nip05Repo: Nip05Repository? = null,
@@ -945,10 +946,11 @@ private fun AddToListDialog(
     ownLists: List<FollowSet>,
     onAddToList: (String) -> Unit,
     onRemoveFromList: (String) -> Unit,
-    onCreateList: ((String) -> Unit)?,
+    onCreateList: ((String, Boolean) -> Unit)?,
     onDismiss: () -> Unit
 ) {
     var newListName by remember { mutableStateOf("") }
+    var newListPrivate by remember { mutableStateOf(false) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -987,6 +989,15 @@ private fun AddToListDialog(
                                 style = MaterialTheme.typography.bodyLarge,
                                 modifier = Modifier.weight(1f)
                             )
+                            if (list.isPrivate) {
+                                androidx.compose.material3.Icon(
+                                    Icons.Outlined.Lock,
+                                    contentDescription = "Private",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(14.dp)
+                                )
+                                Spacer(Modifier.width(4.dp))
+                            }
                             Text(
                                 "${list.members.size}",
                                 style = MaterialTheme.typography.bodySmall,
@@ -1011,14 +1022,38 @@ private fun AddToListDialog(
                     TextButton(
                         onClick = {
                             if (newListName.isNotBlank()) {
-                                onCreateList?.invoke(newListName.trim())
+                                onCreateList?.invoke(newListName.trim(), newListPrivate)
                                 newListName = ""
+                                newListPrivate = false
                             }
                         },
                         enabled = newListName.isNotBlank()
                     ) {
                         Text("Create")
                     }
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(top = 4.dp)
+                ) {
+                    androidx.compose.material3.Icon(
+                        Icons.Outlined.Lock,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        "Private",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    androidx.compose.material3.Switch(
+                        checked = newListPrivate,
+                        onCheckedChange = { newListPrivate = it },
+                        modifier = Modifier.height(24.dp)
+                    )
                 }
             }
         },

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -199,8 +199,22 @@ class EventRouter(
                 val myPubkey = getUserPubkey()
                 if (myPubkey != null && event.pubkey == myPubkey) blossomRepo.updateFromEvent(event)
             }
-            if (event.kind == Nip51.KIND_FOLLOW_SET) listRepo.updateFromEvent(event)
-            if (event.kind == Nip51.KIND_BOOKMARK_SET) bookmarkSetRepo.updateFromEvent(event)
+            if (event.kind == Nip51.KIND_FOLLOW_SET) {
+                val myPubkey = getUserPubkey()
+                val s = getSigner()
+                val decrypted = if (myPubkey != null && s != null && event.pubkey == myPubkey && event.content.isNotBlank()) {
+                    try { s.nip44Decrypt(event.content, myPubkey) } catch (_: Exception) { null }
+                } else null
+                listRepo.updateFromEvent(event, decrypted)
+            }
+            if (event.kind == Nip51.KIND_BOOKMARK_SET) {
+                val myPubkey = getUserPubkey()
+                val s = getSigner()
+                val decrypted = if (myPubkey != null && s != null && event.pubkey == myPubkey && event.content.isNotBlank()) {
+                    try { s.nip44Decrypt(event.content, myPubkey) } catch (_: Exception) { null }
+                } else null
+                bookmarkSetRepo.updateFromEvent(event, decrypted)
+            }
             if (event.kind == Nip30.KIND_USER_EMOJI_LIST) {
                 val myPubkey = getUserPubkey()
                 if (myPubkey != null && event.pubkey == myPubkey) customEmojiRepo.updateFromEvent(event)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -295,12 +295,12 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun followAll(pubkeys: Set<String>) = socialActions.followAll(pubkeys)
 
     // -- List CRUD delegates --
-    fun createList(name: String) = listCrud.createList(name)
+    fun createList(name: String, isPrivate: Boolean = false) = listCrud.createList(name, isPrivate)
     fun addToList(dTag: String, pubkey: String) = listCrud.addToList(dTag, pubkey)
     fun removeFromList(dTag: String, pubkey: String) = listCrud.removeFromList(dTag, pubkey)
     fun deleteList(dTag: String) = listCrud.deleteList(dTag)
     fun fetchUserLists(pubkey: String) = listCrud.fetchUserLists(pubkey)
-    fun createBookmarkSet(name: String) = listCrud.createBookmarkSet(name)
+    fun createBookmarkSet(name: String, isPrivate: Boolean = false) = listCrud.createBookmarkSet(name, isPrivate)
     fun addNoteToBookmarkSet(dTag: String, eventId: String) = listCrud.addNoteToBookmarkSet(dTag, eventId)
     fun removeNoteFromBookmarkSet(dTag: String, eventId: String) = listCrud.removeNoteFromBookmarkSet(dTag, eventId)
     fun deleteBookmarkSet(dTag: String) = listCrud.deleteBookmarkSet(dTag)


### PR DESCRIPTION
## Summary
- Add private list support for follow sets and bookmark sets using NIP-44 encrypted content
- Private list items are stored exclusively in the encrypted `content` field, never in public tags
- Privacy is set at creation time via a toggle in the create dialog; lock icon indicates private lists
- Own encrypted list events are decrypted on receipt in EventRouter, persisted with `isPrivate` flag

## Test plan
- [ ] Create a private people list — verify the event sent has only `["d", "tag"]` in tags with encrypted content
- [ ] Add/remove members to a private list — verify no p-tags leak into public tags
- [ ] Restart app — verify private lists load correctly from SharedPreferences and relay re-fetch
- [ ] Verify lock icon appears on private lists in Lists Hub and Add to List dialogs
- [ ] Create a public list — verify existing behavior unchanged (items in tags, empty content)
- [ ] Use a private list as feed — verify feed shows posts from decrypted members
- [ ] Add to private list from a user's profile — verify event remains encrypted