### PR TITLE
fix: fetch notification referenced events from own relays

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -326,6 +326,11 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         metadataFetcher?.requestQuotedEvent(eventId, relayHints)
     }
 
+    /** Fetch an event expected to live on our own write/read relays (e.g. our own note). */
+    fun requestOwnEvent(eventId: String) {
+        metadataFetcher?.requestOwnEvent(eventId)
+    }
+
     fun requestAddressableEvent(kind: Int, author: String, dTag: String, relayHints: List<String> = emptyList()) {
         metadataFetcher?.requestAddressableEvent(kind, author, dTag, relayHints)
     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -1084,7 +1084,7 @@ private fun ReferencedNotePostCard(
 
     LaunchedEffect(eventId) {
         if (eventRepo.getEvent(eventId) == null) {
-            eventRepo.requestQuotedEvent(eventId)
+            eventRepo.requestOwnEvent(eventId)
         }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -502,6 +502,24 @@ class FeedSubscriptionManager(
     fun subscribeNotifEngagement() {
         val eventIds = notifRepo.getAllPostCardEventIds()
         if (eventIds.isEmpty()) return
+
+        // Fetch any missing referenced events from our own relays first.
+        // Notifications reference the user's own notes (reactions, zaps, reposts
+        // all point at our events). These live on relays we're already connected
+        // to, so a simple ids filter to our write+read relays is fast & reliable
+        // — no need for the generic on-demand quote path.
+        val missingIds = eventIds.filter { eventRepo.getEvent(it) == null }
+        if (missingIds.isNotEmpty()) {
+            val subId = "notif-self-events"
+            val msg = ClientMessage.req(subId, Filter(ids = missingIds))
+            relayPool.sendToWriteRelays(msg)
+            relayPool.sendToReadRelays(msg)
+            scope.launch {
+                subManager.awaitEoseWithTimeout(subId, timeoutMs = 8_000)
+                subManager.closeSubscription(subId)
+            }
+        }
+
         val eventsByAuthor = mutableMapOf<String, MutableList<String>>()
         for (id in eventIds) {
             val event = eventRepo.getEvent(id)


### PR DESCRIPTION
## Summary
- Notification post cards (reactions, zaps, reposts) reference the user's own notes but were fetching them via the generic on-demand quote path, which sends to top-scored relays that may not have the user's events — causing persistent spinners
- Added batch pre-fetch of missing referenced events from write/read relays during `subscribeNotifEngagement()`
- Added `requestOwnEvent()` method that sends directly to write/read relays instead of the generic quote batch path
- Updated `ReferencedNotePostCard` to use `requestOwnEvent()` for individual fallback fetches

## Test plan
- [ ] Open notifications screen — referenced notes should load reliably without stuck spinners
- [ ] Verify reaction, zap, repost, and reply notification groups all display the referenced note
- [ ] Check that older notes (outside the feed window) still load correctly
- [ ] Confirm no regressions in quoted event loading elsewhere (feed, thread view)