### PR TITLE
fix: catch replies missed by p-tag notification filter

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -325,6 +325,14 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         }
     }
 
+    fun getRecentEventIdsByAuthor(pubkey: String, limit: Int = 50): List<String> {
+        return eventCache.snapshot().values
+            .filter { it.kind == 1 && it.pubkey == pubkey }
+            .sortedByDescending { it.created_at }
+            .take(limit)
+            .map { it.id }
+    }
+
     fun cacheEvent(event: NostrEvent) {
         if (eventCache.get(event.id) != null) return  // already cached
         seenEventIds.add(event.id)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -101,6 +101,18 @@ class EventRouter(
                     }
                 }
             }
+        } else if (subscriptionId == "notif-replies-etag") {
+            if (muteRepo.isBlocked(event.pubkey)) return
+            val myPubkey = getUserPubkey()
+            if (myPubkey != null && event.kind == 1) {
+                eventRepo.cacheEvent(event)
+                val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
+                if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+                notifRepo.addEvent(event, myPubkey, replyToMyEvent = true)
+                if (eventRepo.getProfileData(event.pubkey) == null) {
+                    metadataFetcher.addToPendingProfiles(event.pubkey)
+                }
+            }
         } else if (subscriptionId == "self-notes") {
             eventRepo.cacheEvent(event)
             if (event.kind == 1) {


### PR DESCRIPTION
## Summary
- Increase notification filter limit from 100 to 300 so reply events aren't crowded out by more numerous reactions/zaps
- Add secondary `notif-replies-etag` subscription using e-tags on the user's own recent posts, catching replies from clients that omit the p-tag
- Add `replyToMyEvent` bypass in NotificationRepository so e-tag-matched replies pass the p-tag gate
- Deduplicated via existing `seenEvents` LruCache — no double-counting

## Test plan
- [ ] Build and install debug APK
- [ ] Verify `notif-replies-etag` subscription appears in Logcat
- [ ] Have another account reply to a post and confirm it appears in Notifications
- [ ] Verify reactions, zaps, and reposts still appear correctly
- [ ] Verify no duplicate notifications