### PR TITLE
fix: notification event fetching and feed engagement undercounting

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -634,7 +634,7 @@ fun FeedScreen(
                             count = newNoteCount,
                             onClick = {
                                 scope.launch {
-                                    listState.animateScrollToItem(0)
+                                    listState.scrollToItem(0)
                                     viewModel.resetNewNoteCount()
                                 }
                             },


### PR DESCRIPTION
## Summary

- **Notification engagement routing fix**: `subscribeNotifEngagement()` now awaits EOSE from the self-events fetch before building the author map. Previously it fired off the fetch and immediately proceeded, causing `getEvent()` to return null and routing engagement queries to fallback relays instead of each author's inbox relays.

- **Feed engagement EOSE await**: `subscribeEngagementForFeed()` now awaits a count-based EOSE threshold (30% of inbox relays, min 3, 4s timeout) instead of being entirely fire-and-forget. This matches the pattern used for feed EOSE and thread engagement.

- **Consolidated engagement filters**: Replaced 4 separate Filter objects per relay (kinds 7, 6, 9735, 1 individually) with a single combined filter (`kinds=[1,6,7,9735], limit=500`), reducing message size and preventing relay-side truncation at low default limits.

- **Relay count return**: `subscribeEngagementByAuthors` now returns the number of unique relays the subscription was sent to, enabling callers to compute meaningful EOSE thresholds.

- **Minor**: Use `scrollToItem` instead of `animateScrollToItem` for the new note banner tap.

## Test plan

- [ ] Open notifications tab — referenced notes should load reliably (not show loading spinners)
- [ ] Check feed — engagement counts should populate within ~4s of feed loading
- [ ] Open a thread from feed — engagement counts should be similar between feed and thread views
- [ ] Check logcat for `[FeedSub] safety net engagement EOSE received` log line