### PR TITLE
feat: add relay sets and favorite relays (NIP-51)

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1033,14 +1033,23 @@ fun WispNavHost(
                     feedViewModel.forceProfileFetch(operatorPubkey)
                 }
             }
+            val favoriteRelays by feedViewModel.relaySetRepo.favoriteRelays.collectAsState()
+            val relaySets by feedViewModel.relaySetRepo.ownRelaySets.collectAsState()
             RelayDetailScreen(
                 relayUrl = relayUrl,
                 relayInfoRepo = feedViewModel.relayInfoRepo,
                 healthTracker = feedViewModel.healthTracker,
                 consoleEntries = consoleLog,
                 operatorProfile = operatorProfile,
+                isFavorite = relayUrl in favoriteRelays,
+                relaySets = relaySets,
                 onBack = { navController.popBackStack() },
-                onOperatorClick = if (operatorPubkey != null) {{ navController.navigate("profile/$operatorPubkey") }} else null
+                onOperatorClick = if (operatorPubkey != null) {{ navController.navigate("profile/$operatorPubkey") }} else null,
+                onToggleFavorite = { feedViewModel.toggleFavoriteRelay(relayUrl) },
+                onAddToRelaySet = { dTag -> feedViewModel.addRelayToSet(relayUrl, dTag) },
+                onCreateRelaySet = { name ->
+                    feedViewModel.createRelaySet(name, setOf(relayUrl))
+                }
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/repo/RelaySetRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/RelaySetRepository.kt
@@ -1,0 +1,188 @@
+package com.wisp.app.repo
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.wisp.app.nostr.Nip51
+import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.nostr.RelaySet
+import com.wisp.app.relay.RelayConfig
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class RelaySetRepository(private val context: Context, pubkeyHex: String? = null) {
+    private var prefs: SharedPreferences =
+        context.getSharedPreferences(prefsName(pubkeyHex), Context.MODE_PRIVATE)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val relaySets = mutableMapOf<String, RelaySet>()
+
+    private val _ownRelaySets = MutableStateFlow<List<RelaySet>>(emptyList())
+    val ownRelaySets: StateFlow<List<RelaySet>> = _ownRelaySets
+
+    private val _favoriteRelays = MutableStateFlow<List<String>>(emptyList())
+    val favoriteRelays: StateFlow<List<String>> = _favoriteRelays
+
+    private var ownerPubkey: String? = null
+    private var favoriteRelaysTimestamp: Long = 0
+
+    init {
+        loadFromPrefs()
+    }
+
+    fun setOwner(pubkey: String) {
+        ownerPubkey = pubkey
+        refreshOwnSets()
+    }
+
+    fun updateRelaySetFromEvent(event: NostrEvent) {
+        val set = Nip51.parseRelaySetNamed(event) ?: return
+        val key = "${event.pubkey}:${set.dTag}"
+        val existing = relaySets[key]
+        if (existing != null && existing.createdAt >= set.createdAt) return
+        relaySets[key] = set
+        refreshOwnSets()
+    }
+
+    fun updateFavoriteRelaysFromEvent(event: NostrEvent) {
+        if (event.created_at <= favoriteRelaysTimestamp) return
+        favoriteRelaysTimestamp = event.created_at
+        val urls = Nip51.parseRelaySet(event)
+        _favoriteRelays.value = urls
+        saveFavoritesToPrefs(urls)
+    }
+
+    fun getSet(pubkey: String, dTag: String): RelaySet? {
+        return relaySets["$pubkey:$dTag"]
+    }
+
+    fun isFavorite(url: String): Boolean = url in _favoriteRelays.value
+
+    fun addFavorite(url: String): List<String> {
+        val current = _favoriteRelays.value.toMutableList()
+        val normalized = url.trim().trimEnd('/')
+        if (normalized !in current) current.add(normalized)
+        _favoriteRelays.value = current
+        saveFavoritesToPrefs(current)
+        return current
+    }
+
+    fun removeFavorite(url: String): List<String> {
+        val current = _favoriteRelays.value.toMutableList()
+        current.remove(url.trim().trimEnd('/'))
+        _favoriteRelays.value = current
+        saveFavoritesToPrefs(current)
+        return current
+    }
+
+    fun addRelayToSet(url: String, dTag: String): RelaySet? {
+        val owner = ownerPubkey ?: return null
+        val key = "$owner:$dTag"
+        val existing = relaySets[key] ?: return null
+        val normalized = url.trim().trimEnd('/')
+        if (normalized in existing.relays) return existing
+        val updated = existing.copy(relays = existing.relays + normalized)
+        relaySets[key] = updated
+        refreshOwnSets()
+        return updated
+    }
+
+    fun removeRelayFromSet(url: String, dTag: String): RelaySet? {
+        val owner = ownerPubkey ?: return null
+        val key = "$owner:$dTag"
+        val existing = relaySets[key] ?: return null
+        val updated = existing.copy(relays = existing.relays - url.trim().trimEnd('/'))
+        relaySets[key] = updated
+        refreshOwnSets()
+        return updated
+    }
+
+    fun createRelaySet(name: String, relays: Set<String>, dTag: String? = null): RelaySet? {
+        val owner = ownerPubkey ?: return null
+        val tag = dTag ?: name.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
+        val set = RelaySet(
+            pubkey = owner,
+            dTag = tag,
+            name = name,
+            relays = relays.map { it.trim().trimEnd('/') }.filter { RelayConfig.isAcceptableUrl(it) }.toSet(),
+            createdAt = System.currentTimeMillis() / 1000
+        )
+        relaySets["$owner:$tag"] = set
+        refreshOwnSets()
+        return set
+    }
+
+    fun removeRelaySet(dTag: String) {
+        val owner = ownerPubkey ?: return
+        relaySets.remove("$owner:$dTag")
+        refreshOwnSets()
+    }
+
+    fun clear() {
+        relaySets.clear()
+        _ownRelaySets.value = emptyList()
+        _favoriteRelays.value = emptyList()
+        ownerPubkey = null
+        favoriteRelaysTimestamp = 0
+        prefs.edit().clear().apply()
+    }
+
+    fun reload(pubkeyHex: String?) {
+        clear()
+        prefs = context.getSharedPreferences(prefsName(pubkeyHex), Context.MODE_PRIVATE)
+        loadFromPrefs()
+    }
+
+    private fun refreshOwnSets() {
+        val owner = ownerPubkey ?: return
+        val own = relaySets.values.filter { it.pubkey == owner }.sortedBy { it.name }
+        _ownRelaySets.value = own
+        saveSetsToPrefs(own)
+    }
+
+    private fun saveSetsToPrefs(sets: List<RelaySet>) {
+        val serializable = sets.map {
+            SerializableRelaySet(it.pubkey, it.dTag, it.name, it.relays.toList(), it.createdAt)
+        }
+        prefs.edit().putString("relay_sets", json.encodeToString(serializable)).apply()
+    }
+
+    private fun saveFavoritesToPrefs(urls: List<String>) {
+        prefs.edit().putString("favorite_relays", json.encodeToString(urls)).apply()
+    }
+
+    private fun loadFromPrefs() {
+        val setsStr = prefs.getString("relay_sets", null)
+        if (setsStr != null) {
+            try {
+                val serializable = json.decodeFromString<List<SerializableRelaySet>>(setsStr)
+                for (s in serializable) {
+                    val rs = RelaySet(s.pubkey, s.dTag, s.name, s.relays.toSet(), s.createdAt)
+                    relaySets["${s.pubkey}:${s.dTag}"] = rs
+                }
+            } catch (_: Exception) {}
+        }
+        val favsStr = prefs.getString("favorite_relays", null)
+        if (favsStr != null) {
+            try {
+                _favoriteRelays.value = json.decodeFromString<List<String>>(favsStr)
+            } catch (_: Exception) {}
+        }
+    }
+
+    @Serializable
+    private data class SerializableRelaySet(
+        val pubkey: String,
+        val dTag: String,
+        val name: String,
+        val relays: List<String>,
+        val createdAt: Long
+    )
+
+    companion object {
+        private fun prefsName(pubkeyHex: String?): String =
+            if (pubkeyHex != null) "wisp_relay_sets_$pubkeyHex" else "wisp_relay_sets"
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -67,6 +67,7 @@ import com.wisp.app.relay.ScoredRelay
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.ui.text.font.FontWeight
+import com.wisp.app.nostr.RelaySet
 import com.wisp.app.viewmodel.FeedType
 import com.wisp.app.viewmodel.FeedViewModel
 import com.wisp.app.viewmodel.InitLoadingState
@@ -112,6 +113,7 @@ fun FeedScreen(
     val feed by viewModel.feed.collectAsState()
     val feedType by viewModel.feedType.collectAsState()
     val selectedRelay by viewModel.selectedRelay.collectAsState()
+    val selectedRelaySet by viewModel.selectedRelaySet.collectAsState()
     val replyCountVersion by viewModel.eventRepo.replyCountVersion.collectAsState()
     val zapVersion by viewModel.eventRepo.zapVersion.collectAsState()
     val reactionVersion by viewModel.eventRepo.reactionVersion.collectAsState()
@@ -200,14 +202,26 @@ fun FeedScreen(
     }
 
 
+    val favoriteRelays by viewModel.relaySetRepo.favoriteRelays.collectAsState()
+    val ownRelaySets by viewModel.relaySetRepo.ownRelaySets.collectAsState()
+
     if (showRelayPicker) {
         RelayPickerDialog(
             scoredRelays = viewModel.getScoredRelays(),
+            favoriteRelays = favoriteRelays,
+            relaySets = ownRelaySets,
+            relayInfoRepo = viewModel.relayInfoRepo,
             onSelect = { url ->
                 viewModel.setSelectedRelay(url)
                 viewModel.setFeedType(FeedType.RELAY)
                 showRelayPicker = false
             },
+            onSelectRelaySet = { relaySet ->
+                viewModel.setSelectedRelaySet(relaySet)
+                viewModel.setFeedType(FeedType.RELAY)
+                showRelayPicker = false
+            },
+            onCreateRelaySet = { name -> viewModel.createRelaySet(name) },
             onProbe = { domain -> viewModel.probeRelay(domain) },
             onDismiss = { showRelayPicker = false }
         )
@@ -522,7 +536,18 @@ fun FeedScreen(
                     relayUrl = selectedRelay!!,
                     relayInfoRepo = viewModel.relayInfoRepo,
                     relayFeedStatus = relayFeedStatus,
-                    onViewDetails = { onRelayDetail(selectedRelay!!) }
+                    isFavorite = selectedRelay!! in favoriteRelays,
+                    relaySets = ownRelaySets,
+                    onViewDetails = { onRelayDetail(selectedRelay!!) },
+                    onToggleFavorite = { viewModel.toggleFavoriteRelay(selectedRelay!!) },
+                    onAddToRelaySet = { dTag -> viewModel.addRelayToSet(selectedRelay!!, dTag) },
+                    onCreateRelaySet = { name -> viewModel.createRelaySet(name, setOf(selectedRelay!!)) }
+                )
+            }
+            if (feedType == FeedType.RELAY && selectedRelaySet != null && selectedRelay == null) {
+                RelaySetFeedBar(
+                    relaySet = selectedRelaySet!!,
+                    relayFeedStatus = relayFeedStatus
                 )
             }
             Box(
@@ -793,13 +818,21 @@ private fun FeedItem(
 @Composable
 private fun RelayPickerDialog(
     scoredRelays: List<ScoredRelay>,
+    favoriteRelays: List<String>,
+    relaySets: List<RelaySet>,
+    relayInfoRepo: RelayInfoRepository,
     onSelect: (String) -> Unit,
+    onSelectRelaySet: (RelaySet) -> Unit,
+    onCreateRelaySet: (String) -> Unit,
     onProbe: suspend (String) -> String?,
     onDismiss: () -> Unit
 ) {
     var urlInput by remember { mutableStateOf("") }
     var isProbing by remember { mutableStateOf(false) }
     var probeError by remember { mutableStateOf<String?>(null) }
+    var expandedSetDTag by remember { mutableStateOf<String?>(null) }
+    var showCreateSet by remember { mutableStateOf(false) }
+    var newSetName by remember { mutableStateOf("") }
     val scope = rememberCoroutineScope()
 
     AlertDialog(
@@ -860,15 +893,199 @@ private fun RelayPickerDialog(
 
                 Spacer(Modifier.size(12.dp))
 
-                // Scored relay list
-                if (scoredRelays.isEmpty()) {
-                    Text(
-                        "No relay scores available yet",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                } else {
-                    LazyColumn(modifier = Modifier.heightIn(max = 300.dp)) {
+                LazyColumn(modifier = Modifier.heightIn(max = 400.dp)) {
+                    // Favorites section
+                    if (favoriteRelays.isNotEmpty()) {
+                        item {
+                            Text(
+                                "Favorites",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(bottom = 4.dp)
+                            )
+                        }
+                        items(favoriteRelays) { url ->
+                            Surface(
+                                onClick = { onSelect(url) },
+                                shape = RoundedCornerShape(8.dp),
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    RelayIcon(
+                                        iconUrl = relayInfoRepo.getIconUrl(url),
+                                        relayUrl = url,
+                                        size = 24.dp
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Text(
+                                        url.removePrefix("wss://").removePrefix("ws://").removeSuffix("/"),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                }
+                            }
+                        }
+                        item { Spacer(Modifier.height(8.dp)) }
+                    }
+
+                    // Relay Sets section — always shown so user can create their first set
+                    item {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                "Relay Sets",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Surface(
+                                onClick = { showCreateSet = !showCreateSet },
+                                shape = RoundedCornerShape(8.dp),
+                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+                            ) {
+                                Text(
+                                    "+ New Set",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                                )
+                            }
+                        }
+                    }
+                    if (showCreateSet) {
+                        item(key = "create-set-input") {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                androidx.compose.material3.OutlinedTextField(
+                                    value = newSetName,
+                                    onValueChange = { newSetName = it },
+                                    placeholder = { Text("Set name") },
+                                    singleLine = true,
+                                    modifier = Modifier.weight(1f),
+                                    textStyle = MaterialTheme.typography.bodySmall
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Surface(
+                                    onClick = {
+                                        if (newSetName.isNotBlank()) {
+                                            onCreateRelaySet(newSetName.trim())
+                                            newSetName = ""
+                                            showCreateSet = false
+                                        }
+                                    },
+                                    shape = RoundedCornerShape(8.dp),
+                                    color = if (newSetName.isNotBlank()) MaterialTheme.colorScheme.primary
+                                           else MaterialTheme.colorScheme.surfaceVariant
+                                ) {
+                                    Text(
+                                        "Create",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = if (newSetName.isNotBlank()) MaterialTheme.colorScheme.onPrimary
+                                               else MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    for (relaySet in relaySets) {
+                        item(key = "set-${relaySet.dTag}") {
+                            Surface(
+                                onClick = { expandedSetDTag = if (expandedSetDTag == relaySet.dTag) null else relaySet.dTag },
+                                shape = RoundedCornerShape(8.dp),
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        relaySet.name,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        fontWeight = FontWeight.Medium,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    Text(
+                                        "${relaySet.relays.size} relays",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                    Icon(
+                                        Icons.Filled.ArrowDropDown,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                }
+                            }
+                        }
+                        if (expandedSetDTag == relaySet.dTag) {
+                            // Combined feed button
+                            item(key = "set-combined-${relaySet.dTag}") {
+                                Surface(
+                                    onClick = { onSelectRelaySet(relaySet) },
+                                    shape = RoundedCornerShape(8.dp),
+                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                                    modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 2.dp, bottom = 2.dp)
+                                ) {
+                                    Text(
+                                        "Combined Feed",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        fontWeight = FontWeight.Medium,
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
+                                    )
+                                }
+                            }
+                            // Individual relays in the set
+                            items(relaySet.relays.toList(), key = { "set-relay-${relaySet.dTag}-$it" }) { url ->
+                                Surface(
+                                    onClick = { onSelect(url) },
+                                    shape = RoundedCornerShape(8.dp),
+                                    modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 2.dp, bottom = 2.dp)
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        RelayIcon(
+                                            iconUrl = relayInfoRepo.getIconUrl(url),
+                                            relayUrl = url,
+                                            size = 20.dp
+                                        )
+                                        Spacer(Modifier.width(8.dp))
+                                        Text(
+                                            url.removePrefix("wss://").removePrefix("ws://").removeSuffix("/"),
+                                            style = MaterialTheme.typography.bodySmall
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (relaySets.isNotEmpty() || showCreateSet) {
+                        item { Spacer(Modifier.height(8.dp)) }
+                    }
+
+                    // All Relays section
+                    if (scoredRelays.isNotEmpty()) {
+                        item {
+                            Text(
+                                "All Relays",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(bottom = 4.dp)
+                            )
+                        }
                         items(scoredRelays) { scored ->
                             Surface(
                                 onClick = { onSelect(scored.url) },
@@ -891,6 +1108,14 @@ private fun RelayPickerDialog(
                                     )
                                 }
                             }
+                        }
+                    } else if (favoriteRelays.isEmpty() && relaySets.isEmpty()) {
+                        item {
+                            Text(
+                                "No relay scores available yet",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodySmall
+                            )
                         }
                     }
                 }
@@ -1030,13 +1255,20 @@ private fun RelayFeedBar(
     relayUrl: String,
     relayInfoRepo: RelayInfoRepository,
     relayFeedStatus: RelayFeedStatus,
-    onViewDetails: () -> Unit
+    isFavorite: Boolean = false,
+    relaySets: List<RelaySet> = emptyList(),
+    onViewDetails: () -> Unit,
+    onToggleFavorite: () -> Unit = {},
+    onAddToRelaySet: (String) -> Unit = {},
+    onCreateRelaySet: (String) -> Unit = {}
 ) {
     val info = remember(relayUrl) { relayInfoRepo.getInfo(relayUrl) }
     val iconUrl = remember(relayUrl) { relayInfoRepo.getIconUrl(relayUrl) }
     val domain = remember(relayUrl) {
         relayUrl.removePrefix("wss://").removePrefix("ws://").removeSuffix("/")
     }
+    var showSetPicker by remember { mutableStateOf(false) }
+    var newSetName by remember { mutableStateOf("") }
 
     val statusColor = when (relayFeedStatus) {
         is RelayFeedStatus.Streaming -> androidx.compose.ui.graphics.Color(0xFF4CAF50)
@@ -1094,6 +1326,37 @@ private fun RelayFeedBar(
                         )
                     }
                 }
+                Spacer(Modifier.width(6.dp))
+                // Favorite star
+                Surface(
+                    onClick = onToggleFavorite,
+                    shape = RoundedCornerShape(16.dp),
+                    color = androidx.compose.ui.graphics.Color.Transparent
+                ) {
+                    Text(
+                        if (isFavorite) "\u2605" else "\u2606",
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = if (isFavorite) MaterialTheme.colorScheme.primary
+                               else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+                // Add to set pill
+                Surface(
+                    onClick = { showSetPicker = true },
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant
+                ) {
+                    Text(
+                        "+Set",
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+                // Details pill
                 Surface(
                     onClick = onViewDetails,
                     shape = RoundedCornerShape(16.dp),
@@ -1103,6 +1366,126 @@ private fun RelayFeedBar(
                         "Details",
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
                         style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+        }
+    }
+
+    if (showSetPicker) {
+        AlertDialog(
+            onDismissRequest = { showSetPicker = false },
+            title = { Text("Add to Relay Set") },
+            text = {
+                Column {
+                    if (relaySets.isNotEmpty()) {
+                        for (set in relaySets) {
+                            val contains = relayUrl in set.relays
+                            Surface(
+                                onClick = {
+                                    onAddToRelaySet(set.dTag)
+                                    showSetPicker = false
+                                },
+                                shape = RoundedCornerShape(8.dp),
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        set.name,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    if (contains) {
+                                        Text(
+                                            "\u2713",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        HorizontalDivider(
+                            modifier = Modifier.padding(vertical = 8.dp),
+                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+                        )
+                    }
+                    androidx.compose.material3.OutlinedTextField(
+                        value = newSetName,
+                        onValueChange = { newSetName = it },
+                        placeholder = { Text("New set name") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        trailingIcon = {
+                            if (newSetName.isNotBlank()) {
+                                IconButton(onClick = {
+                                    onCreateRelaySet(newSetName.trim())
+                                    newSetName = ""
+                                    showSetPicker = false
+                                }) {
+                                    Text("Create", style = MaterialTheme.typography.labelSmall)
+                                }
+                            }
+                        }
+                    )
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { showSetPicker = false }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun RelaySetFeedBar(
+    relaySet: RelaySet,
+    relayFeedStatus: RelayFeedStatus
+) {
+    val statusColor = when (relayFeedStatus) {
+        is RelayFeedStatus.Streaming -> androidx.compose.ui.graphics.Color(0xFF4CAF50)
+        is RelayFeedStatus.Connecting, is RelayFeedStatus.Subscribing -> androidx.compose.ui.graphics.Color(0xFFFFC107)
+        is RelayFeedStatus.Disconnected, is RelayFeedStatus.ConnectionFailed,
+        is RelayFeedStatus.TimedOut -> androidx.compose.ui.graphics.Color(0xFFFF5252)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Surface(
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Status dot
+                if (relayFeedStatus !is RelayFeedStatus.Idle) {
+                    androidx.compose.foundation.Canvas(
+                        modifier = Modifier.size(10.dp)
+                    ) {
+                        drawCircle(color = statusColor, radius = size.minDimension / 2)
+                    }
+                    Spacer(Modifier.width(8.dp))
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = relaySet.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = "${relaySet.relays.size} relays",
+                        style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -27,6 +27,7 @@ import com.wisp.app.repo.NotificationRepository
 import com.wisp.app.repo.PinRepository
 import com.wisp.app.repo.RelayHintStore
 import com.wisp.app.repo.RelayListRepository
+import com.wisp.app.repo.RelaySetRepository
 
 /**
  * Routes incoming relay events to the appropriate repositories based on subscription ID.
@@ -45,6 +46,7 @@ class EventRouter(
     private val blossomRepo: BlossomRepository,
     private val customEmojiRepo: CustomEmojiRepository,
     private val relayListRepo: RelayListRepository,
+    private val relaySetRepo: RelaySetRepository,
     private val relayScoreBoard: RelayScoreBoard,
     private val relayHintStore: RelayHintStore,
     private val keyRepo: KeyRepository,
@@ -223,6 +225,15 @@ class EventRouter(
                     try { s.nip44Decrypt(event.content, myPubkey) } catch (_: Exception) { null }
                 } else null
                 bookmarkSetRepo.updateFromEvent(event, decrypted)
+            }
+            if (event.kind == Nip51.KIND_RELAY_SET) {
+                relaySetRepo.updateRelaySetFromEvent(event)
+            }
+            if (event.kind == Nip51.KIND_FAVORITE_RELAYS) {
+                val myPubkey = getUserPubkey()
+                if (myPubkey != null && event.pubkey == myPubkey) {
+                    relaySetRepo.updateFavoriteRelaysFromEvent(event)
+                }
             }
             if (event.kind == Nip30.KIND_USER_EMOJI_LIST) {
                 val myPubkey = getUserPubkey()

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -33,6 +33,7 @@ import com.wisp.app.repo.ProfileRepository
 import com.wisp.app.repo.RelayHintStore
 import com.wisp.app.repo.RelayInfoRepository
 import com.wisp.app.repo.RelayListRepository
+import com.wisp.app.repo.RelaySetRepository
 import com.wisp.app.repo.ZapPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -62,6 +63,7 @@ class StartupCoordinator(
     private val listRepo: ListRepository,
     private val bookmarkRepo: BookmarkRepository,
     private val bookmarkSetRepo: BookmarkSetRepository,
+    private val relaySetRepo: RelaySetRepository,
     private val pinRepo: PinRepository,
     private val blossomRepo: BlossomRepository,
     private val customEmojiRepo: CustomEmojiRepository,
@@ -127,6 +129,7 @@ class StartupCoordinator(
         muteRepo.clear()
         bookmarkRepo.clear()
         bookmarkSetRepo.clear()
+        relaySetRepo.clear()
         pinRepo.clear()
         listRepo.clear()
         blossomRepo.clear()
@@ -152,6 +155,7 @@ class StartupCoordinator(
         muteRepo.reload(newPubkey)
         bookmarkRepo.reload(newPubkey)
         bookmarkSetRepo.reload(newPubkey)
+        relaySetRepo.reload(newPubkey)
         pinRepo.reload(newPubkey)
         listRepo.reload(newPubkey)
         blossomRepo.reload(newPubkey)
@@ -282,6 +286,7 @@ class StartupCoordinator(
         getUserPubkey()?.let {
             listRepo.setOwner(it)
             bookmarkSetRepo.setOwner(it)
+            relaySetRepo.setOwner(it)
         }
 
         // Unified startup: cold start shows profile discovery UI, warm start skips to feed.
@@ -439,13 +444,14 @@ class StartupCoordinator(
             Filter(kinds = listOf(0), authors = listOf(myPubkey), limit = 1),
             Filter(kinds = listOf(3), authors = listOf(myPubkey), limit = 1),
             Filter(kinds = listOf(10002), authors = listOf(myPubkey), limit = 1),
-            Filter(kinds = listOf(10050, 10007, 10006), authors = listOf(myPubkey), limit = 3),
+            Filter(kinds = listOf(10050, 10007, 10006, Nip51.KIND_FAVORITE_RELAYS), authors = listOf(myPubkey), limit = 4),
             Filter(kinds = listOf(Nip51.KIND_MUTE_LIST), authors = listOf(myPubkey), limit = 1),
             Filter(kinds = listOf(Nip51.KIND_PIN_LIST), authors = listOf(myPubkey), limit = 1),
             Filter(kinds = listOf(Nip51.KIND_BOOKMARK_LIST), authors = listOf(myPubkey), limit = 1),
             Filter(kinds = listOf(Blossom.KIND_SERVER_LIST), authors = listOf(myPubkey), limit = 1),
             Filter(kinds = listOf(Nip51.KIND_FOLLOW_SET), authors = listOf(myPubkey), limit = 50),
             Filter(kinds = listOf(Nip51.KIND_BOOKMARK_SET), authors = listOf(myPubkey), limit = 50),
+            Filter(kinds = listOf(Nip51.KIND_RELAY_SET), authors = listOf(myPubkey), limit = 50),
             Filter(kinds = listOf(Nip30.KIND_USER_EMOJI_LIST), authors = listOf(myPubkey), limit = 1),
             Filter(kinds = listOf(Nip30.KIND_EMOJI_SET), authors = listOf(myPubkey), limit = 50)
         )


### PR DESCRIPTION
## Summary
- Add NIP-51 support for named relay sets (kind 30002) and favorite relays (kind 10012)
- Relay picker shows favorites section, relay sets with combined multi-relay feed option, and individual relay selection
- Relay feed bar includes favorite star toggle and add-to-set pill for quick actions
- Relay detail screen has favorite toggle and add-to-set button with set picker dialog
- New `RelaySetRepository` with SharedPreferences persistence, event routing, and startup subscription

## Test plan
- [ ] Open relay picker from feed type dropdown — verify favorites and relay sets sections appear
- [ ] Favorite a relay from the relay feed bar or detail screen — verify it appears in picker favorites section
- [ ] Create a relay set from relay picker or detail screen — verify it appears in relay sets section
- [ ] Add relays to a set — verify set expands to show individual relays
- [ ] Select "Combined Feed" on a relay set — verify events load from all relays in the set
- [ ] Select individual relay from a set — verify single relay feed works
- [ ] Verify kind 10012 and 30002 events are published to write relays