### PR TITLE
feat: inline search relay selector and layout rework

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
@@ -10,31 +10,43 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
@@ -88,6 +100,8 @@ fun SearchScreen(
     val notes by viewModel.notes.collectAsState()
     val lists by viewModel.lists.collectAsState()
     val isSearching by viewModel.isSearching.collectAsState()
+    val searchRelays by viewModel.searchRelays.collectAsState()
+    val selectedRelay by viewModel.selectedRelay.collectAsState()
 
     val tabs = SearchTab.entries
 
@@ -107,31 +121,13 @@ fun SearchScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            OutlinedTextField(
-                value = query,
-                onValueChange = { viewModel.updateQuery(it, profileRepo, eventRepo) },
-                placeholder = { Text("Search users and notes") },
-                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-                trailingIcon = {
-                    if (query.isNotEmpty()) {
-                        IconButton(onClick = { viewModel.clear() }) {
-                            Icon(Icons.Default.Clear, contentDescription = "Clear")
-                        }
-                    }
-                },
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(
-                    onSearch = {
-                        viewModel.selectTab(SearchTab.RELAYS)
-                        viewModel.search(query, relayPool, eventRepo, muteRepo)
-                    }
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            // People / Notes filter
+            ResultFilterSelector(
+                localFilter = localFilter,
+                onSelectFilter = { viewModel.selectLocalFilter(it) }
             )
 
+            // Tabs
             TabRow(selectedTabIndex = tabs.indexOf(selectedTab)) {
                 Tab(
                     selected = selectedTab == SearchTab.MY_DEVICE,
@@ -153,7 +149,8 @@ fun SearchScreen(
                     localNotes = localNotes,
                     eventRepo = eventRepo,
                     contactRepo = contactRepo,
-                    onSelectFilter = { viewModel.selectLocalFilter(it) },
+                    onQueryChange = { viewModel.updateQuery(it, profileRepo, eventRepo) },
+                    onClear = { viewModel.clear() },
                     onProfileClick = onProfileClick,
                     onNoteClick = onNoteClick,
                     onQuotedNoteClick = onQuotedNoteClick,
@@ -173,9 +170,17 @@ fun SearchScreen(
                     notes = notes,
                     lists = lists,
                     isSearching = isSearching,
+                    localFilter = localFilter,
+                    searchRelays = searchRelays,
+                    selectedRelay = selectedRelay,
+                    onSelectRelay = { viewModel.selectRelay(it) },
+                    onAddRelay = { viewModel.addSearchRelay(it) },
+                    onRemoveRelay = { viewModel.removeSearchRelay(it) },
+                    onQueryChange = { viewModel.updateQuery(it, profileRepo, eventRepo) },
+                    onClear = { viewModel.clear() },
+                    onSearch = { viewModel.search(query, relayPool, eventRepo, muteRepo) },
                     eventRepo = eventRepo,
                     contactRepo = contactRepo,
-                    extendedNetworkCache = extendedNetworkCache,
                     onProfileClick = onProfileClick,
                     onNoteClick = onNoteClick,
                     onQuotedNoteClick = onQuotedNoteClick,
@@ -202,7 +207,8 @@ private fun MyDeviceTab(
     localNotes: List<NostrEvent>,
     eventRepo: EventRepository,
     contactRepo: ContactRepository?,
-    onSelectFilter: (LocalFilter) -> Unit,
+    onQueryChange: (String) -> Unit,
+    onClear: () -> Unit,
     onProfileClick: (String) -> Unit,
     onNoteClick: (NostrEvent) -> Unit,
     onQuotedNoteClick: ((String) -> Unit)?,
@@ -216,21 +222,12 @@ private fun MyDeviceTab(
     onDeleteEvent: (String, Int) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
-        Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            FilterChip(
-                selected = localFilter == LocalFilter.PEOPLE,
-                onClick = { onSelectFilter(LocalFilter.PEOPLE) },
-                label = { Text("People") }
-            )
-            FilterChip(
-                selected = localFilter == LocalFilter.NOTES,
-                onClick = { onSelectFilter(LocalFilter.NOTES) },
-                label = { Text("Notes") }
-            )
-        }
+        // Search bar
+        SearchBar(
+            query = query,
+            onQueryChange = onQueryChange,
+            onClear = onClear
+        )
 
         when {
             query.isBlank() -> {
@@ -259,8 +256,11 @@ private fun MyDeviceTab(
             }
 
             localFilter == LocalFilter.PEOPLE -> {
+                val sortedLocalUsers = localUsers.sortedByDescending {
+                    contactRepo?.isFollowing(it.pubkey) == true
+                }
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(localUsers, key = { it.pubkey }) { profile ->
+                    items(sortedLocalUsers, key = { it.pubkey }) { profile ->
                         UserResultItem(
                             profile = profile,
                             isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
@@ -299,6 +299,7 @@ private fun MyDeviceTab(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun RelaysTab(
     query: String,
@@ -306,9 +307,17 @@ private fun RelaysTab(
     notes: List<NostrEvent>,
     lists: List<FollowSet>,
     isSearching: Boolean,
+    localFilter: LocalFilter,
+    searchRelays: List<String>,
+    selectedRelay: String?,
+    onSelectRelay: (String?) -> Unit,
+    onAddRelay: (String) -> Boolean,
+    onRemoveRelay: (String) -> Unit,
+    onQueryChange: (String) -> Unit,
+    onClear: () -> Unit,
+    onSearch: () -> Unit,
     eventRepo: EventRepository,
     contactRepo: ContactRepository?,
-    extendedNetworkCache: ExtendedNetworkCache?,
     onProfileClick: (String) -> Unit,
     onNoteClick: (NostrEvent) -> Unit,
     onQuotedNoteClick: ((String) -> Unit)?,
@@ -322,6 +331,24 @@ private fun RelaysTab(
     onAddToList: (String) -> Unit,
     onDeleteEvent: (String, Int) -> Unit
 ) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Relay selector
+        RelaySelector(
+            searchRelays = searchRelays,
+            selectedRelay = selectedRelay,
+            onSelectRelay = onSelectRelay,
+            onAddRelay = onAddRelay,
+            onRemoveRelay = onRemoveRelay
+        )
+
+        // Search bar + Go
+        SearchBar(
+            query = query,
+            onQueryChange = onQueryChange,
+            onClear = onClear,
+            onSearch = onSearch
+        )
+
     when {
         isSearching -> {
             Box(
@@ -357,25 +384,12 @@ private fun RelaysTab(
         }
 
         else -> {
-            val filteredUsers = users.filter { profile ->
-                val pk = profile.pubkey
-                contactRepo?.isFollowing(pk) == true ||
-                        extendedNetworkCache?.firstDegreePubkeys?.contains(pk) == true ||
-                        extendedNetworkCache?.qualifiedPubkeys?.contains(pk) == true ||
-                        profile.nip05 != null
-            }.take(5)
-
             LazyColumn(modifier = Modifier.fillMaxSize()) {
-                if (filteredUsers.isNotEmpty()) {
-                    item {
-                        Text(
-                            "Users",
-                            style = MaterialTheme.typography.titleSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                        )
+                if (localFilter == LocalFilter.PEOPLE) {
+                    val sortedUsers = users.sortedByDescending {
+                        contactRepo?.isFollowing(it.pubkey) == true
                     }
-                    items(filteredUsers, key = { it.pubkey }) { profile ->
+                    items(sortedUsers, key = { it.pubkey }) { profile ->
                         UserResultItem(
                             profile = profile,
                             isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
@@ -383,43 +397,30 @@ private fun RelaysTab(
                             onToggleFollow = { onToggleFollow(profile.pubkey) }
                         )
                     }
-                    item {
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                    }
-                }
-
-                if (lists.isNotEmpty()) {
-                    item {
-                        Text(
-                            "Lists",
-                            style = MaterialTheme.typography.titleSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                        )
-                    }
-                    items(lists, key = { "${it.pubkey}:${it.dTag}" }) { list ->
-                        ListResultItem(
-                            followSet = list,
-                            eventRepo = eventRepo,
-                            onClick = { onListClick(list) }
-                        )
-                    }
-                    if (notes.isNotEmpty()) {
+                } else {
+                    if (lists.isNotEmpty()) {
                         item {
-                            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                            Text(
+                                "Lists",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                            )
+                        }
+                        items(lists, key = { "${it.pubkey}:${it.dTag}" }) { list ->
+                            ListResultItem(
+                                followSet = list,
+                                eventRepo = eventRepo,
+                                onClick = { onListClick(list) }
+                            )
+                        }
+                        if (notes.isNotEmpty()) {
+                            item {
+                                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                            }
                         }
                     }
-                }
 
-                if (notes.isNotEmpty()) {
-                    item {
-                        Text(
-                            "Notes",
-                            style = MaterialTheme.typography.titleSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                        )
-                    }
                     items(notes, key = { it.id }) { event ->
                         val profile = eventRepo.getProfileData(event.pubkey)
                         PostCard(
@@ -444,6 +445,193 @@ private fun RelaysTab(
             }
         }
     }
+    } // Column
+}
+
+@Composable
+private fun ResultFilterSelector(
+    localFilter: LocalFilter,
+    onSelectFilter: (LocalFilter) -> Unit
+) {
+    Row(
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        FilterChip(
+            selected = localFilter == LocalFilter.PEOPLE,
+            onClick = { onSelectFilter(LocalFilter.PEOPLE) },
+            label = { Text("People") }
+        )
+        FilterChip(
+            selected = localFilter == LocalFilter.NOTES,
+            onClick = { onSelectFilter(LocalFilter.NOTES) },
+            label = { Text("Notes") }
+        )
+    }
+}
+
+@Composable
+private fun SearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onClear: () -> Unit,
+    onSearch: (() -> Unit)? = null
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            placeholder = { Text("Search users and notes") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+            trailingIcon = {
+                if (query.isNotEmpty()) {
+                    IconButton(onClick = onClear) {
+                        Icon(Icons.Default.Clear, contentDescription = "Clear")
+                    }
+                }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = if (onSearch != null) ImeAction.Search else ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onSearch = { onSearch?.invoke() }
+            ),
+            modifier = Modifier.weight(1f)
+        )
+        if (onSearch != null) {
+            IconButton(onClick = onSearch) {
+                Icon(Icons.Default.Search, contentDescription = "Go")
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RelaySelector(
+    searchRelays: List<String>,
+    selectedRelay: String?,
+    onSelectRelay: (String?) -> Unit,
+    onAddRelay: (String) -> Boolean,
+    onRemoveRelay: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var showAddDialog by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        OutlinedTextField(
+            value = selectedRelay?.removePrefix("wss://") ?: "All relays",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Search relay") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth()
+        )
+
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            DropdownMenuItem(
+                text = { Text("All relays") },
+                onClick = {
+                    onSelectRelay(null)
+                    expanded = false
+                }
+            )
+            searchRelays.forEach { url ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            url.removePrefix("wss://"),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    },
+                    trailingIcon = {
+                        IconButton(
+                            onClick = { onRemoveRelay(url) },
+                            modifier = Modifier.size(24.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = "Remove relay",
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                    },
+                    onClick = {
+                        onSelectRelay(url)
+                        expanded = false
+                    }
+                )
+            }
+            HorizontalDivider()
+            DropdownMenuItem(
+                text = { Text("Add new") },
+                leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
+                onClick = {
+                    expanded = false
+                    showAddDialog = true
+                }
+            )
+        }
+    }
+
+    if (showAddDialog) {
+        AddRelayDialog(
+            onDismiss = { showAddDialog = false },
+            onAdd = { url ->
+                if (onAddRelay(url)) {
+                    showAddDialog = false
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun AddRelayDialog(
+    onDismiss: () -> Unit,
+    onAdd: (String) -> Unit
+) {
+    var url by remember { mutableStateOf("wss://") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add search relay") },
+        text = {
+            OutlinedTextField(
+                value = url,
+                onValueChange = { url = it },
+                placeholder = { Text("wss://relay.example.com") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { onAdd(url) })
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onAdd(url) }) {
+                Text("Add")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- Rearrange search screen: shared People/Notes filter chips at top, tabs below, search bar inside each tab
- Relays tab gets a relay selector dropdown (All relays / individual relay) with add/remove support via dialog
- Remove aggressive user filtering on relay search results — show all results from relays
- Sort followed users to top of people lists on both My Device and Relays tabs
- Search bar on Relays tab includes a Go button for triggering relay queries

## Test plan
- [ ] Open Search → People/Notes chips visible above tabs
- [ ] My Device tab shows search bar, type to search cached users/notes
- [ ] Relays tab shows relay dropdown → search bar with Go button
- [ ] Select a single relay → search queries only that relay
- [ ] Select "All relays" → queries all configured relays
- [ ] Tap "Add new" in dropdown → dialog to add a relay URL, persists across sessions
- [ ] Tap X on a relay in dropdown → removes it; if selected, falls back to All
- [ ] People results show followed users at top on both tabs
- [ ] Notes filter shows lists + notes on Relays tab