### PR TITLE
fix: reconnect write relays before failing to publish

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -416,6 +416,39 @@ class RelayPool {
     }
 
     /**
+     * Triggers connect() on any disconnected write relays and waits briefly
+     * for at least one to become connected. Returns the number of connected
+     * write relays after the wait.
+     */
+    suspend fun ensureWriteRelaysConnected(timeoutMs: Long = 5000): Int {
+        val writeRelays = relays.filter { it.config.write }
+        val alreadyConnected = writeRelays.count { it.isConnected }
+        if (alreadyConnected > 0) return alreadyConnected
+
+        Log.d("RLC", "[Pool] ensureWriteRelaysConnected — 0/${writeRelays.size} connected, triggering reconnect")
+        for (relay in writeRelays) {
+            if (!relay.isConnected) {
+                relay.resetBackoff()
+                relay.connect()
+            }
+        }
+
+        // Poll briefly for a write relay to connect
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val connected = writeRelays.count { it.isConnected }
+            if (connected > 0) {
+                Log.d("RLC", "[Pool] ensureWriteRelaysConnected — $connected write relay(s) now connected")
+                return connected
+            }
+            delay(200)
+        }
+        val final = writeRelays.count { it.isConnected }
+        Log.d("RLC", "[Pool] ensureWriteRelaysConnected — timed out, $final write relay(s) connected")
+        return final
+    }
+
+    /**
      * Start tracking OK responses for a published event.
      * Updates [broadcastState] as relays respond, then auto-clears after all respond or timeout.
      */

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -345,10 +345,21 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         }
         val event = signer.signEvent(kind = 1, content = finalContent, tags = tags)
         val msg = ClientMessage.event(event)
-        val sentCount = if (replyTo != null && outboxRouter != null) {
+        var sentCount = if (replyTo != null && outboxRouter != null) {
             outboxRouter.publishToInbox(msg, replyTo.pubkey)
         } else {
             relayPool.sendToWriteRelays(msg)
+        }
+        // If no relays were reachable, try reconnecting write relays and retry once
+        if (sentCount == 0) {
+            val reconnected = relayPool.ensureWriteRelaysConnected()
+            if (reconnected > 0) {
+                sentCount = if (replyTo != null && outboxRouter != null) {
+                    outboxRouter.publishToInbox(msg, replyTo.pubkey)
+                } else {
+                    relayPool.sendToWriteRelays(msg)
+                }
+            }
         }
         if (sentCount == 0) {
             _error.value = "No relays connected — note was not published"


### PR DESCRIPTION
## Summary
- Adds `RelayPool.ensureWriteRelaysConnected()` which triggers reconnection on disconnected write relays and waits up to 5s for at least one to come back
- When `publishNote` gets `sentCount == 0`, it now calls this method and retries once before showing the error
- Fixes an edge case where users with few write relays could not publish notes if their relays were temporarily disconnected, while reactions/zaps (which ignore send failures) appeared to work fine

## Test plan
- [ ] Verify normal publishing still works with connected relays (no delay added)
- [ ] Test with a user whose write relays are slow to connect — note should publish after brief reconnect
- [ ] Confirm the "No relays connected" error still shows if relays are truly unreachable after the 5s timeout