### PR TITLE
Fix custom emojis not loading in thread view emoji picker

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -867,6 +867,8 @@ fun WispNavHost(
             }
             val threadListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
             val threadPinnedIds by feedViewModel.pinRepo.pinnedIds.collectAsState()
+            val threadResolvedEmojis by feedViewModel.customEmojiRepo.resolvedEmojis.collectAsState()
+            val threadUnicodeEmojis by feedViewModel.customEmojiRepo.unicodeEmojis.collectAsState()
             ThreadScreen(
                 viewModel = threadViewModel,
                 eventRepo = feedViewModel.eventRepo,
@@ -918,7 +920,10 @@ fun WispNavHost(
                 onHashtagClick = { tag ->
                     navController.navigate("hashtag/${java.net.URLEncoder.encode(tag, "UTF-8")}")
                 },
-                translationRepo = feedViewModel.translationRepo
+                translationRepo = feedViewModel.translationRepo,
+                resolvedEmojis = threadResolvedEmojis,
+                unicodeEmojis = threadUnicodeEmojis,
+                onManageEmojis = { navController.navigate(Routes.CUSTOM_EMOJIS) }
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
@@ -80,7 +80,10 @@ fun ThreadScreen(
     onDeleteEvent: (String, Int) -> Unit = { _, _ -> },
     onAddToList: (String) -> Unit = {},
     onHashtagClick: ((String) -> Unit)? = null,
-    translationRepo: TranslationRepository? = null
+    translationRepo: TranslationRepository? = null,
+    resolvedEmojis: Map<String, String> = emptyMap(),
+    unicodeEmojis: List<String> = emptyList(),
+    onManageEmojis: (() -> Unit)? = null
 ) {
     val flatThread by viewModel.flatThread.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
@@ -220,6 +223,9 @@ fun ThreadScreen(
                             zapDetails = zapDetailsList,
                             repostDetails = repostPubkeys,
                             reactionEmojiUrls = eventReactionEmojiUrls,
+                            resolvedEmojis = resolvedEmojis,
+                            unicodeEmojis = unicodeEmojis,
+                            onManageEmojis = onManageEmojis,
                             relayIcons = relayIcons,
                             onNavigateToProfileFromDetails = onProfileClick,
                             onFollowAuthor = { onToggleFollow(event.pubkey) },


### PR DESCRIPTION
## Summary
- ThreadScreen was not passing `resolvedEmojis`, `unicodeEmojis`, or `onManageEmojis` to PostCard, so the emoji picker only showed the 5 default unicode emojis
- Collect custom emoji state from `customEmojiRepo` and pass it through to PostCard in thread view, matching the feed view behavior

## Test plan
- [ ] Open a thread view and tap the reaction button
- [ ] Verify custom image emojis and unicode shortcuts appear in the picker
- [ ] Verify the "Manage" button navigates to the custom emoji screen
- [ ] Confirm feed view emoji picker still works as before