### PR TITLE
fix: filter repost notifications to only the user's own posts

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -45,7 +45,7 @@ class NotificationRepository(context: Context, pubkeyHex: String?) {
         if (event.pubkey == myPubkey) return
         if (seenEvents.get(event.id) != null) return
         val hasPTag = event.tags.any { it.size >= 2 && it[0] == "p" && it[1] == myPubkey }
-        // Kind 6 reposts may omit the p-tag; accept if we recognize the reposted event as ours
+        // Kind 6 reposts may omit the p-tag; callers must pre-filter kind 6 ownership
         if (!hasPTag && event.kind != 6) return
 
         seenEvents.put(event.id, true)


### PR DESCRIPTION
## Summary
- Engagement subscriptions added kind 6 filters (from #51), but EventRouter routed all repost events to NotificationRepository without verifying the reposted event belongs to the current user — causing everyone's reposts to appear as notifications
- Add ownership check in EventRouter: only route kind 6 events to notifications when the reposted event is authored by the current user
- Add missing `6 -> eventRepo.addEvent(event)` in the engagement handler so repost counts are actually tracked from engagement subscriptions

## Test plan
- [ ] Open the app and browse the feed
- [ ] Verify notifications only show reposts of your own posts, not others'
- [ ] Visit a profile and confirm repost counts still display correctly
- [ ] Repost someone's post and verify it doesn't generate a self-notification