### PR TITLE
fix: respect NIP-09 deletion events from relays

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -386,7 +386,7 @@ class OutboxRouter(
 
         for ((relayUrl, eventIds) in relayToEventIds) {
             val uniqueIds = eventIds.distinct()
-            val filter = Filter(kinds = listOf(1, 6, 7, 9735), eTags = uniqueIds, limit = 500)
+            val filter = Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = uniqueIds, limit = 500)
             if (relayPool.sendToRelayOrEphemeral(relayUrl, ClientMessage.req(prefix, filter))) {
                 targetedRelays.add(relayUrl)
             }
@@ -395,7 +395,7 @@ class OutboxRouter(
         // Fallback: authors without known relay lists → send to our read relays
         if (fallbackEventIds.isNotEmpty()) {
             val uniqueIds = fallbackEventIds.distinct()
-            val filter = Filter(kinds = listOf(1, 6, 7, 9735), eTags = uniqueIds, limit = 500)
+            val filter = Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = uniqueIds, limit = 500)
             relayPool.sendToReadRelays(ClientMessage.req(prefix, filter))
         }
 
@@ -404,7 +404,7 @@ class OutboxRouter(
         if (safetyNetRelays.isNotEmpty()) {
             val allEventIds = eventsByAuthor.values.flatten().distinct()
             if (allEventIds.isNotEmpty()) {
-                val filter = Filter(kinds = listOf(1, 6, 7, 9735), eTags = allEventIds, limit = 500)
+                val filter = Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = allEventIds, limit = 500)
                 val msg = ClientMessage.req(prefix, filter)
                 for (url in safetyNetRelays) {
                     if (relayPool.sendToRelayOrEphemeral(url, msg)) {

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -210,8 +210,11 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             5 -> {
                 val deletedIds = Nip09.getDeletedEventIds(event)
                 for (id in deletedIds) {
-                    deletedEventsRepo?.markDeleted(id)
-                    removeEvent(id)
+                    val target = eventCache.get(id)
+                    if (target == null || target.pubkey == event.pubkey) {
+                        deletedEventsRepo?.markDeleted(id)
+                        removeEvent(id)
+                    }
                 }
             }
             7 -> addReaction(event)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -63,6 +63,7 @@ class EventRouter(
             val myPubkey = getUserPubkey()
             if (myPubkey != null) {
                 when (event.kind) {
+                    5 -> eventRepo.addEvent(event)
                     6 -> eventRepo.addEvent(event)
                     7, 9735 -> eventRepo.addEvent(event)
                     1 -> {
@@ -114,6 +115,7 @@ class EventRouter(
             return
         } else if (subscriptionId.startsWith("engage") || subscriptionId.startsWith("user-engage")) {
             when (event.kind) {
+                5 -> eventRepo.addEvent(event)
                 6 -> eventRepo.addEvent(event)
                 7 -> eventRepo.addEvent(event)
                 9735 -> {


### PR DESCRIPTION
## Summary
- Add kind 5 to engagement subscription filters so deletion events are fetched from relays
- Route kind 5 events through notification and engagement handlers in EventRouter
- Add author validation before honoring deletions — only delete events where the author matches, preventing malicious kind 5 events from removing other users' events

## Test plan
- [ ] Publish a note, then delete it from another client — verify it disappears from the feed
- [ ] Verify that a kind 5 event from a different author does not remove someone else's note
- [ ] Confirm reactions, reposts, and zaps still work correctly with the updated filters