### PR TITLE
fix: wallet showing stale connecting state

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -97,6 +98,11 @@ fun WalletScreen(
 ) {
     val walletState by viewModel.walletState.collectAsState()
     val currentPage by viewModel.currentPage.collectAsState()
+
+    // Always refresh wallet state when this screen appears
+    LaunchedEffect(Unit) {
+        viewModel.refreshState()
+    }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),


### PR DESCRIPTION
## Summary
- Refresh wallet state every time the wallet screen appears via `LaunchedEffect`
- Stop regressing to "Connecting" when the NWC relay disconnects in the background — keep last known balance visible
- Add silent reconnect mode so re-establishing a dropped relay doesn't flash the connecting UI

## Test plan
- [ ] Open wallet screen with a connected NWC wallet — balance should load immediately
- [ ] Navigate away, wait for relay idle disconnect, navigate back — should show balance (not "Connecting")
- [ ] Send a zap from feed, then open wallet — balance should refresh without connecting state
- [ ] First-time wallet setup still shows proper connecting flow with status lines
- [ ] Connection timeout still shows error after 10s if relay is unreachable