### PR TITLE
Add on-device translation to feed posts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,4 +70,7 @@ dependencies {
     implementation(libs.zxing.core)
     implementation(libs.kmp.tor.runtime)
     implementation(libs.kmp.tor.resource.exec)
+    implementation(libs.mlkit.translate)
+    implementation(libs.mlkit.language.id)
+    implementation(libs.kotlinx.coroutines.play.services)
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,6 +45,10 @@
 -keep class io.matthewnelson.kmp.tor.** { *; }
 -dontwarn io.matthewnelson.kmp.tor.**
 
+# ML Kit
+-keep class com.google.mlkit.** { *; }
+-dontwarn com.google.mlkit.**
+
 # java.lang.management (not available on Android)
 -dontwarn java.lang.management.ManagementFactory
 -dontwarn java.lang.management.RuntimeMXBean

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -717,7 +717,8 @@ fun WispNavHost(
                 onDeleteEvent = { eventId, kind -> feedViewModel.deleteEvent(eventId, kind) },
                 onAddNoteToList = { eventId -> addToListEventId = eventId },
                 onSendDm = if (!isOwnProfile) {{ navController.navigate("dm/$pubkey") }} else null,
-                signer = activeSigner
+                signer = activeSigner,
+                translationRepo = feedViewModel.translationRepo
             )
         }
 
@@ -761,7 +762,8 @@ fun WispNavHost(
                 userPubkey = feedViewModel.getUserPubkey(),
                 listedIds = searchListedIds,
                 onAddToList = { eventId -> addToListEventId = eventId },
-                onDeleteEvent = { eventId, kind -> feedViewModel.deleteEvent(eventId, kind) }
+                onDeleteEvent = { eventId, kind -> feedViewModel.deleteEvent(eventId, kind) },
+                translationRepo = feedViewModel.translationRepo
             )
         }
 
@@ -915,7 +917,8 @@ fun WispNavHost(
                 onAddToList = { eventId -> addToListEventId = eventId },
                 onHashtagClick = { tag ->
                     navController.navigate("hashtag/${java.net.URLEncoder.encode(tag, "UTF-8")}")
-                }
+                },
+                translationRepo = feedViewModel.translationRepo
             )
         }
 
@@ -971,6 +974,7 @@ fun WispNavHost(
                 userPubkey = feedViewModel.getUserPubkey(),
                 noteActions = hashtagNoteActions,
                 nip05Repo = feedViewModel.nip05Repo,
+                translationRepo = feedViewModel.translationRepo,
                 onBack = { navController.popBackStack() }
             )
         }
@@ -1189,7 +1193,8 @@ fun WispNavHost(
                     feedViewModel.removeNoteFromBookmarkSet(dTag, eventId)
                 } else null,
                 onToggleFollow = { pubkey -> feedViewModel.toggleFollow(pubkey) },
-                onBlockUser = { pubkey -> feedViewModel.blockUser(pubkey) }
+                onBlockUser = { pubkey -> feedViewModel.blockUser(pubkey) },
+                translationRepo = feedViewModel.translationRepo
             )
         }
 
