### PR TITLE
fix: improve link rendering and detect wss:// relay URLs

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -931,6 +931,11 @@ fun WispNavHost(
                 onHashtagClick = { tag ->
                     navController.navigate("hashtag/${java.net.URLEncoder.encode(tag, "UTF-8")}")
                 },
+                onRelayClick = { url ->
+                    feedViewModel.setSelectedRelay(url)
+                    feedViewModel.setFeedType(FeedType.RELAY)
+                    navController.popBackStack(Routes.FEED, inclusive = false)
+                },
                 translationRepo = feedViewModel.translationRepo,
                 resolvedEmojis = threadResolvedEmojis,
                 unicodeEmojis = threadUnicodeEmojis,
@@ -981,6 +986,11 @@ fun WispNavHost(
                     nip05Repo = feedViewModel.nip05Repo,
                     onHashtagClick = { clickedTag ->
                         navController.navigate("hashtag/${java.net.URLEncoder.encode(clickedTag, "UTF-8")}")
+                    },
+                    onRelayClick = { url ->
+                        feedViewModel.setSelectedRelay(url)
+                        feedViewModel.setFeedType(FeedType.RELAY)
+                        navController.popBackStack(Routes.FEED, inclusive = false)
                     }
                 )
             }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -172,7 +172,11 @@ fun FeedScreen(
             isFollowing = { pubkey -> viewModel.contactRepo.isFollowing(pubkey) },
             userPubkey = userPubkey,
             nip05Repo = viewModel.nip05Repo,
-            onHashtagClick = onHashtagClick
+            onHashtagClick = onHashtagClick,
+            onRelayClick = { url ->
+                viewModel.setSelectedRelay(url)
+                viewModel.setFeedType(FeedType.RELAY)
+            }
         )
     }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
@@ -80,6 +80,7 @@ fun ThreadScreen(
     onDeleteEvent: (String, Int) -> Unit = { _, _ -> },
     onAddToList: (String) -> Unit = {},
     onHashtagClick: ((String) -> Unit)? = null,
+    onRelayClick: ((String) -> Unit)? = null,
     translationRepo: TranslationRepository? = null,
     resolvedEmojis: Map<String, String> = emptyMap(),
     unicodeEmojis: List<String> = emptyList(),
@@ -145,7 +146,8 @@ fun ThreadScreen(
             isFollowing = { pubkey -> contactRepo.isFollowing(pubkey) },
             userPubkey = userPubkey,
             nip05Repo = nip05Repo,
-            onHashtagClick = onHashtagClick
+            onHashtagClick = onHashtagClick,
+            onRelayClick = onRelayClick
         )
     }
 


### PR DESCRIPTION
## Summary
- URLs on their own line render as rich preview cards (existing behavior), while URLs mid-paragraph now render as inline clickable hyperlinks instead of breaking the reading flow with a full card
- `wss://` and `ws://` relay URLs are now detected by the URL regex and rendered as clickable links that open the relay feed
- Added `InlineLinkSegment` type to distinguish inline vs standalone link rendering

## Test plan
- [x] URL on its own line shows rich preview card
- [x] URL mid-paragraph shows as inline clickable hyperlink
- [x] `wss://relay.damus.io` renders as clickable link and opens relay feed
- [x] Image URLs mid-paragraph still render as images (block-level)