### PR TITLE
feat: add anonymous zap support

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -692,7 +692,7 @@ fun WispNavHost(
                 onNoteClick = { event -> navController.navigate("thread/${event.id}") },
                 onQuotedNoteClick = { eventId -> navController.navigate("thread/$eventId") },
                 onReact = { event, emoji -> feedViewModel.toggleReaction(event, emoji) },
-                onZap = { event, amountMsats, message -> feedViewModel.sendZap(event, amountMsats, message) },
+                onZap = { event, amountMsats, message, isAnonymous -> feedViewModel.sendZap(event, amountMsats, message, isAnonymous) },
                 userPubkey = feedViewModel.getUserPubkey(),
                 isWalletConnected = feedViewModel.nwcRepo.hasConnection(),
                 onWallet = { navController.navigate(Routes.WALLET) },
@@ -849,10 +849,10 @@ fun WispNavHost(
                 ZapDialog(
                     isWalletConnected = isNwcConnected,
                     onDismiss = { threadZapTarget = null },
-                    onZap = { amountMsats, message ->
+                    onZap = { amountMsats, message, isAnonymous ->
                         val event = threadZapTarget ?: return@ZapDialog
                         threadZapTarget = null
-                        feedViewModel.sendZap(event, amountMsats, message)
+                        feedViewModel.sendZap(event, amountMsats, message, isAnonymous)
                     },
                     onGoToWallet = { navController.navigate(Routes.WALLET) }
                 )
@@ -1245,10 +1245,10 @@ fun WispNavHost(
                 ZapDialog(
                     isWalletConnected = isNwcConnected,
                     onDismiss = { notifZapTarget = null },
-                    onZap = { amountMsats, message ->
+                    onZap = { amountMsats, message, isAnonymous ->
                         val event = notifZapTarget ?: return@ZapDialog
                         notifZapTarget = null
-                        feedViewModel.sendZap(event, amountMsats, message)
+                        feedViewModel.sendZap(event, amountMsats, message, isAnonymous)
                     },
                     onGoToWallet = { navController.navigate(Routes.WALLET) }
                 )

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt
@@ -46,6 +46,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -87,7 +89,7 @@ private val BoltGlow = Color(0x40FFD700)
 fun ZapDialog(
     isWalletConnected: Boolean,
     onDismiss: () -> Unit,
-    onZap: (amountMsats: Long, message: String) -> Unit,
+    onZap: (amountMsats: Long, message: String, isAnonymous: Boolean) -> Unit,
     onGoToWallet: () -> Unit
 ) {
     if (!isWalletConnected) {
@@ -116,6 +118,7 @@ fun ZapDialog(
     var isCustom by remember { mutableStateOf(false) }
     var customAmount by remember { mutableStateOf("") }
     var message by remember { mutableStateOf("") }
+    var isAnonymous by remember { mutableStateOf(false) }
     var showSaveDialog by remember { mutableStateOf(false) }
     var editMode by remember { mutableStateOf(false) }
 
@@ -338,7 +341,30 @@ fun ZapDialog(
                         )
                     }
 
-                    Spacer(Modifier.height(24.dp))
+                    Spacer(Modifier.height(16.dp))
+
+                    // Anonymous toggle
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Anonymous",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Switch(
+                            checked = isAnonymous,
+                            onCheckedChange = { isAnonymous = it },
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = LightningOrange,
+                                checkedTrackColor = LightningOrange.copy(alpha = 0.5f)
+                            )
+                        )
+                    }
+
+                    Spacer(Modifier.height(16.dp))
 
                     // Action buttons
                     Row(
@@ -354,7 +380,7 @@ fun ZapDialog(
 
                         Button(
                             onClick = {
-                                onZap(effectiveAmount * 1000, effectiveMessage.ifEmpty { message })
+                                onZap(effectiveAmount * 1000, effectiveMessage.ifEmpty { message }, isAnonymous)
                             },
                             enabled = effectiveAmount > 0,
                             modifier = Modifier.weight(2f),

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -233,10 +233,10 @@ fun FeedScreen(
         ZapDialog(
             isWalletConnected = isWalletConnected,
             onDismiss = { zapTargetEvent = null },
-            onZap = { amountMsats, message ->
+            onZap = { amountMsats, message, isAnonymous ->
                 val event = zapTargetEvent ?: return@ZapDialog
                 zapTargetEvent = null
-                viewModel.sendZap(event, amountMsats, message)
+                viewModel.sendZap(event, amountMsats, message, isAnonymous)
             },
             onGoToWallet = onWallet
         )

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -108,7 +108,7 @@ fun UserProfileScreen(
     onNoteClick: (NostrEvent) -> Unit = {},
     onQuotedNoteClick: ((String) -> Unit)? = null,
     onReact: (NostrEvent, String) -> Unit = { _, _ -> },
-    onZap: (NostrEvent, Long, String) -> Unit = { _, _, _ -> },
+    onZap: (NostrEvent, Long, String, Boolean) -> Unit = { _, _, _, _ -> },
     userPubkey: String? = null,
     isWalletConnected: Boolean = false,
     onWallet: () -> Unit = {},
@@ -170,10 +170,10 @@ fun UserProfileScreen(
         ZapDialog(
             isWalletConnected = isWalletConnected,
             onDismiss = { zapTargetEvent = null },
-            onZap = { amountMsats, message ->
+            onZap = { amountMsats, message, isAnonymous ->
                 val event = zapTargetEvent ?: return@ZapDialog
                 zapTargetEvent = null
-                onZap(event, amountMsats, message)
+                onZap(event, amountMsats, message, isAnonymous)
             },
             onGoToWallet = onWallet
         )

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -290,7 +290,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun sendRepost(event: NostrEvent) = socialActions.sendRepost(event)
     fun sendReaction(event: NostrEvent, content: String = "+") = socialActions.toggleReaction(event, content)
     fun toggleReaction(event: NostrEvent, emoji: String) = socialActions.toggleReaction(event, emoji)
-    fun sendZap(event: NostrEvent, amountMsats: Long, message: String = "") = socialActions.sendZap(event, amountMsats, message)
+    fun sendZap(event: NostrEvent, amountMsats: Long, message: String = "", isAnonymous: Boolean = false) = socialActions.sendZap(event, amountMsats, message, isAnonymous)
     fun togglePin(eventId: String) = socialActions.togglePin(eventId)
     fun deleteEvent(eventId: String, kind: Int) = socialActions.deleteEvent(eventId, kind)
     fun followAll(pubkeys: Set<String>) = socialActions.followAll(pubkeys)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
@@ -222,7 +222,7 @@ class SocialActionManager(
         return subId
     }
 
-    fun sendZap(event: NostrEvent, amountMsats: Long, message: String = "") {
+    fun sendZap(event: NostrEvent, amountMsats: Long, message: String = "", isAnonymous: Boolean = false) {
         val profileData = eventRepo.getProfileData(event.pubkey)
         val lud16 = profileData?.lud16
         if (lud16.isNullOrBlank()) {
@@ -243,12 +243,13 @@ class SocialActionManager(
                 recipientPubkey = event.pubkey,
                 eventId = event.id,
                 amountMsats = amountMsats,
-                message = message
+                message = message,
+                isAnonymous = isAnonymous
             )
             _zapInProgress.value = _zapInProgress.value - event.id
             result.fold(
                 onSuccess = {
-                    val myPubkey = getUserPubkey() ?: ""
+                    val myPubkey = if (isAnonymous) "" else (getUserPubkey() ?: "")
                     eventRepo.addOptimisticZap(event.id, myPubkey, amountMsats / 1000, message)
                     _zapSuccess.tryEmit(event.id)
                 },


### PR DESCRIPTION
## Summary
- Add anonymous toggle to the zap dialog (Switch with lightning orange theming)
- When enabled, zap requests are signed with a random throwaway keypair via `Keys.generate()`, hiding the sender's identity per NIP-57
- Threads the `isAnonymous` flag through `ZapDialog` → screen callers → `FeedViewModel` → `SocialActionManager` → `ZapSender`
- Optimistic zap uses empty pubkey for anonymous zaps so the sender's identity isn't leaked locally

## Test plan
- [ ] Open zap dialog from feed, thread, profile, and notification screens — verify anonymous toggle appears
- [ ] Send a normal zap (toggle off) — confirm receipt shows your pubkey
- [ ] Send an anonymous zap (toggle on) — confirm receipt shows a random pubkey, not yours
- [ ] Verify optimistic zap display doesn't attribute anonymous zaps to your profile