### PR TITLE
refactor: merge zaps into reaction groups

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 3
-        versionName = "0.2.1"
+        versionCode = 4
+        versionName = "0.2.3"
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- Merged zaps into ReactionGroup to eliminate duplicate notification cards
- Bumped version to 0.2.3

## Test plan
- [ ] Verify notifications with reactions and zaps display in a single grouped card
- [ ] Verify zap amounts display correctly within the reaction group
- [ ] Confirm no duplicate notification cards appear