### PR TITLE
fix: fetch and display repost counts on profile screen

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -382,6 +382,7 @@ class OutboxRouter(
             val uniqueIds = eventIds.distinct()
             val filters = listOf(
                 Filter(kinds = listOf(7), eTags = uniqueIds),
+                Filter(kinds = listOf(6), eTags = uniqueIds),
                 Filter(kinds = listOf(9735), eTags = uniqueIds),
                 Filter(kinds = listOf(1), eTags = uniqueIds)
             )
@@ -393,6 +394,7 @@ class OutboxRouter(
             val uniqueIds = fallbackEventIds.distinct()
             val filters = listOf(
                 Filter(kinds = listOf(7), eTags = uniqueIds),
+                Filter(kinds = listOf(6), eTags = uniqueIds),
                 Filter(kinds = listOf(9735), eTags = uniqueIds),
                 Filter(kinds = listOf(1), eTags = uniqueIds)
             )
@@ -406,6 +408,7 @@ class OutboxRouter(
             if (allEventIds.isNotEmpty()) {
                 val filters = listOf(
                     Filter(kinds = listOf(7), eTags = allEventIds),
+                    Filter(kinds = listOf(6), eTags = allEventIds),
                     Filter(kinds = listOf(9735), eTags = allEventIds),
                     Filter(kinds = listOf(1), eTags = allEventIds)
                 )

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -144,6 +144,7 @@ fun UserProfileScreen(
     val nip05Version by nip05Repo?.version?.collectAsState() ?: remember { mutableIntStateOf(0) }
     val reactionVersion by eventRepo?.reactionVersion?.collectAsState() ?: remember { mutableIntStateOf(0) }
     val replyCountVersion by eventRepo?.replyCountVersion?.collectAsState() ?: remember { mutableIntStateOf(0) }
+    val repostVersion by eventRepo?.repostVersion?.collectAsState() ?: remember { mutableIntStateOf(0) }
     val zapVersion by eventRepo?.zapVersion?.collectAsState() ?: remember { mutableIntStateOf(0) }
     val relaySourceVersion by eventRepo?.relaySourceVersion?.collectAsState() ?: remember { mutableIntStateOf(0) }
 
@@ -376,6 +377,7 @@ fun UserProfileScreen(
                         items(items = rootNotes, key = { it.id }) { event ->
                             val likeCount = reactionVersion.let { eventRepo?.getReactionCount(event.id) ?: 0 }
                             val replyCount = replyCountVersion.let { eventRepo?.getReplyCount(event.id) ?: 0 }
+                            val repostCount = repostVersion.let { eventRepo?.getRepostCount(event.id) ?: 0 }
                             val zapSats = zapVersion.let { eventRepo?.getZapSats(event.id) ?: 0L }
                             val userEmojis = reactionVersion.let { userPubkey?.let { eventRepo?.getUserReactionEmojis(event.id, it) } ?: emptySet() }
                             val reactionDetails = remember(reactionVersion, event.id) {
@@ -411,6 +413,7 @@ fun UserProfileScreen(
                                 hasUserZapped = hasUserZapped,
                                 likeCount = likeCount,
                                 replyCount = replyCount,
+                                repostCount = repostCount,
                                 zapSats = zapSats,
                                 isZapAnimating = event.id in zapAnimatingIds,
                                 isZapInProgress = event.id in zapInProgressIds,
@@ -447,6 +450,7 @@ fun UserProfileScreen(
                         items(items = replies, key = { it.id }) { event ->
                             val likeCount = reactionVersion.let { eventRepo?.getReactionCount(event.id) ?: 0 }
                             val replyCount = replyCountVersion.let { eventRepo?.getReplyCount(event.id) ?: 0 }
+                            val repostCount2 = repostVersion.let { eventRepo?.getRepostCount(event.id) ?: 0 }
                             val zapSats = zapVersion.let { eventRepo?.getZapSats(event.id) ?: 0L }
                             val userEmojis = reactionVersion.let { userPubkey?.let { eventRepo?.getUserReactionEmojis(event.id, it) } ?: emptySet() }
                             val reactionDetails = remember(reactionVersion, event.id) {
@@ -477,6 +481,7 @@ fun UserProfileScreen(
                                 hasUserZapped = hasUserZapped2,
                                 likeCount = likeCount,
                                 replyCount = replyCount,
+                                repostCount = repostCount2,
                                 zapSats = zapSats,
                                 isZapAnimating = event.id in zapAnimatingIds,
                                 isZapInProgress = event.id in zapInProgressIds,

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
@@ -316,6 +316,7 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
                 activeEngagementSubIds.add(subId)
                 val filters = listOf(
                     Filter(kinds = listOf(7), eTags = batch),
+                    Filter(kinds = listOf(6), eTags = batch),
                     Filter(kinds = listOf(9735), eTags = batch),
                     Filter(kinds = listOf(1), eTags = batch)
                 )
@@ -328,6 +329,7 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
             activeEngagementSubIds.add(subId)
             val filters = listOf(
                 Filter(kinds = listOf(7), eTags = batch),
+                Filter(kinds = listOf(6), eTags = batch),
                 Filter(kinds = listOf(9735), eTags = batch),
                 Filter(kinds = listOf(1), eTags = batch)
             )


### PR DESCRIPTION
## Summary
- Add kind 6 (repost) to engagement subscription filters in `UserProfileViewModel` and `OutboxRouter.subscribeEngagementByAuthors()` so repost events are actually fetched from relays
- Collect `repostVersion` StateFlow in `UserProfileScreen` to trigger recomposition when repost data arrives
- Calculate and pass `repostCount` to `PostCard` in both the Notes and Replies tabs

## Test plan
- [ ] Open a user profile with notes that have reposts
- [ ] Verify repost counts display correctly on the Notes tab
- [ ] Verify repost counts display correctly on the Replies tab
- [ ] Verify other engagement counts (likes, replies, zaps) still work