### PR TITLE
feat: add pull-to-refresh on feed and notifications

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1325,7 +1325,8 @@ fun WispNavHost(
                 resolvedEmojis = notifResolvedEmojis,
                 unicodeEmojis = notifUnicodeEmojis,
                 onManageEmojis = { navController.navigate(Routes.CUSTOM_EMOJIS) },
-                zapError = feedViewModel.zapError
+                zapError = feedViewModel.zapError,
+                onRefresh = { feedViewModel.refreshDmsAndNotifications() }
             )
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -198,6 +199,7 @@ fun FeedScreen(
 
 
     val initialLoadDone by viewModel.initialLoadDone.collectAsState()
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
 
     LaunchedEffect(isAtTop) {
         if (isAtTop) viewModel.resetNewNoteCount()
@@ -603,7 +605,11 @@ fun FeedScreen(
                         }
                     }
                 } else {
-                    Box(modifier = Modifier.fillMaxSize()) {
+                    PullToRefreshBox(
+                        isRefreshing = isRefreshing,
+                        onRefresh = { viewModel.refreshFeed() },
+                        modifier = Modifier.fillMaxSize()
+                    ) {
                         LazyColumn(
                             state = listState,
                             modifier = Modifier.fillMaxSize()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -104,9 +105,11 @@ fun NotificationsScreen(
     resolvedEmojis: Map<String, String> = emptyMap(),
     unicodeEmojis: List<String> = emptyList(),
     onManageEmojis: (() -> Unit)? = null,
-    zapError: SharedFlow<String>? = null
+    zapError: SharedFlow<String>? = null,
+    onRefresh: () -> Unit = {}
 ) {
     val notifications by viewModel.filteredNotifications.collectAsState()
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
     val currentFilter by viewModel.filter.collectAsState()
     val summary by viewModel.summary24h.collectAsState()
     val eventRepo = viewModel.eventRepository
@@ -216,11 +219,17 @@ fun NotificationsScreen(
             )
         }
     ) { padding ->
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = { viewModel.refresh(onRefresh) },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
         if (notifications.isEmpty()) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(padding)
                     .padding(32.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
@@ -241,7 +250,6 @@ fun NotificationsScreen(
                 state = listState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(padding)
             ) {
                 item(key = "summary_24h") {
                     DailySummaryBar(
@@ -325,6 +333,7 @@ fun NotificationsScreen(
                 }
             }
         }
+        } // PullToRefreshBox
     }
 }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -66,6 +66,9 @@ class FeedSubscriptionManager(
     private val _relayFeedStatus = MutableStateFlow<RelayFeedStatus>(RelayFeedStatus.Idle)
     val relayFeedStatus: StateFlow<RelayFeedStatus> = _relayFeedStatus
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing
+
     val _initialLoadDone = MutableStateFlow(false)
     val initialLoadDone: StateFlow<Boolean> = _initialLoadDone
 
@@ -156,6 +159,19 @@ class FeedSubscriptionManager(
 
     fun subscribeFeed() {
         resubscribeFeed()
+    }
+
+    fun refreshFeed() {
+        _isRefreshing.value = true
+        eventRepo.clearFeed()
+        resubscribeFeed()
+        scope.launch {
+            // Don't wait for full EOSE — just show the spinner briefly so the
+            // user gets tactile feedback that the refresh fired. Events will
+            // stream in as relays respond.
+            delay(3000)
+            _isRefreshing.value = false
+        }
     }
 
     fun resubscribeFeed() {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -221,6 +221,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val feedType: StateFlow<FeedType> = feedSub.feedType
     val selectedRelay: StateFlow<String?> = feedSub.selectedRelay
     val selectedRelaySet: StateFlow<RelaySet?> = feedSub.selectedRelaySet
+    val isRefreshing: StateFlow<Boolean> = feedSub.isRefreshing
     val relayFeedStatus: StateFlow<RelayFeedStatus> = feedSub.relayFeedStatus
     val loadingScreenComplete: StateFlow<Boolean> = feedSub.loadingScreenComplete
     val selectedList: StateFlow<com.wisp.app.nostr.FollowSet?> = listRepo.selectedList
@@ -246,6 +247,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     // -- Feed subscription delegates --
     fun setFeedType(type: FeedType) = feedSub.setFeedType(type)
     fun setSelectedRelay(url: String) = feedSub.setSelectedRelay(url)
+    fun refreshFeed() = feedSub.refreshFeed()
     fun retryRelayFeed() = feedSub.retryRelayFeed()
     fun loadMore() = feedSub.loadMore()
     fun pauseEngagement() = feedSub.pauseEngagement()

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
@@ -49,6 +49,9 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
     val summary24h: StateFlow<NotificationSummary>
         get() = notifRepo?.summary24h ?: MutableStateFlow(NotificationSummary())
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing
+
     private val _filter = MutableStateFlow(NotificationFilter.ALL)
     val filter: StateFlow<NotificationFilter> = _filter
 
@@ -101,6 +104,15 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
 
     fun isFollowing(pubkey: String): Boolean {
         return contactRepo?.isFollowing(pubkey) ?: false
+    }
+
+    fun refresh(onRefresh: () -> Unit) {
+        _isRefreshing.value = true
+        onRefresh()
+        viewModelScope.launch {
+            delay(3000)
+            _isRefreshing.value = false
+        }
     }
 
     fun markRead() {


### PR DESCRIPTION
## Summary
- Adds Material3 `PullToRefreshBox` to the feed and notifications screens
- Pull-down closes all existing subscriptions and re-creates them from scratch, recovering from stale relay connections where the socket is alive but events stop flowing
- Refresh indicator shows for 3 seconds while events stream in, avoiding long waits for full EOSE across 64+ relays

## Test plan
- [ ] Pull down on feed screen — spinner appears for ~3s, feed clears and repopulates with fresh notes
- [ ] Pull down on notifications screen — same behavior, notifications re-fetch
- [ ] Verify normal scrolling is unaffected (no accidental refresh triggers)