### PR TITLE
fix: periodic refresh of DM and notification subscriptions

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -761,6 +761,7 @@ fun WispNavHost(
 
         composable(Routes.DM_LIST) {
             LaunchedEffect(Unit) {
+                feedViewModel.refreshDmsAndNotifications()
                 // Decrypt pending gift wraps when signer is available
                 activeSigner?.let { dmListViewModel.decryptPending(it) }
                 dmListViewModel.markDmsRead()
@@ -1219,6 +1220,7 @@ fun WispNavHost(
                 onDispose { feedViewModel.notifRepo.isViewing = false }
             }
             LaunchedEffect(Unit) {
+                feedViewModel.refreshDmsAndNotifications()
                 notificationsViewModel.markRead()
             }
             var notifZapTarget by remember { mutableStateOf<NostrEvent?>(null) }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -234,6 +234,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun onAppPause() = startup.onAppPause()
     fun onAppResume(pausedMs: Long) = startup.onAppResume(pausedMs)
     fun refreshRelays() = startup.refreshRelays()
+    fun refreshDmsAndNotifications() = startup.refreshDmsAndNotifications()
 
     // -- Feed subscription delegates --
     fun setFeedType(type: FeedType) = feedSub.setFeedType(type)


### PR DESCRIPTION
## Summary
- Add a periodic 3-minute job in `StartupCoordinator` that re-sends DM and notification subscription REQs to all relays, preventing silent subscription drops
- Re-subscribe on entry to the Notifications and DM List screens via `LaunchedEffect`
- Expose `refreshDmsAndNotifications()` through `FeedViewModel` for screen-level access

## Test plan
- [ ] Verify notifications and DMs continue arriving after 5+ minutes of idle use
- [ ] Verify entering the Notifications screen triggers a subscription refresh
- [ ] Verify entering the DM List screen triggers a subscription refresh
- [ ] Verify account switching cancels the refresh job cleanly