### PR TITLE
feat: show broadcast progress when publishing notes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1,8 +1,12 @@
 package com.wisp.app
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import com.wisp.app.ui.screen.BroadcastStatusBar
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -385,10 +389,12 @@ fun WispNavHost(
         }
     ) { innerPadding ->
 
+    val broadcastState by feedViewModel.relayPool.broadcastState.collectAsState()
+
+    Box(modifier = Modifier.padding(innerPadding)) {
     NavHost(
         navController = navController,
-        startDestination = startDestination,
-        modifier = Modifier.padding(innerPadding)
+        startDestination = startDestination
     ) {
         composable(Routes.AUTH) {
             AuthScreen(
@@ -1364,6 +1370,14 @@ fun WispNavHost(
             )
         }
     }
+
+    BroadcastStatusBar(
+        broadcastState = broadcastState,
+        modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .padding(bottom = 16.dp)
+    )
+    } // Box
 
     } // Scaffold
 }

--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -271,14 +271,15 @@ class OutboxRouter(
      * Publish an event to own write relays AND the target user's read (inbox) relays.
      * Used for replies, reactions, and reposts so they reach the intended recipient.
      */
-    fun publishToInbox(eventMsg: String, targetPubkey: String) {
-        relayPool.sendToWriteRelays(eventMsg)
+    fun publishToInbox(eventMsg: String, targetPubkey: String): Int {
+        var sentCount = relayPool.sendToWriteRelays(eventMsg)
         val readRelays = relayListRepo.getReadRelays(targetPubkey)
         if (readRelays != null) {
             for (url in readRelays) {
-                relayPool.sendToRelayOrEphemeral(url, eventMsg)
+                if (relayPool.sendToRelayOrEphemeral(url, eventMsg)) sentCount++
             }
         }
+        return sentCount
     }
 
     /**

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -1,6 +1,8 @@
 package com.wisp.app.ui.screen
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
@@ -70,6 +72,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.ui.text.font.FontWeight
 import com.wisp.app.nostr.RelaySet
+import com.wisp.app.relay.BroadcastState
 import com.wisp.app.viewmodel.FeedType
 import com.wisp.app.viewmodel.FeedViewModel
 import com.wisp.app.viewmodel.InitLoadingState
@@ -1639,6 +1642,49 @@ private fun RelayFeedEmptyState(
             is RelayFeedStatus.Streaming, is RelayFeedStatus.Idle -> {
                 // Streaming with empty feed shouldn't normally happen, show spinner
                 CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            }
+        }
+    }
+}
+
+@Composable
+fun BroadcastStatusBar(
+    broadcastState: BroadcastState?,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = broadcastState != null,
+        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+        modifier = modifier
+    ) {
+        val state = broadcastState ?: return@AnimatedVisibility
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            shadowElevation = 2.dp
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (state.accepted < state.sent) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        strokeWidth = 1.5.dp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(
+                    text = if (state.accepted < state.sent) {
+                        "Broadcasting (${state.accepted}/${state.sent})"
+                    } else {
+                        "Published to ${state.accepted} relay${if (state.accepted != 1) "s" else ""}"
+                    },
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- Instead of fire-and-forget publishing, shows a floating toast with live relay confirmation count ("Broadcasting 0/5" → "Published to 5 relays")
- If no relays are connected, shows an error on the compose screen instead of silently navigating back
- Toast appears globally (all screens) so users can continue browsing while broadcast completes

## Test plan
- [ ] Publish a note normally — toast should appear at bottom showing relay confirmations, then fade
- [ ] Reply to a note — same broadcast toast on the thread screen
- [ ] Enable airplane mode, try to publish — should see error "No relays connected" and stay on compose screen
- [ ] Verify toast styling matches bottom nav color and is compact