### PR TITLE
feat: repost badge with multiple avatars and timestamp

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -274,7 +274,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         val dedupSet = countedReactionIds.get(targetEventId)
             ?: mutableSetOf<String>().also { countedReactionIds.put(targetEventId, it) }
         synchronized(dedupSet) { if (!dedupSet.add(event.id)) return }
-        val emoji = event.content.ifBlank { "❤️" }
+        val emoji = if (event.content.isBlank() || event.content == "+") "❤️" else event.content
 
         // Cache custom emoji URLs from reaction event tags
         val emojiTags = Nip30.parseEmojiTags(event)
@@ -529,6 +529,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     }
 
     fun getRepostCount(eventId: String): Int = repostAuthors.get(eventId)?.size ?: 0
+
+    fun getRepostTime(eventId: String): Long? = feedSortTime.get(eventId)
 
     fun markUserRepost(eventId: String) {
         userReposts.put(eventId, true)

--- a/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
@@ -265,9 +265,10 @@ class MetadataFetcher(
             if (eventRepo.getProfileData(event.pubkey) == null) {
                 addToPendingProfiles(event.pubkey)
             }
-            val reposter = eventRepo.getRepostAuthor(event.id)
-            if (reposter != null && eventRepo.getProfileData(reposter) == null) {
-                addToPendingProfiles(reposter)
+            for (reposter in eventRepo.getReposterPubkeys(event.id).take(5)) {
+                if (eventRepo.getProfileData(reposter) == null) {
+                    addToPendingProfiles(reposter)
+                }
             }
             if (event.kind == 1 && event.id !in scannedQuoteEvents) {
                 scannedQuoteEvents.add(event.id)

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -95,7 +95,8 @@ fun PostCard(
     eventRepo: EventRepository? = null,
     relayIcons: List<Pair<String, String?>> = emptyList(),
     onRelayClick: (String) -> Unit = {},
-    repostedBy: String? = null,
+    repostPubkeys: List<String> = emptyList(),
+    repostTime: Long? = null,
     reactionDetails: Map<String, List<String>> = emptyMap(),
     zapDetails: List<Triple<String, Long, String>> = emptyList(),
     onNavigateToProfileFromDetails: ((String) -> Unit)? = null,
@@ -145,10 +146,16 @@ fun PostCard(
             .clickable(onClick = onNoteClick)
             .padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
-        if (repostedBy != null) {
+        if (repostPubkeys.isNotEmpty()) {
+            val maxAvatars = 10
+            val displayPubkeys = repostPubkeys.take(maxAvatars)
+            val overflow = repostPubkeys.size - maxAvatars
+            val formattedRepostTime = repostTime?.let { formatTimestamp(it) }
+
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(start = 40.dp, bottom = 4.dp)
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp)
             ) {
                 Icon(
                     Icons.Outlined.Repeat,
@@ -157,11 +164,47 @@ fun PostCard(
                     modifier = Modifier.size(14.dp)
                 )
                 Spacer(Modifier.width(4.dp))
+
+                // Overlapping avatars
+                Box(modifier = Modifier.height(20.dp).width((displayPubkeys.size * 14 + 6 + 4).dp)) {
+                    displayPubkeys.forEachIndexed { index, pubkey ->
+                        val avatarUrl = eventRepo?.getProfileData(pubkey)?.picture
+                        Box(modifier = Modifier.offset(x = (index * 14).dp)) {
+                            ProfilePicture(
+                                url = avatarUrl,
+                                size = 20,
+                                showFollowBadge = false,
+                                onClick = { onNavigateToProfileFromDetails?.invoke(pubkey) }
+                            )
+                        }
+                    }
+                }
+
+                // Label text
+                val labelText = if (repostPubkeys.size == 1) {
+                    val name = eventRepo?.getProfileData(repostPubkeys.first())?.displayString
+                        ?: (repostPubkeys.first().take(8) + "...")
+                    "$name retweeted"
+                } else if (overflow > 0) {
+                    "and $overflow others retweeted"
+                } else {
+                    "retweeted"
+                }
                 Text(
-                    text = "$repostedBy retweeted",
+                    text = labelText,
                     style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
+
+                if (formattedRepostTime != null) {
+                    Text(
+                        text = " \u00B7 $formattedRepostTime",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
             }
         }
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -756,14 +756,8 @@ private fun FeedItem(
             url to viewModel.relayInfoRepo.getIconUrl(url)
         }
     }
-    val repostAuthorPubkey = remember(event.id) {
-        viewModel.eventRepo.getRepostAuthor(event.id)
-    }
-    val repostedByName = remember(repostAuthorPubkey, profileVersion) {
-        repostAuthorPubkey?.let { pk ->
-            viewModel.eventRepo.getProfileData(pk)?.displayString
-                ?: pk.take(8) + "..."
-        }
+    val repostTime = remember(repostVersion, event.id) {
+        viewModel.eventRepo.getRepostTime(event.id)
     }
     val reactionDetails = remember(reactionVersion, event.id) {
         viewModel.eventRepo.getReactionDetails(event.id)
@@ -816,7 +810,8 @@ private fun FeedItem(
         isZapInProgress = isZapInProgress,
         eventRepo = viewModel.eventRepo,
         relayIcons = relayIcons,
-        repostedBy = repostedByName,
+        repostPubkeys = repostPubkeys,
+        repostTime = repostTime,
         reactionDetails = reactionDetails,
         zapDetails = zapDetails,
         repostDetails = repostPubkeys,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -404,9 +404,8 @@ fun UserProfileScreen(
                                 } ?: emptyList()
                             }
                             val repostPubkey = viewModel.repostAuthors[event.id]
-                            val repostedByName = repostPubkey?.let { pk ->
-                                eventRepo?.getProfileData(pk)?.displayString
-                                    ?: pk.take(8) + "..."
+                            val profileRepostPubkeys = remember(repostPubkey) {
+                                if (repostPubkey != null) listOf(repostPubkey) else emptyList()
                             }
                             val hasUserReposted = eventRepo?.hasUserReposted(event.id) == true
                             val hasUserZapped = zapVersion.let { eventRepo?.hasUserZapped(event.id) == true }
@@ -435,7 +434,7 @@ fun UserProfileScreen(
                                 isZapAnimating = event.id in zapAnimatingIds,
                                 isZapInProgress = event.id in zapInProgressIds,
                                 eventRepo = eventRepo,
-                                repostedBy = repostedByName,
+                                repostPubkeys = profileRepostPubkeys,
                                 reactionDetails = reactionDetails,
                                 zapDetails = zapDetails,
                                 reactionEmojiUrls = eventReactionEmojiUrls,


### PR DESCRIPTION
## Summary
- Replace single-name repost badge with up to 10 overlapping reposter avatars, overflow count ("and N others retweeted"), and relative repost timestamp
- Centered badge layout that expands naturally with more avatars
- MetadataFetcher now prefetches profiles for up to 5 reposters (previously only the first)
- Normalize "+" reaction content to heart emoji

## Test plan
- [ ] View feed with reposted notes — verify avatars display with count and timestamp
- [ ] Verify single-reposter case shows display name fallback
- [ ] Verify badge doesn't break for notes with no reposts
- [ ] Check UserProfileScreen repost badges still work