### PR TITLE
fix: suppress notification sounds for previous session events

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -515,7 +515,7 @@ class StartupCoordinator(
      * when all relay subscriptions have been torn down.
      */
     fun subscribeDmsAndNotifications(myPubkey: String) {
-        notifRepo.notifInitialized = false
+        notifRepo.soundEligibleAfter = System.currentTimeMillis() / 1000
         val dmFilter = Filter(kinds = listOf(1059), pTags = listOf(myPubkey))
         val dmReqMsg = ClientMessage.req("dms", dmFilter)
         relayPool.sendToAll(dmReqMsg)
@@ -555,7 +555,6 @@ class StartupCoordinator(
 
         scope.launch {
             subManager.awaitEoseWithTimeout("notif")
-            notifRepo.notifInitialized = true
             // Wait for self-notes to arrive before engagement so referenced events are cached
             subManager.awaitEoseWithTimeout("self-notes", timeoutMs = 5_000)
             subManager.closeSubscription("self-notes")


### PR DESCRIPTION
## Summary
- Replace `notifInitialized` boolean flag with `soundEligibleAfter` timestamp set to app start time
- Only events with `created_at >= soundEligibleAfter` trigger notification sounds
- Fixes dozens of notification blips firing on cold start from historical events

## Test plan
- [ ] Cold start the app — no notification sounds should play for existing events
- [ ] Leave app running — new incoming reactions/zaps should still trigger sounds
- [ ] Force reconnect — historical events from re-subscription should not trigger sounds