### PR TITLE
fix: unified signer management for local and remote signing modes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Keys
-import com.wisp.app.nostr.LocalSigner
 import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.Nip18
 import com.wisp.app.nostr.Nip19
@@ -244,7 +243,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             return
         }
 
-        val s = signer ?: keyRepo.getKeypair()?.let { LocalSigner(it.privkey, it.pubkey) }
+        val s = signer
         if (s == null) {
             _error.value = "Not logged in"
             return

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.wisp.app.nostr.LocalSigner
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.NostrSigner
 import com.wisp.app.relay.Relay
@@ -82,7 +81,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val keyRepo = KeyRepository(app)
     private val pubkeyHex: String? = keyRepo.getPubkeyHex()
 
-    var signer: NostrSigner? = keyRepo.getKeypair()?.let { LocalSigner(it.privkey, it.pubkey) }
+    var signer: NostrSigner? = null
         private set
 
     fun setSigner(s: NostrSigner) {


### PR DESCRIPTION
Navigation.kt now creates an activeSigner for both LOCAL (nsec) and REMOTE (NIP-55) modes via a single remember(signingMode) block, replacing the remote-only remoteSigner. This fixes reactions, follows, lists, and other social actions silently failing in local nsec mode because FeedViewModel.signer was null.