### PR TITLE
fix: reset NWC connection state before reconnecting

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/NwcRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NwcRepository.kt
@@ -88,6 +88,11 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
         }
         connection = conn
 
+        // Reset state so ViewModel sees fresh false→true transitions and
+        // sendRequest() properly waits for negotiation/subscription setup
+        _isConnected.value = false
+        _isReady.value = false
+
         // Disconnect old relay if any
         relay?.disconnect()
 


### PR DESCRIPTION
## Summary
- Reset `_isConnected` and `_isReady` to `false` at the start of `NwcRepository.connect()` to prevent stale state from a previous connection causing a race condition
- Without the reset, the ViewModel's connection monitor would immediately trigger `fetchBalance()` on the stale `true` value, sending the balance request before the `nwc-responses` subscription was active — the wallet service's response was missed, leaving the UI stuck on the connecting screen

## Test plan
- [ ] Connect a wallet, navigate away, navigate back to wallet — balance should load
- [ ] Kill and relaunch the app with a saved NWC connection — wallet should connect and show balance
- [ ] Disconnect wallet, reconnect — should transition to balance screen without getting stuck