### PR TITLE
fix: add missing R8 keep rules for java.lang.management

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -44,3 +44,7 @@
 # kmp-tor
 -keep class io.matthewnelson.kmp.tor.** { *; }
 -dontwarn io.matthewnelson.kmp.tor.**
+
+# java.lang.management (not available on Android)
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean


### PR DESCRIPTION
## Summary
- Suppress R8 warnings for `java.lang.management.ManagementFactory` and `RuntimeMXBean` which aren't available on Android

## Test plan
- [ ] `./gradlew assembleRelease` completes without missing class errors