### PR TITLE
Merge zaps into ReactionGroup to fix duplicate notification cards

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
@@ -21,20 +21,20 @@ sealed class NotificationGroup {
     abstract val groupId: String
     abstract val latestTimestamp: Long
 
+    companion object {
+        /** Sentinel key used in ReactionGroup.reactions to represent reposts. */
+        const val REPOST_EMOJI = "__repost__"
+        /** Sentinel key used in ReactionGroup.reactions to represent zaps. */
+        const val ZAP_EMOJI = "__zap__"
+    }
+
     data class ReactionGroup(
         override val groupId: String,
         val referencedEventId: String,
         val reactions: Map<String, List<String>>, // emoji -> list of pubkeys
         val reactionTimestamps: Map<String, Long> = emptyMap(), // pubkey -> created_at
         val emojiUrls: Map<String, String> = emptyMap(), // ":shortcode:" -> url for custom emojis
-        override val latestTimestamp: Long
-    ) : NotificationGroup()
-
-    data class ZapGroup(
-        override val groupId: String,
-        val referencedEventId: String,
-        val zaps: List<ZapEntry>,
-        val totalSats: Long,
+        val zapEntries: List<ZapEntry> = emptyList(),
         override val latestTimestamp: Long
     ) : NotificationGroup()
 
@@ -60,19 +60,4 @@ sealed class NotificationGroup {
         override val latestTimestamp: Long
     ) : NotificationGroup()
 
-    data class RepostNotification(
-        override val groupId: String,
-        val senderPubkey: String,
-        val repostEventId: String,
-        val repostedEventId: String,
-        override val latestTimestamp: Long
-    ) : NotificationGroup()
-
-    data class RepostGroup(
-        override val groupId: String,
-        val repostedEventId: String,
-        val reposters: List<String>, // pubkeys, newest first
-        val repostTimestamps: Map<String, Long>, // pubkey -> created_at
-        override val latestTimestamp: Long
-    ) : NotificationGroup()
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
@@ -86,9 +86,13 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
                     NotificationFilter.ALL -> notifs
                     NotificationFilter.REPLIES -> notifs.filterIsInstance<NotificationGroup.ReplyNotification>()
                     NotificationFilter.REACTIONS -> notifs.filterIsInstance<NotificationGroup.ReactionGroup>()
-                    NotificationFilter.ZAPS -> notifs.filterIsInstance<NotificationGroup.ZapGroup>()
+                    NotificationFilter.ZAPS -> notifs.filter {
+                        it is NotificationGroup.ReactionGroup &&
+                            NotificationGroup.ZAP_EMOJI in it.reactions
+                    }
                     NotificationFilter.REPOSTS -> notifs.filter {
-                        it is NotificationGroup.RepostNotification || it is NotificationGroup.RepostGroup
+                        it is NotificationGroup.ReactionGroup &&
+                            NotificationGroup.REPOST_EMOJI in it.reactions
                     }
                     NotificationFilter.MENTIONS -> notifs.filter {
                         it is NotificationGroup.MentionNotification || it is NotificationGroup.QuoteNotification


### PR DESCRIPTION
## Summary
- Merges `ZapGroup` into `ReactionGroup` using a `ZAP_EMOJI` sentinel key (same pattern as `REPOST_EMOJI`), fixing duplicate notification cards when a note receives both reactions and zaps
- Adds `zapEntries: List<ZapEntry>` field to `ReactionGroup` to preserve per-zap data (sats, message)
- Removes `ZapGroup` data class, `ZapGroupRow` composable, and all associated branching
- Zap rows render inside `ReactionGroupRow` in order: zaps → reposts → emoji reactions

## Test plan
- [ ] Receive reactions + zaps on the same note — single card with zap rows + reaction rows
- [ ] Old zap + recent reaction — zap should NOT appear in "recent" split
- [ ] ZAPS filter tab still shows relevant notifications
- [ ] Zap amounts and messages still display correctly
- [ ] Repost + zap + reaction on same note — all three sections render in correct order