### PR TITLE
feat: render nostr:naddr1 references in text notes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -326,6 +326,17 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         metadataFetcher?.requestQuotedEvent(eventId, relayHints)
     }
 
+    fun requestAddressableEvent(kind: Int, author: String, dTag: String, relayHints: List<String> = emptyList()) {
+        metadataFetcher?.requestAddressableEvent(kind, author, dTag, relayHints)
+    }
+
+    fun findAddressableEvent(kind: Int, author: String, dTag: String): NostrEvent? {
+        return eventCache.snapshot().values.firstOrNull { event ->
+            event.kind == kind && event.pubkey == author &&
+                event.tags.any { it.size >= 2 && it[0] == "d" && it[1] == dTag }
+        }
+    }
+
     fun getEvent(id: String): NostrEvent? = eventCache.get(id)
 
     fun getProfileData(pubkey: String): ProfileData? = profileRepo?.get(pubkey)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -376,6 +376,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
                 when (val data = Nip19.decodeNostrUri("nostr:$bech32")) {
                     is com.wisp.app.nostr.NostrUriData.ProfileRef -> pubkeys.add(data.pubkey)
                     is com.wisp.app.nostr.NostrUriData.NoteRef -> eventIds.add(data.eventId)
+                    is com.wisp.app.nostr.NostrUriData.AddressRef -> {}
                     null -> {}
                 }
             } catch (_: Exception) {}


### PR DESCRIPTION
## Summary
- Decode `naddr1` TLV entities (NIP-19) with d-tag, relay hints, author pubkey, and kind
- Kind 0/1 naddr references render as quoted notes via addressable event fetching
- Kind 30311 (NIP-53 live streams) render as inline cards with ExoPlayer, LIVE/ENDED badge, title, summary, and host profile
- All other kinds show an "Unsupported event kind" badge

## Test plan
- [ ] Verify `nostr:naddr1` references to live streams render with inline video player
- [ ] Verify ended streams show cover image and ENDED badge
- [ ] Verify unsupported kind naddr references show fallback badge
- [ ] Verify existing `nostr:note1`, `nostr:nevent1`, `nostr:npub1`, `nostr:nprofile1` rendering is unaffected