### PR TITLE
refactor: simplify notification referenced event loading

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -1084,7 +1084,7 @@ private fun ReferencedNotePostCard(
 
     LaunchedEffect(eventId) {
         if (eventRepo.getEvent(eventId) == null) {
-            eventRepo.requestOwnEvent(eventId)
+            eventRepo.requestQuotedEvent(eventId)
         }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -83,6 +83,12 @@ class EventRouter(
                     }
                 }
             }
+        } else if (subscriptionId == "self-notes") {
+            eventRepo.cacheEvent(event)
+            if (event.kind == 1) {
+                val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
+                if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+            }
         } else if (subscriptionId.startsWith("quote-")) {
             eventRepo.cacheEvent(event)
             if (event.kind == 1 && eventRepo.getProfileData(event.pubkey) == null) {


### PR DESCRIPTION
## Summary
- Fetch user's own recent notes upfront via a `self-notes` subscription (kind 1, limit 200) instead of the fragile per-notification `notif-self-events` fetch
- Route `self-notes` events through EventRouter to cache them before engagement subscriptions start
- Use the batched quote-fetch path (`requestQuotedEvent`) for any remaining missing events in notifications UI (handles other people's notes too)
- Remove the `notif-self-events` phase from `subscribeNotifEngagement()` since own events are already cached

## Test plan
- [ ] Open notifications tab — verify reaction/zap/repost notifications show the referenced note without loading spinners
- [ ] Verify reply notifications show both the parent note (user's own) and the reply
- [ ] Check that notifications still load correctly after app restart (cold start)
- [ ] Verify no regression in feed loading or engagement counts