### PR TITLE
fix: filter reposts against mute list

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -187,6 +187,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                 if (event.content.isNotBlank()) {
                     try {
                         val inner = fromJson(event.content)
+                        if (muteRepo?.isBlocked(inner.pubkey) == true) return
+                        if (muteRepo?.containsMutedWord(inner.content) == true) return
                         val authors = repostAuthors.get(inner.id)
                             ?: mutableSetOf<String>().also { repostAuthors.put(inner.id, it) }
                         authors.add(event.pubkey)


### PR DESCRIPTION
## Summary
- Kind 6 reposts were bypassing mute/block filters — only the reposter's pubkey was checked, not the inner event's author or content
- Add `isBlocked()` and `containsMutedWord()` checks on the parsed inner event before repost tracking or feed insertion

## Test plan
- [ ] Block a user, verify their posts don't appear even when reposted by a followed user
- [ ] Add a muted word, verify reposts containing that word are hidden
- [ ] Verify normal reposts from non-blocked users still appear correctly