### PR TITLE
Fix notifications not refreshing on app resume

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -142,10 +142,10 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         onReconnected = { force ->
             Log.d("RLC", "[FeedVM] onReconnected(force=$force) feedType=${feedSub.feedType.value} selectedRelay=${feedSub.selectedRelay.value} feedSize=${eventRepo.feed.value.size}")
             feedSub.subscribeFeed()
+            val myPubkey = getUserPubkey()
+            if (myPubkey != null) startup.subscribeDmsAndNotifications(myPubkey)
             if (force) {
                 startup.fetchRelayListsForFollows()
-                val myPubkey = getUserPubkey()
-                if (myPubkey != null) startup.subscribeDmsAndNotifications(myPubkey)
             }
         }
     )


### PR DESCRIPTION
## Summary
- `subscribeDmsAndNotifications()` was only called on force reconnects (pause >= 30s), so returning from a short pause while on the notifications screen showed stale data
- Moved the call outside the `if (force)` block so notifications and DMs re-subscribe on every app resume, matching the feed's behavior

## Test plan
- [ ] Open notifications screen, minimize app for < 30s, reopen — notifications should refresh
- [ ] Open notifications screen, minimize app for > 30s, reopen — notifications should refresh
- [ ] Open feed screen, minimize and reopen — feed still refreshes as before