### PR TITLE
fix: clear quoteTarget in all onReply handlers to prevent stale quotes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -679,6 +679,7 @@ fun WispNavHost(
                 onBack = { navController.popBackStack() },
                 onReply = { event ->
                     replyTarget = event
+                    quoteTarget = null
                     composeViewModel.clear()
                     navController.navigate(Routes.COMPOSE)
                 },
@@ -755,6 +756,7 @@ fun WispNavHost(
                 },
                 onReply = { event ->
                     replyTarget = event
+                    quoteTarget = null
                     composeViewModel.clear()
                     navController.navigate(Routes.COMPOSE)
                 },
@@ -890,6 +892,7 @@ fun WispNavHost(
                 onBack = { navController.popBackStack() },
                 onReply = { event ->
                     replyTarget = event
+                    quoteTarget = null
                     composeViewModel.clear()
                     navController.navigate(Routes.COMPOSE)
                 },
@@ -1210,6 +1213,7 @@ fun WispNavHost(
                 onQuotedNoteClick = { eventId -> navController.navigate("thread/$eventId") },
                 onReply = { event ->
                     replyTarget = event
+                    quoteTarget = null
                     composeViewModel.clear()
                     navController.navigate(Routes.COMPOSE)
                 },
@@ -1332,6 +1336,7 @@ fun WispNavHost(
                 },
                 onReply = { event ->
                     replyTarget = event
+                    quoteTarget = null
                     composeViewModel.clear()
                     navController.navigate(Routes.COMPOSE)
                 },


### PR DESCRIPTION
## Summary
- Five `onReply` handlers (UserProfile, Search, Thread, BookmarkSet, Notifications) were missing `quoteTarget = null`, causing a previously quoted note to persist and reappear when the user later replies to a different note
- FeedScreen and HashtagScreen already cleared both targets correctly — this brings the remaining screens in line

## Test plan
- [ ] Quote a note and publish it
- [ ] Navigate to a thread/profile/search/notifications screen and tap Reply on a different note
- [ ] Verify the compose screen shows "Reply" (not "Quote") with no stale quote attached