### PR TITLE
fix: instant scroll for new notes bubble

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -634,7 +634,7 @@ fun FeedScreen(
                             count = newNoteCount,
                             onClick = {
                                 scope.launch {
-                                    listState.animateScrollToItem(0)
+                                    listState.scrollToItem(0)
                                     viewModel.resetNewNoteCount()
                                 }
                             },


### PR DESCRIPTION
## Summary
- Use `scrollToItem(0)` instead of `animateScrollToItem(0)` for the new notes bubble on feed screens
- Tapping the bubble now jumps instantly to the top with no visible scroll animation, matching the back-to-top behavior in ThreadScreen

## Test plan
- [ ] Open a feed, scroll down, wait for new notes bubble to appear
- [ ] Tap the bubble and verify it jumps to top instantly with no animation
- [ ] Verify the same behavior on relay feeds