### PR TITLE
fix: hide system bars in fullscreen video and survive rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/com/wisp/app/ui/component/FullScreenVideoPlayer.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/FullScreenVideoPlayer.kt
@@ -31,6 +31,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import android.app.Activity
+import android.content.ContextWrapper
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -63,6 +68,18 @@ fun FullScreenVideoPlayer(
 
         DisposableEffect(videoUrl) {
             onDispose { exoPlayer.release() }
+        }
+
+        DisposableEffect(Unit) {
+            val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
+            val window = activity.window
+            val insetsController = WindowCompat.getInsetsController(window, window.decorView)
+            insetsController.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            insetsController.hide(WindowInsetsCompat.Type.systemBars())
+            onDispose {
+                insetsController.show(WindowInsetsCompat.Type.systemBars())
+            }
         }
 
         Box(
@@ -119,4 +136,13 @@ fun FullScreenVideoPlayer(
             }
         }
     }
+}
+
+private fun android.content.Context.findActivity(): Activity? {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
 }


### PR DESCRIPTION
## Summary
- Hide system navigation and status bars when entering fullscreen video using immersive sticky mode (`WindowInsetsControllerCompat`), so the ExoPlayer timeline scrubber is no longer obscured by the nav bar
- Add `configChanges` to `MainActivity` so device rotation doesn't destroy the Activity and restart the video player — playback continues seamlessly in landscape
- System bars restore automatically when dismissing fullscreen, and can be temporarily revealed with an edge swipe

## Test plan
- [ ] Open a video and enter fullscreen — nav bar and status bar should be hidden
- [ ] Verify the timeline scrubber at the bottom is fully accessible
- [ ] Rotate device while in fullscreen — video should keep playing without interruption and fill the new dimensions
- [ ] Dismiss fullscreen — system bars should reappear
- [ ] Swipe from bottom edge in fullscreen — nav bar should appear briefly then auto-hide