### PR TITLE
fix: relay and blossom server lists not showing on first launch

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -400,6 +400,8 @@ fun WispNavHost(
                         }
                     } else {
                         feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        blossomServersViewModel.reload()
                         // Start relay connections immediately so TCP/TLS handshakes
                         // run in parallel with the onboarding welcome animation
                         feedViewModel.initRelays()
@@ -1243,6 +1245,8 @@ fun WispNavHost(
                     )
                     feedViewModel.setFeedType(FeedType.EXTENDED_FOLLOWS)
                     feedViewModel.reloadForNewAccount()
+                    relayViewModel.reload()
+                    blossomServersViewModel.reload()
                     feedViewModel.initRelays()
                     walletViewModel.refreshState()
                     navController.navigate(Routes.LOADING) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/BlossomServersViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/BlossomServersViewModel.kt
@@ -31,6 +31,11 @@ class BlossomServersViewModel(app: Application) : AndroidViewModel(app) {
     private val _published = MutableStateFlow(false)
     val published: StateFlow<Boolean> = _published
 
+    /** Re-point prefs at the current user's file so flows pick up their server data. */
+    fun reload() {
+        blossomRepo.reload(keyRepo.getPubkeyHex())
+    }
+
     fun refreshServers() {
         blossomRepo.refreshFromPrefs()
     }


### PR DESCRIPTION
## Summary
- Relay lists (general, DM, search, blocked) and blossom media servers were blank on the relay/blossom settings screens after first login, but appeared correctly after app restart
- Root cause: `RelayViewModel` and `BlossomServersViewModel` each create their own `KeyRepository`/`BlossomRepository` instance, which were constructed before login with a null pubkey — pointing at the wrong SharedPreferences file (`wisp_prefs` instead of `wisp_prefs_<pubkey>`)
- Added `StateFlow`s + `OnSharedPreferenceChangeListener` to `KeyRepository` and `BlossomRepository` so relay data propagates reactively to the UI
- Added `reload()` to `RelayViewModel` and `BlossomServersViewModel`, called from both login paths in Navigation
- Also targets indexer relays specifically for self-data fetch and adds timestamp dedup in `EventRouter` to prevent stale overwrites from slow relays

## Test plan
- [ ] Clear app data, log in with external signer, navigate to relay settings — all relay types should be populated immediately
- [ ] Clear app data, log in with external signer, navigate to blossom servers — servers should be populated immediately
- [ ] Verify relay editing (add/remove/toggle read-write) still works on relay settings screen
- [ ] Verify account switching still loads correct relay lists
- [ ] Check logcat for `subscribeSelfData: eoseCount=` — should show 3-4