### PR TITLE
feat: inline links for profile bio and bare domain detection

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -698,6 +698,7 @@ private fun ProfileHeader(
                 content = about,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
+                plainLinks = true,
                 eventRepo = eventRepo,
                 onProfileClick = onNavigateToProfile
             )


### PR DESCRIPTION
## Summary
- Bare domains (e.g. `domain.com`, `example.pro/about`) are now detected as clickable links using a TLD allowlist, preventing false positives like `domain.8839734`
- New `plainLinks` parameter on `RichContent` renders links as inline blue clickable text instead of OG preview cards
- Profile bios use `plainLinks = true` so URLs appear as lightweight inline links rather than heavy link preview cards

## Test plan
- [ ] Profile bio with `https://example.com` renders as inline blue clickable text, not a preview card
- [ ] Note with `domain.com` renders as a clickable link (opens `https://domain.com`)
- [ ] Note with `domain.8839734` renders as plain text (not detected as a link)
- [ ] Bare domain with path `example.com/about` is detected and clickable
- [ ] Notes still show link preview cards for URLs (default behavior unchanged)
- [ ] Existing hashtag, profile mention, and nostr: URI detection still works