### PR TITLE
feat: split search into My Device and Relays tabs

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -723,6 +723,7 @@ fun WispNavHost(
                 viewModel = searchViewModel,
                 relayPool = feedViewModel.relayPool,
                 eventRepo = feedViewModel.eventRepo,
+                profileRepo = feedViewModel.profileRepo,
                 muteRepo = feedViewModel.muteRepo,
                 contactRepo = feedViewModel.contactRepo,
                 extendedNetworkCache = extNetCache,

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -574,6 +574,15 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
 
 
+    fun searchNotes(query: String, limit: Int = 50): List<NostrEvent> {
+        if (query.isBlank()) return emptyList()
+        val lowerQuery = query.lowercase()
+        return eventCache.snapshot().values
+            .filter { it.kind == 1 && it.content.lowercase().contains(lowerQuery) }
+            .sortedByDescending { it.created_at }
+            .take(limit)
+    }
+
     fun clearFeed() {
         synchronized(feedList) {
             feedList.clear()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
@@ -1,6 +1,7 @@
 package com.wisp.app.ui.screen
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,12 +20,15 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -44,9 +48,12 @@ import com.wisp.app.repo.ContactRepository
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.ExtendedNetworkCache
 import com.wisp.app.repo.MuteRepository
+import com.wisp.app.repo.ProfileRepository
 import com.wisp.app.ui.component.FollowButton
 import com.wisp.app.ui.component.PostCard
 import com.wisp.app.ui.component.ProfilePicture
+import com.wisp.app.viewmodel.LocalFilter
+import com.wisp.app.viewmodel.SearchTab
 import com.wisp.app.viewmodel.SearchViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,6 +62,7 @@ fun SearchScreen(
     viewModel: SearchViewModel,
     relayPool: RelayPool,
     eventRepo: EventRepository,
+    profileRepo: ProfileRepository,
     muteRepo: MuteRepository? = null,
     contactRepo: ContactRepository? = null,
     extendedNetworkCache: ExtendedNetworkCache? = null,
@@ -72,10 +80,16 @@ fun SearchScreen(
     onDeleteEvent: (String, Int) -> Unit = { _, _ -> }
 ) {
     val query by viewModel.query.collectAsState()
+    val selectedTab by viewModel.selectedTab.collectAsState()
+    val localFilter by viewModel.localFilter.collectAsState()
+    val localUsers by viewModel.localUsers.collectAsState()
+    val localNotes by viewModel.localNotes.collectAsState()
     val users by viewModel.users.collectAsState()
     val notes by viewModel.notes.collectAsState()
     val lists by viewModel.lists.collectAsState()
     val isSearching by viewModel.isSearching.collectAsState()
+
+    val tabs = SearchTab.entries
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -95,7 +109,7 @@ fun SearchScreen(
         ) {
             OutlinedTextField(
                 value = query,
-                onValueChange = { viewModel.updateQuery(it) },
+                onValueChange = { viewModel.updateQuery(it, profileRepo, eventRepo) },
                 placeholder = { Text("Search users and notes") },
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                 trailingIcon = {
@@ -109,6 +123,7 @@ fun SearchScreen(
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                 keyboardActions = KeyboardActions(
                     onSearch = {
+                        viewModel.selectTab(SearchTab.RELAYS)
                         viewModel.search(query, relayPool, eventRepo, muteRepo)
                     }
                 ),
@@ -117,126 +132,313 @@ fun SearchScreen(
                     .padding(horizontal = 16.dp, vertical = 8.dp)
             )
 
-            when {
-                isSearching -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
-                    }
-                }
+            TabRow(selectedTabIndex = tabs.indexOf(selectedTab)) {
+                Tab(
+                    selected = selectedTab == SearchTab.MY_DEVICE,
+                    onClick = { viewModel.selectTab(SearchTab.MY_DEVICE) },
+                    text = { Text("My Device") }
+                )
+                Tab(
+                    selected = selectedTab == SearchTab.RELAYS,
+                    onClick = { viewModel.selectTab(SearchTab.RELAYS) },
+                    text = { Text("Relays") }
+                )
+            }
 
-                users.isEmpty() && notes.isEmpty() && lists.isEmpty() && query.isNotEmpty() && !isSearching -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            "No results found",
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+            when (selectedTab) {
+                SearchTab.MY_DEVICE -> MyDeviceTab(
+                    query = query,
+                    localFilter = localFilter,
+                    localUsers = localUsers,
+                    localNotes = localNotes,
+                    eventRepo = eventRepo,
+                    contactRepo = contactRepo,
+                    onSelectFilter = { viewModel.selectLocalFilter(it) },
+                    onProfileClick = onProfileClick,
+                    onNoteClick = onNoteClick,
+                    onQuotedNoteClick = onQuotedNoteClick,
+                    onReply = onReply,
+                    onReact = onReact,
+                    onToggleFollow = onToggleFollow,
+                    onBlockUser = onBlockUser,
+                    userPubkey = userPubkey,
+                    listedIds = listedIds,
+                    onAddToList = onAddToList,
+                    onDeleteEvent = onDeleteEvent
+                )
+
+                SearchTab.RELAYS -> RelaysTab(
+                    query = query,
+                    users = users,
+                    notes = notes,
+                    lists = lists,
+                    isSearching = isSearching,
+                    eventRepo = eventRepo,
+                    contactRepo = contactRepo,
+                    extendedNetworkCache = extendedNetworkCache,
+                    onProfileClick = onProfileClick,
+                    onNoteClick = onNoteClick,
+                    onQuotedNoteClick = onQuotedNoteClick,
+                    onReply = onReply,
+                    onReact = onReact,
+                    onListClick = onListClick,
+                    onToggleFollow = onToggleFollow,
+                    onBlockUser = onBlockUser,
+                    userPubkey = userPubkey,
+                    listedIds = listedIds,
+                    onAddToList = onAddToList,
+                    onDeleteEvent = onDeleteEvent
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MyDeviceTab(
+    query: String,
+    localFilter: LocalFilter,
+    localUsers: List<ProfileData>,
+    localNotes: List<NostrEvent>,
+    eventRepo: EventRepository,
+    contactRepo: ContactRepository?,
+    onSelectFilter: (LocalFilter) -> Unit,
+    onProfileClick: (String) -> Unit,
+    onNoteClick: (NostrEvent) -> Unit,
+    onQuotedNoteClick: ((String) -> Unit)?,
+    onReply: (NostrEvent) -> Unit,
+    onReact: (NostrEvent, String) -> Unit,
+    onToggleFollow: (String) -> Unit,
+    onBlockUser: (String) -> Unit,
+    userPubkey: String?,
+    listedIds: Set<String>,
+    onAddToList: (String) -> Unit,
+    onDeleteEvent: (String, Int) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FilterChip(
+                selected = localFilter == LocalFilter.PEOPLE,
+                onClick = { onSelectFilter(LocalFilter.PEOPLE) },
+                label = { Text("People") }
+            )
+            FilterChip(
+                selected = localFilter == LocalFilter.NOTES,
+                onClick = { onSelectFilter(LocalFilter.NOTES) },
+                label = { Text("Notes") }
+            )
+        }
+
+        when {
+            query.isBlank() -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        "Search cached users and notes",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            localFilter == LocalFilter.PEOPLE && localUsers.isEmpty() ||
+            localFilter == LocalFilter.NOTES && localNotes.isEmpty() -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        "No results on your device",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            localFilter == LocalFilter.PEOPLE -> {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(localUsers, key = { it.pubkey }) { profile ->
+                        UserResultItem(
+                            profile = profile,
+                            isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
+                            onClick = { onProfileClick(profile.pubkey) },
+                            onToggleFollow = { onToggleFollow(profile.pubkey) }
                         )
                     }
                 }
+            }
 
-                users.isEmpty() && notes.isEmpty() && lists.isEmpty() -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            "Search for users and notes",
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+            localFilter == LocalFilter.NOTES -> {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(localNotes, key = { it.id }) { event ->
+                        val profile = eventRepo.getProfileData(event.pubkey)
+                        PostCard(
+                            event = event,
+                            profile = profile,
+                            onReply = { onReply(event) },
+                            onProfileClick = { onProfileClick(event.pubkey) },
+                            onNavigateToProfile = onProfileClick,
+                            onNoteClick = { onNoteClick(event) },
+                            onQuotedNoteClick = onQuotedNoteClick,
+                            onReact = { emoji -> onReact(event, emoji) },
+                            eventRepo = eventRepo,
+                            onFollowAuthor = { onToggleFollow(event.pubkey) },
+                            onBlockAuthor = { onBlockUser(event.pubkey) },
+                            isOwnEvent = event.pubkey == userPubkey,
+                            onAddToList = { onAddToList(event.id) },
+                            isInList = event.id in listedIds,
+                            onDelete = { onDeleteEvent(event.id, event.kind) }
                         )
                     }
                 }
+            }
+        }
+    }
+}
 
-                else -> {
-                    val filteredUsers = users.filter { profile ->
-                        val pk = profile.pubkey
-                        val inNetwork = contactRepo?.isFollowing(pk) == true ||
-                                extendedNetworkCache?.firstDegreePubkeys?.contains(pk) == true ||
-                                extendedNetworkCache?.qualifiedPubkeys?.contains(pk) == true ||
-                                profile.nip05 != null
-                        inNetwork
-                    }.take(5)
+@Composable
+private fun RelaysTab(
+    query: String,
+    users: List<ProfileData>,
+    notes: List<NostrEvent>,
+    lists: List<FollowSet>,
+    isSearching: Boolean,
+    eventRepo: EventRepository,
+    contactRepo: ContactRepository?,
+    extendedNetworkCache: ExtendedNetworkCache?,
+    onProfileClick: (String) -> Unit,
+    onNoteClick: (NostrEvent) -> Unit,
+    onQuotedNoteClick: ((String) -> Unit)?,
+    onReply: (NostrEvent) -> Unit,
+    onReact: (NostrEvent, String) -> Unit,
+    onListClick: (FollowSet) -> Unit,
+    onToggleFollow: (String) -> Unit,
+    onBlockUser: (String) -> Unit,
+    userPubkey: String?,
+    listedIds: Set<String>,
+    onAddToList: (String) -> Unit,
+    onDeleteEvent: (String, Int) -> Unit
+) {
+    when {
+        isSearching -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            }
+        }
 
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        if (filteredUsers.isNotEmpty()) {
-                            item {
-                                Text(
-                                    "Users",
-                                    style = MaterialTheme.typography.titleSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                                )
-                            }
-                            items(filteredUsers, key = { it.pubkey }) { profile ->
-                                UserResultItem(
-                                    profile = profile,
-                                    isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
-                                    onClick = { onProfileClick(profile.pubkey) },
-                                    onToggleFollow = { onToggleFollow(profile.pubkey) }
-                                )
-                            }
-                            item {
-                                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                            }
+        users.isEmpty() && notes.isEmpty() && lists.isEmpty() && query.isNotEmpty() && !isSearching -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    "No results found",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        users.isEmpty() && notes.isEmpty() && lists.isEmpty() -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    "Press search to query relays",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        else -> {
+            val filteredUsers = users.filter { profile ->
+                val pk = profile.pubkey
+                contactRepo?.isFollowing(pk) == true ||
+                        extendedNetworkCache?.firstDegreePubkeys?.contains(pk) == true ||
+                        extendedNetworkCache?.qualifiedPubkeys?.contains(pk) == true ||
+                        profile.nip05 != null
+            }.take(5)
+
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                if (filteredUsers.isNotEmpty()) {
+                    item {
+                        Text(
+                            "Users",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                    }
+                    items(filteredUsers, key = { it.pubkey }) { profile ->
+                        UserResultItem(
+                            profile = profile,
+                            isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
+                            onClick = { onProfileClick(profile.pubkey) },
+                            onToggleFollow = { onToggleFollow(profile.pubkey) }
+                        )
+                    }
+                    item {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                    }
+                }
+
+                if (lists.isNotEmpty()) {
+                    item {
+                        Text(
+                            "Lists",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                    }
+                    items(lists, key = { "${it.pubkey}:${it.dTag}" }) { list ->
+                        ListResultItem(
+                            followSet = list,
+                            eventRepo = eventRepo,
+                            onClick = { onListClick(list) }
+                        )
+                    }
+                    if (notes.isNotEmpty()) {
+                        item {
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
                         }
+                    }
+                }
 
-                        if (lists.isNotEmpty()) {
-                            item {
-                                Text(
-                                    "Lists",
-                                    style = MaterialTheme.typography.titleSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                                )
-                            }
-                            items(lists, key = { "${it.pubkey}:${it.dTag}" }) { list ->
-                                ListResultItem(
-                                    followSet = list,
-                                    eventRepo = eventRepo,
-                                    onClick = { onListClick(list) }
-                                )
-                            }
-                            if (notes.isNotEmpty()) {
-                                item {
-                                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                                }
-                            }
-                        }
-
-                        if (notes.isNotEmpty()) {
-                            item {
-                                Text(
-                                    "Notes",
-                                    style = MaterialTheme.typography.titleSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                                )
-                            }
-                            items(notes, key = { it.id }) { event ->
-                                val profile = eventRepo.getProfileData(event.pubkey)
-                                PostCard(
-                                    event = event,
-                                    profile = profile,
-                                    onReply = { onReply(event) },
-                                    onProfileClick = { onProfileClick(event.pubkey) },
-                                    onNavigateToProfile = onProfileClick,
-                                    onNoteClick = { onNoteClick(event) },
-                                    onQuotedNoteClick = onQuotedNoteClick,
-                                    onReact = { emoji -> onReact(event, emoji) },
-                                    eventRepo = eventRepo,
-                                    onFollowAuthor = { onToggleFollow(event.pubkey) },
-                                    onBlockAuthor = { onBlockUser(event.pubkey) },
-                                    isOwnEvent = event.pubkey == userPubkey,
-                                    onAddToList = { onAddToList(event.id) },
-                                    isInList = event.id in listedIds,
-                                    onDelete = { onDeleteEvent(event.id, event.kind) }
-                                )
-                            }
-                        }
+                if (notes.isNotEmpty()) {
+                    item {
+                        Text(
+                            "Notes",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                    }
+                    items(notes, key = { it.id }) { event ->
+                        val profile = eventRepo.getProfileData(event.pubkey)
+                        PostCard(
+                            event = event,
+                            profile = profile,
+                            onReply = { onReply(event) },
+                            onProfileClick = { onProfileClick(event.pubkey) },
+                            onNavigateToProfile = onProfileClick,
+                            onNoteClick = { onNoteClick(event) },
+                            onQuotedNoteClick = onQuotedNoteClick,
+                            onReact = { emoji -> onReact(event, emoji) },
+                            eventRepo = eventRepo,
+                            onFollowAuthor = { onToggleFollow(event.pubkey) },
+                            onBlockAuthor = { onBlockUser(event.pubkey) },
+                            isOwnEvent = event.pubkey == userPubkey,
+                            onAddToList = { onAddToList(event.id) },
+                            isInList = event.id in listedIds,
+                            onDelete = { onDeleteEvent(event.id, event.kind) }
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds a **My Device** tab with instant local search across cached profiles (~2,000) and notes (~5,000) using `ProfileRepository.search()` and a new `EventRepository.searchNotes()`
- Moves existing relay search (NIP-50) into a **Relays** tab, preserving current behavior unchanged
- Search field is shared — typing searches locally in real-time (150ms debounce), keyboard submit switches to Relays tab

## Test plan
- [ ] Open Search, type a name → "My Device" People tab shows instant results from profile cache
- [ ] Switch to Notes filter → shows matching notes from feed cache
- [ ] Switch to "Relays" tab, hit search → existing relay search behavior works as before
- [ ] Clear button resets both tabs
- [ ] Empty states show appropriate messages for each tab/filter