### PR TITLE
Fix own notes not appearing in follows feed

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -305,6 +305,10 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                 markVersionDirty()
             }
         }
+        if (event.kind == 1) {
+            val isReply = event.tags.any { it.size >= 2 && it[0] == "e" }
+            if (!isReply) binaryInsert(event)
+        }
         _quotedEventVersion.value++
     }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -93,7 +93,10 @@ class FeedSubscriptionManager(
 
     fun applyAuthorFilterForFeedType(type: FeedType) {
         eventRepo.setAuthorFilter(when (type) {
-            FeedType.FOLLOWS -> contactRepo.getFollowList().map { it.pubkey }.toSet()
+            FeedType.FOLLOWS -> {
+                val follows = contactRepo.getFollowList().map { it.pubkey }.toSet()
+                if (pubkeyHex != null) follows + pubkeyHex else follows
+            }
             FeedType.LIST -> listRepo.selectedList.value?.members
             else -> null  // EXTENDED_FOLLOWS and RELAY show everything
         })


### PR DESCRIPTION
## Summary
- Insert kind-1 root notes into the feed list in `cacheEvent()` so published notes appear immediately instead of being silently dropped when the relay echo arrives
- Include the user's own pubkey in the follows author filter so their notes aren't filtered out

## Test plan
- [ ] Publish a note and verify it appears in the follows feed without refreshing
- [ ] Verify replies are still excluded from the feed (only root notes shown)
- [ ] Switch between feed types (follows/extended/relay) and confirm own notes remain visible in follows