### PR TITLE
fix: suppress notification sounds and zap animations for historical events

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -38,6 +38,8 @@ class NotificationRepository(context: Context, pubkeyHex: String?) {
 
     @Volatile var appIsActive: Boolean = true
 
+    @Volatile var notifInitialized: Boolean = false
+
     @Volatile var isViewing: Boolean = false
 
     private var lastReadTimestamp: Long = prefs.getLong(KEY_LAST_READ, 0L)
@@ -73,10 +75,10 @@ class NotificationRepository(context: Context, pubkeyHex: String?) {
                 } else {
                     _hasUnread.value = true
                 }
-                if (event.kind == 9735 && appIsActive) {
+                if (event.kind == 9735 && appIsActive && notifInitialized) {
                     _zapReceived.tryEmit(Unit)
                 }
-                if (appIsActive && event.kind != 9735) {
+                if (appIsActive && notifInitialized && event.kind != 9735) {
                     _notifReceived.tryEmit(Unit)
                 }
             }
@@ -100,6 +102,7 @@ class NotificationRepository(context: Context, pubkeyHex: String?) {
             _notifications.value = emptyList()
             _summary24h.value = NotificationSummary()
             _hasUnread.value = false
+            notifInitialized = false
         }
         prefs.edit().clear().apply()
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -497,6 +497,7 @@ class StartupCoordinator(
      * when all relay subscriptions have been torn down.
      */
     fun subscribeDmsAndNotifications(myPubkey: String) {
+        notifRepo.notifInitialized = false
         val dmFilter = Filter(kinds = listOf(1059), pTags = listOf(myPubkey))
         val dmReqMsg = ClientMessage.req("dms", dmFilter)
         relayPool.sendToAll(dmReqMsg)
@@ -525,6 +526,7 @@ class StartupCoordinator(
         }
         scope.launch {
             subManager.awaitEoseWithTimeout("notif")
+            notifRepo.notifInitialized = true
             feedSub.subscribeNotifEngagement()
         }
     }


### PR DESCRIPTION
## Summary
- Add `notifInitialized` flag to `NotificationRepository` that gates sound and zap animation emissions
- Reset flag to `false` at the start of `subscribeDmsAndNotifications()` and set `true` after EOSE arrives
- Prevents flood of notification sounds and stuck zap animations on cold start and force reconnect (30s+ background)

## Test plan
- [ ] Force-close app with pending notifications, reopen — zero sounds on startup
- [ ] Wait for feed to load, receive a live reaction/zap — sound plays and animation shows
- [ ] Background app 30+ seconds, reopen — zero sounds during reload, live events trigger normally
- [ ] Switch accounts — flag resets cleanly via `clear()`