### PR TITLE
feat: add 24h summary bar and type filter to notifications

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
@@ -1,5 +1,15 @@
 package com.wisp.app.nostr
 
+data class NotificationSummary(
+    val replyCount: Int = 0,
+    val reactionCount: Int = 0,
+    val zapCount: Int = 0,
+    val zapSats: Long = 0,
+    val repostCount: Int = 0,
+    val mentionCount: Int = 0,
+    val quoteCount: Int = 0
+)
+
 data class ZapEntry(
     val pubkey: String,
     val sats: Long,


### PR DESCRIPTION
## Summary
- Add a 24-hour activity summary bar pinned at the top of the notifications list showing reply, reaction, zap (sats), repost, and mention counts with outlined Material icons
- Add a type filter dropdown in the top app bar (All, Replies, Reactions, Zaps, Reposts, Mentions) matching the feed screen's dropdown pattern
- Summary bar always shows all-type totals regardless of active filter

## Test plan
- [ ] Build and install debug APK
- [ ] Navigate to notifications screen, verify 24h summary bar appears below header
- [ ] Verify summary shows correct counts with outlined icons and zero values for inactive types
- [ ] Test each filter option in dropdown — list filters correctly, check mark on selected
- [ ] Verify summary bar stays visible and unchanged when switching filters
- [ ] Confirm Recent/Earlier section splitting still works with filters active