### PR TITLE
Add dark/light mode toggle

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/wisp/app/MainActivity.kt
@@ -1,10 +1,18 @@
 package com.wisp.app
 
+import android.content.Context
 import android.os.Bundle
+import androidx.activity.SystemBarStyle
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.FragmentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.remember
 import com.wisp.app.ui.theme.WispTheme
 
 class MainActivity : FragmentActivity() {
@@ -13,8 +21,32 @@ class MainActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            WispTheme {
-                WispNavHost()
+            val prefs = remember { getSharedPreferences("wisp_settings", Context.MODE_PRIVATE) }
+            var isDarkTheme by rememberSaveable { mutableStateOf(prefs.getBoolean("dark_theme", true)) }
+
+            LaunchedEffect(isDarkTheme) {
+                enableEdgeToEdge(
+                    statusBarStyle = if (isDarkTheme) {
+                        SystemBarStyle.dark(android.graphics.Color.TRANSPARENT)
+                    } else {
+                        SystemBarStyle.light(android.graphics.Color.TRANSPARENT, android.graphics.Color.TRANSPARENT)
+                    },
+                    navigationBarStyle = if (isDarkTheme) {
+                        SystemBarStyle.dark(android.graphics.Color.TRANSPARENT)
+                    } else {
+                        SystemBarStyle.light(android.graphics.Color.TRANSPARENT, android.graphics.Color.TRANSPARENT)
+                    }
+                )
+            }
+
+            WispTheme(isDarkTheme = isDarkTheme) {
+                WispNavHost(
+                    isDarkTheme = isDarkTheme,
+                    onToggleTheme = {
+                        isDarkTheme = !isDarkTheme
+                        prefs.edit().putBoolean("dark_theme", isDarkTheme).apply()
+                    }
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -117,7 +117,10 @@ object Routes {
 }
 
 @Composable
-fun WispNavHost() {
+fun WispNavHost(
+    isDarkTheme: Boolean = true,
+    onToggleTheme: () -> Unit = {}
+) {
     val navController = rememberNavController()
     val authViewModel: AuthViewModel = viewModel()
     val feedViewModel: FeedViewModel = viewModel()
@@ -388,6 +391,8 @@ fun WispNavHost() {
         composable(Routes.FEED) {
             FeedScreen(
                 viewModel = feedViewModel,
+                isDarkTheme = isDarkTheme,
+                onToggleTheme = onToggleTheme,
                 scrollToTopTrigger = scrollToTopTrigger,
                 onCompose = {
                     replyTarget = null

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -22,6 +22,8 @@ import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.FormatListBulleted
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.DarkMode
+import androidx.compose.material.icons.outlined.LightMode
 import androidx.compose.material.icons.outlined.QrCode2
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.KeyboardArrowRight
@@ -50,6 +52,8 @@ import com.wisp.app.nostr.ProfileData
 fun WispDrawerContent(
     profile: ProfileData?,
     pubkey: String?,
+    isDarkTheme: Boolean = true,
+    onToggleTheme: () -> Unit = {},
     onProfile: () -> Unit,
     onFeed: () -> Unit,
     onSearch: () -> Unit,
@@ -80,6 +84,14 @@ fun WispDrawerContent(
             ) {
                 ProfilePicture(url = profile?.picture, size = 64)
                 Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = onToggleTheme) {
+                    Icon(
+                        if (isDarkTheme) Icons.Outlined.DarkMode else Icons.Outlined.LightMode,
+                        contentDescription = "Toggle theme",
+                        modifier = Modifier.size(24.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
                 IconButton(onClick = { showQrDialog = true }) {
                     Icon(
                         Icons.Outlined.QrCode2,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -78,6 +78,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun FeedScreen(
     viewModel: FeedViewModel,
+    isDarkTheme: Boolean = true,
+    onToggleTheme: () -> Unit = {},
     onCompose: () -> Unit,
     onReply: (NostrEvent) -> Unit,
     onRelays: () -> Unit,
@@ -254,6 +256,8 @@ fun FeedScreen(
             WispDrawerContent(
                 profile = userProfile,
                 pubkey = userPubkey,
+                isDarkTheme = isDarkTheme,
+                onToggleTheme = onToggleTheme,
                 onProfile = {
                     scope.launch { drawerState.close() }
                     onProfileEdit()

--- a/app/src/main/kotlin/com/wisp/app/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/theme/Theme.kt
@@ -2,6 +2,7 @@ package com.wisp.app.ui.theme
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -22,19 +23,32 @@ private val DarkColorScheme = darkColorScheme(
     outline = Color(0xFF343338)
 )
 
+private val LightColorScheme = lightColorScheme(
+    primary = Color(0xFFFF9800),
+    onPrimary = Color.White,
+    secondary = Color(0xFFFFB74D),
+    background = Color(0xFFECECEC),
+    surface = Color(0xFFF5F5F5),
+    surfaceVariant = Color(0xFFE0E0E0),
+    onBackground = Color(0xFF1C1B1F),
+    onSurface = Color(0xFF1C1B1F),
+    onSurfaceVariant = Color(0xFF6B6B6B),
+    outline = Color(0xFFCCCCCC)
+)
+
 private val WispTypography = Typography(
     titleLarge = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold),
     titleMedium = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold),
     bodyLarge = TextStyle(fontSize = 15.sp, lineHeight = 22.sp),
     bodyMedium = TextStyle(fontSize = 14.sp),
     bodySmall = TextStyle(fontSize = 12.sp),
-    labelSmall = TextStyle(fontSize = 11.sp, color = Color(0xFF999999))
+    labelSmall = TextStyle(fontSize = 11.sp)
 )
 
 @Composable
-fun WispTheme(content: @Composable () -> Unit) {
+fun WispTheme(isDarkTheme: Boolean = true, content: @Composable () -> Unit) {
     MaterialTheme(
-        colorScheme = DarkColorScheme,
+        colorScheme = if (isDarkTheme) DarkColorScheme else LightColorScheme,
         typography = WispTypography,
         content = content
     )


### PR DESCRIPTION
## Summary
- Add light color scheme to Theme.kt with soft gray backgrounds
- Add theme toggle icon button in the navigation drawer header (dark mode / light mode icon)
- Persist theme preference in SharedPreferences (`wisp_settings`)
- System status/navigation bars adapt to the selected theme

## Test plan
- [ ] Toggle button appears in drawer next to QR/bitcoin icons
- [ ] Clicking toggles between light and dark mode instantly
- [ ] Preference persists after killing and restarting the app
- [ ] All screens render correctly in both modes
- [ ] Status bar adapts (dark icons on light, light icons on dark)