@@ -1326,7 +1331,8 @@ fun WispNavHost(
                 unicodeEmojis = notifUnicodeEmojis,
                 onManageEmojis = { navController.navigate(Routes.CUSTOM_EMOJIS) },
                 zapError = feedViewModel.zapError,
-                onRefresh = { feedViewModel.refreshDmsAndNotifications() }
+                onRefresh = { feedViewModel.refreshDmsAndNotifications() },
+                translationRepo = feedViewModel.translationRepo
             )
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/repo/TranslationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/TranslationRepository.kt
@@ -1,0 +1,135 @@
+package com.wisp.app.repo
+
+import com.google.mlkit.nl.languageid.LanguageIdentification
+import com.google.mlkit.nl.translate.TranslateLanguage
+import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.TranslatorOptions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+enum class TranslationStatus {
+    IDLE,
+    IDENTIFYING_LANGUAGE,
+    DOWNLOADING_MODEL,
+    TRANSLATING,
+    DONE,
+    ERROR,
+    SAME_LANGUAGE
+}
+
+data class TranslationState(
+    val status: TranslationStatus = TranslationStatus.IDLE,
+    val translatedText: String = "",
+    val sourceLanguage: String = "",
+    val targetLanguage: String = "",
+    val errorMessage: String = ""
+)
+
+class TranslationRepository {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val cache = ConcurrentHashMap<String, TranslationState>()
+
+    private val _version = MutableStateFlow(0)
+    val version: StateFlow<Int> = _version
+
+    fun getState(eventId: String): TranslationState =
+        cache[eventId] ?: TranslationState()
+
+    fun translate(eventId: String, content: String) {
+        val current = cache[eventId]
+        if (current != null && current.status != TranslationStatus.ERROR) return
+
+        val targetTag = TranslateLanguage.fromLanguageTag(Locale.getDefault().language)
+        if (targetTag == null) {
+            cache[eventId] = TranslationState(
+                status = TranslationStatus.ERROR,
+                errorMessage = "Unsupported target language"
+            )
+            _version.value++
+            return
+        }
+
+        cache[eventId] = TranslationState(status = TranslationStatus.IDENTIFYING_LANGUAGE)
+        _version.value++
+
+        scope.launch {
+            try {
+                val identifier = LanguageIdentification.getClient()
+                val detectedTag = identifier.identifyLanguage(content).await()
+
+                if (detectedTag == "und") {
+                    cache[eventId] = TranslationState(
+                        status = TranslationStatus.ERROR,
+                        errorMessage = "Could not detect language"
+                    )
+                    _version.value++
+                    return@launch
+                }
+
+                val sourceTag = TranslateLanguage.fromLanguageTag(detectedTag)
+                if (sourceTag == null) {
+                    cache[eventId] = TranslationState(
+                        status = TranslationStatus.ERROR,
+                        errorMessage = "Unsupported source language: $detectedTag"
+                    )
+                    _version.value++
+                    return@launch
+                }
+
+                if (sourceTag == targetTag) {
+                    cache[eventId] = TranslationState(
+                        status = TranslationStatus.SAME_LANGUAGE,
+                        sourceLanguage = displayName(detectedTag),
+                        targetLanguage = displayName(Locale.getDefault().language)
+                    )
+                    _version.value++
+                    return@launch
+                }
+
+                cache[eventId] = TranslationState(
+                    status = TranslationStatus.DOWNLOADING_MODEL,
+                    sourceLanguage = displayName(detectedTag),
+                    targetLanguage = displayName(Locale.getDefault().language)
+                )
+                _version.value++
+
+                val options = TranslatorOptions.Builder()
+                    .setSourceLanguage(sourceTag)
+                    .setTargetLanguage(targetTag)
+                    .build()
+                val translator = Translation.getClient(options)
+
+                translator.downloadModelIfNeeded().await()
+
+                cache[eventId] = cache[eventId]!!.copy(status = TranslationStatus.TRANSLATING)
+                _version.value++
+
+                val result = translator.translate(content).await()
+
+                cache[eventId] = TranslationState(
+                    status = TranslationStatus.DONE,
+                    translatedText = result,
+                    sourceLanguage = displayName(detectedTag),
+                    targetLanguage = displayName(Locale.getDefault().language)
+                )
+                _version.value++
+            } catch (e: Exception) {
+                cache[eventId] = TranslationState(
+                    status = TranslationStatus.ERROR,
+                    errorMessage = e.message ?: "Translation failed"
+                )
+                _version.value++
+            }
+        }
+    }
+
+    private fun displayName(languageTag: String): String =
+        Locale(languageTag).displayLanguage
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -125,6 +125,7 @@ fun FeedScreen(
     val followList by viewModel.contactRepo.followList.collectAsState()
     val profileVersion by viewModel.eventRepo.profileVersion.collectAsState()
     val nip05Version by viewModel.nip05Repo.version.collectAsState()
+    val translationVersion by viewModel.translationRepo.version.collectAsState()
     val connectedCount by viewModel.relayPool.connectedCount.collectAsState()
     val listState = rememberLazyListState()
     LaunchedEffect(scrollToTopTrigger) {
@@ -648,7 +649,8 @@ fun FeedScreen(
                                         viewModel.setFeedType(FeedType.RELAY)
                                     },
                                     noteActions = noteActions,
-                                    onManageEmojis = onCustomEmojis
+                                    onManageEmojis = onCustomEmojis,
+                                    translationVersion = translationVersion
                                 )
                             }
                             if (initialLoadDone) {
@@ -724,7 +726,8 @@ private fun FeedItem(
     onDelete: () -> Unit = {},
     onRelayClick: (String) -> Unit = {},
     noteActions: NoteActions? = null,
-    onManageEmojis: (() -> Unit)? = null
+    onManageEmojis: (() -> Unit)? = null,
+    translationVersion: Int = 0
 ) {
     val profileData = remember(profileVersion, event.pubkey) {
         viewModel.eventRepo.getProfileData(event.pubkey)
@@ -781,6 +784,9 @@ private fun FeedItem(
     val eventReactionEmojiUrls = remember(reactionVersion, event.id) {
         viewModel.eventRepo.getReactionEmojiUrls(event.id)
     }
+    val translationState = remember(translationVersion, event.id) {
+        viewModel.translationRepo.getState(event.id)
+    }
     PostCard(
         event = event,
         profile = profileData,
@@ -824,7 +830,9 @@ private fun FeedItem(
         reactionEmojiUrls = eventReactionEmojiUrls,
         resolvedEmojis = resolvedEmojis,
         unicodeEmojis = unicodeEmojis,
-        onManageEmojis = onManageEmojis
+        onManageEmojis = onManageEmojis,
+        translationState = translationState,
+        onTranslate = { viewModel.translateEvent(event.id, event.content) }
     )
 }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/HashtagFeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/HashtagFeedScreen.kt
@@ -30,6 +30,7 @@ import com.wisp.app.ui.component.NoteActions
 import com.wisp.app.ui.component.PostCard
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.Nip05Repository
+import com.wisp.app.repo.TranslationRepository
 import com.wisp.app.viewmodel.HashtagFeedViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -40,6 +41,7 @@ fun HashtagFeedScreen(
     userPubkey: String?,
     noteActions: NoteActions,
     nip05Repo: Nip05Repository? = null,
+    translationRepo: TranslationRepository? = null,
     onBack: () -> Unit
 ) {
     val hashtag by viewModel.hashtag.collectAsState()
@@ -99,7 +101,8 @@ fun HashtagFeedScreen(
                         zapVersion = zapVersion,
                         repostVersion = repostVersion,
                         noteActions = noteActions,
-                        nip05Repo = nip05Repo
+                        nip05Repo = nip05Repo,
+                        translationRepo = translationRepo
                     )
                 }
             }
@@ -118,7 +121,8 @@ private fun HashtagFeedItem(
     zapVersion: Int,
     repostVersion: Int,
     noteActions: NoteActions,
-    nip05Repo: Nip05Repository? = null
+    nip05Repo: Nip05Repository? = null,
+    translationRepo: TranslationRepository? = null
 ) {
     val profile = remember(profileVersion, event.pubkey) {
         eventRepo.getProfileData(event.pubkey)
@@ -156,6 +160,10 @@ private fun HashtagFeedItem(
     val reactionEmojiUrls = remember(reactionVersion, event.id) {
         eventRepo.getReactionEmojiUrls(event.id)
     }
+    val translationVersion by translationRepo?.version?.collectAsState() ?: remember { androidx.compose.runtime.mutableIntStateOf(0) }
+    val translationState = remember(translationVersion, event.id) {
+        translationRepo?.getState(event.id) ?: com.wisp.app.repo.TranslationState()
+    }
 
     PostCard(
         event = event,
@@ -190,6 +198,8 @@ private fun HashtagFeedItem(
         onPin = { noteActions.onPin(event.id) },
         onDelete = { noteActions.onDelete(event.id, event.kind) },
         onQuotedNoteClick = noteActions.onNoteClick,
-        noteActions = noteActions
+        noteActions = noteActions,
+        translationState = translationState,
+        onTranslate = { translationRepo?.translate(event.id, event.content) }
     )
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
@@ -45,6 +45,7 @@ import com.wisp.app.repo.ContactRepository
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.Nip05Repository
 import com.wisp.app.repo.RelayInfoRepository
+import com.wisp.app.repo.TranslationRepository
 import com.wisp.app.ui.component.NoteActions
 import com.wisp.app.ui.component.PostCard
 import com.wisp.app.viewmodel.ThreadViewModel
@@ -78,7 +79,8 @@ fun ThreadScreen(
     onTogglePin: (String) -> Unit = {},
     onDeleteEvent: (String, Int) -> Unit = { _, _ -> },
     onAddToList: (String) -> Unit = {},
-    onHashtagClick: ((String) -> Unit)? = null
+    onHashtagClick: ((String) -> Unit)? = null,
+    translationRepo: TranslationRepository? = null
 ) {
     val flatThread by viewModel.flatThread.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
@@ -120,6 +122,7 @@ fun ThreadScreen(
     val repostVersion by eventRepo.repostVersion.collectAsState()
     val relaySourceVersion by eventRepo.relaySourceVersion.collectAsState()
     val nip05Version by nip05Repo?.version?.collectAsState() ?: remember { mutableIntStateOf(0) }
+    val translationVersion by translationRepo?.version?.collectAsState() ?: remember { mutableIntStateOf(0) }
     val followList by contactRepo.followList.collectAsState()
 
     val noteActions = remember(userPubkey) {
@@ -189,6 +192,9 @@ fun ThreadScreen(
                                 url to relayInfoRepo?.getIconUrl(url)
                             }
                         }
+                        val translationState = remember(translationVersion, event.id) {
+                            translationRepo?.getState(event.id) ?: com.wisp.app.repo.TranslationState()
+                        }
                         PostCard(
                             event = event,
                             profile = profileData,
@@ -228,6 +234,8 @@ fun ThreadScreen(
                             nip05Repo = nip05Repo,
                             onQuotedNoteClick = onQuotedNoteClick,
                             noteActions = noteActions,
+                            translationState = translationState,
+                            onTranslate = { translationRepo?.translate(event.id, event.content) },
                             modifier = Modifier.padding(start = (min(depth, 4) * 24).dp)
                         )
                     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -38,6 +38,7 @@ import com.wisp.app.repo.CustomEmojiRepository
 import com.wisp.app.repo.ZapPreferences
 import com.wisp.app.repo.RelayHintStore
 import com.wisp.app.repo.RelayInfoRepository
+import com.wisp.app.repo.TranslationRepository
 import com.wisp.app.repo.RelayListRepository
 import com.wisp.app.repo.RelaySetRepository
 import com.wisp.app.repo.ZapSender
@@ -154,6 +155,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         app, contactRepo, muteRepo, relayListRepo, relayPool, subManager, relayScoreBoard, pubkeyHex, socialGraphDb
     )
     val customEmojiRepo = CustomEmojiRepository(app, pubkeyHex)
+    val translationRepo = TranslationRepository()
     val zapPrefs = ZapPreferences(app, pubkeyHex)
     private val processingDispatcher = Dispatchers.Default
 
@@ -231,6 +233,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
 
     fun getUserPubkey(): String? = keyRepo.getPubkeyHex()
     fun resetNewNoteCount() = eventRepo.resetNewNoteCount()
+    fun translateEvent(eventId: String, content: String) = translationRepo.translate(eventId, content)
     fun queueProfileFetch(pubkey: String) = metadataFetcher.queueProfileFetch(pubkey)
     fun forceProfileFetch(pubkey: String) = metadataFetcher.forceProfileFetch(pubkey)
     fun markLoadingComplete() = feedSub.markLoadingComplete()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ splashscreen = "1.0.1"
 zxing = "3.5.3"
 kmp-tor = "2.0.0"
 kmp-tor-resource = "408.12.0"
+mlkit-translate = "17.0.3"
+mlkit-language-id = "17.0.6"
 activity-compose = "1.9.3"
 navigation-compose = "2.8.5"
 lifecycle = "2.8.7"
@@ -47,6 +49,9 @@ splashscreen = { group = "androidx.core", name = "core-splashscreen", version.re
 zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing" }
 kmp-tor-runtime = { group = "io.matthewnelson.kmp-tor", name = "runtime", version.ref = "kmp-tor" }
 kmp-tor-resource-exec = { group = "io.matthewnelson.kmp-tor", name = "resource-exec-tor", version.ref = "kmp-tor-resource" }
+mlkit-translate = { group = "com.google.mlkit", name = "translate", version.ref = "mlkit-translate" }
+mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version.ref = "mlkit-language-id" }
+kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Adds a "Translate" option to the 3-dot overflow menu on every post, using Google ML Kit for on-device translation
- Detects source language automatically, downloads translation models on first use (~30MB per language pair), works offline after that
- Displays translated text inline below the original content with a "Translated from {language}" label
- Menu toggles between "Translate" / "Show Original" / "Show Translation" once translated, shows "Same Language" when source matches device locale
- Translation state cached by event ID via `TranslationRepository` following the existing `Nip05Repository` version-counter pattern

## Test plan
- [ ] Build succeeds with `./gradlew assembleDebug`
- [ ] Open feed with foreign-language posts, tap 3-dot menu → "Translate"
- [ ] Verify progress states show inline (detecting language → downloading model → translating)
- [ ] Translated text appears below original with "Translated from {language}" header
- [ ] Menu changes to "Show Original" after translation; toggling hides/shows translation
- [ ] Same-language posts show disabled "Same Language" menu item
- [ ] Translation persists when scrolling away and back
- [ ] Translation works on all screens: feed, thread, profile, notifications, search, hashtag feed, bookmark sets