### PR TITLE
fix: isolate relay feed from main feed pipeline

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -263,13 +263,13 @@ class RelayPool {
                         if (shouldEmit) {
                             _events.tryEmit(msg.event)
                             _relayEvents.tryEmit(RelayEvent(msg.event, relay.config.url, msg.subscriptionId))
-                            if (msg.subscriptionId == "feed") {
+                            if (msg.subscriptionId.startsWith("feed")) {
                                 val count = ++feedEventCounter
                                 if (count == 1 || count % 50 == 0) {
                                     Log.d("RLC", "[Pool] feed event #$count: kind=${msg.event.kind} from=${msg.event.pubkey.take(8)} relay=${relay.config.url}")
                                 }
                             }
-                        } else if (msg.subscriptionId == "feed") {
+                        } else if (msg.subscriptionId.startsWith("feed")) {
                             val count = ++feedEventDedupCounter
                             if (count == 1 || count % 50 == 0) {
                                 Log.d("RLC", "[Pool] feed event DEDUPED #$count: kind=${msg.event.kind} from=${msg.event.pubkey.take(8)}")
@@ -279,7 +279,7 @@ class RelayPool {
                         unsupportedCounts.remove(relay.config.url) // Relay works, clear counter
                     }
                     is RelayMessage.Eose -> {
-                        if (msg.subscriptionId == "feed") {
+                        if (msg.subscriptionId.startsWith("feed")) {
                             Log.d("RLC", "[Pool] feed EOSE from ${relay.config.url} (total feed events=$feedEventCounter deduped=$feedEventDedupCounter)")
                         }
                         _eoseSignals.tryEmit(msg.subscriptionId)
@@ -613,7 +613,9 @@ class RelayPool {
         }
 
         // Create ephemeral relay if needed — computeIfAbsent is atomic on ConcurrentHashMap
+        var isNew = false
         val ephemeral = ephemeralRelays.computeIfAbsent(url) {
+            isNew = true
             val relay = Relay(RelayConfig(url, read = true, write = false), client, scope)
             relay.autoReconnect = false
             wireByteTracking(relay)
@@ -629,8 +631,8 @@ class RelayPool {
             trackSubscription(url, subId, message)
         }
         ephemeralLastUsed[url] = System.currentTimeMillis()
-        ephemeral.send(message)
-        return true
+        val sent = ephemeral.send(message)
+        return sent || isNew  // new relays will drain queue on connect
     }
 
     private fun cooldownForFailure(httpCode: Int?): Long {
@@ -801,7 +803,7 @@ class RelayPool {
 
     fun closeOnAllRelays(subscriptionId: String) {
         Log.d("RLC", "[Pool] closeOnAllRelays($subscriptionId)")
-        if (subscriptionId == "feed") {
+        if (subscriptionId.startsWith("feed")) {
             Log.d("RLC", "[Pool] closing feed sub — total events=$feedEventCounter deduped=$feedEventDedupCounter")
             feedEventCounter = 0
             feedEventDedupCounter = 0
@@ -856,6 +858,11 @@ class RelayPool {
     fun getEphemeralCount(): Int = ephemeralRelays.size
 
     fun isRelayConnected(url: String): Boolean = relayIndex[url]?.isConnected == true
+
+    /** Clear cooldown for a specific relay so it can be retried immediately. */
+    fun clearCooldown(url: String) {
+        relayCooldowns.remove(url)
+    }
 
     /** Returns remaining cooldown in seconds, or 0 if not on cooldown. */
     fun getRelayCooldownRemaining(url: String): Int {

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -29,6 +29,12 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     private val _feed = MutableStateFlow<List<NostrEvent>>(emptyList())
     val feed: StateFlow<List<NostrEvent>> = _feed
 
+    // Isolated relay feed state — completely separate from the main feed pipeline
+    private val relayFeedList = mutableListOf<NostrEvent>()
+    private val relayFeedIds = HashSet<String>()
+    private val _relayFeed = MutableStateFlow<List<NostrEvent>>(emptyList())
+    val relayFeed: StateFlow<List<NostrEvent>> = _relayFeed
+
     // Author filter: null = show all, non-null = only show events from these pubkeys
     private val _authorFilter = MutableStateFlow<Set<String>?>(null)
 
@@ -96,6 +102,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val feedDirty = Channel<Unit>(Channel.CONFLATED)
     private val feedInserted = Channel<Unit>(Channel.CONFLATED)
+    private val relayFeedInserted = Channel<Unit>(Channel.CONFLATED)
     private val versionDirty = Channel<Unit>(Channel.CONFLATED)
 
     init {
@@ -111,6 +118,13 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                 _feed.value = if (filter == null) raw else raw.filter {
                     it.pubkey in filter || isRepostedByAny(it.id, filter)
                 }
+            }
+        }
+        // Relay feed emission — same 50ms settle pattern but for isolated relay feed
+        scope.launch {
+            for (signal in relayFeedInserted) {
+                delay(50)
+                _relayFeed.value = synchronized(relayFeedList) { relayFeedList.toList() }
             }
         }
         // Immediate emission channel — used for explicit flushes (purge, filter change, etc.)
@@ -345,10 +359,6 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                 markVersionDirty()
             }
         }
-        if (event.kind == 1) {
-            val isReply = event.tags.any { it.size >= 2 && it[0] == "e" }
-            if (!isReply) binaryInsert(event)
-        }
         _quotedEventVersion.value++
     }
 
@@ -357,6 +367,12 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         synchronized(feedList) {
             if (feedIds.remove(eventId)) {
                 feedList.removeAll { it.id == eventId }
+            }
+        }
+        synchronized(relayFeedList) {
+            if (relayFeedIds.remove(eventId)) {
+                relayFeedList.removeAll { it.id == eventId }
+                _relayFeed.value = relayFeedList.toList()
             }
         }
         feedDirty.trySend(Unit)
@@ -595,6 +611,12 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             feedList.removeAll { it.pubkey == pubkey }
             removed.forEach { feedIds.remove(it.id) }
         }
+        synchronized(relayFeedList) {
+            val removed = relayFeedList.filter { it.pubkey == pubkey }
+            relayFeedList.removeAll { it.pubkey == pubkey }
+            removed.forEach { relayFeedIds.remove(it.id) }
+            if (removed.isNotEmpty()) _relayFeed.value = relayFeedList.toList()
+        }
         // Evict from eventCache so blocked content doesn't appear in threads/quotes
         val snapshot = eventCache.snapshot()
         for ((id, event) in snapshot) {
@@ -625,22 +647,103 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             .take(limit)
     }
 
-    fun clearFeed() {
+    /**
+     * Clear only the display state (feedList, feedIds, feedSortTime) without touching
+     * seenEventIds or eventCache. This preserves dedup state so in-flight events from
+     * non-feed subscriptions are still rejected on feed switch.
+     */
+    fun resetFeedDisplay() {
         synchronized(feedList) {
             feedList.clear()
             feedIds.clear()
         }
-        eventCache.evictAll()
-        seenEventIds.clear()
         feedSortTime.evictAll()
         _feed.value = emptyList()
         _newNoteCount.value = 0
         countNewNotes = false
     }
 
+    // -- Isolated relay feed methods --
+
+    fun addRelayFeedEvent(event: NostrEvent) {
+        if (muteRepo?.isBlocked(event.pubkey) == true) return
+        if (deletedEventsRepo?.isDeleted(event.id) == true) return
+
+        when (event.kind) {
+            1 -> {
+                val isReply = event.tags.any { it.size >= 2 && it[0] == "e" }
+                if (!isReply) {
+                    eventCache.put(event.id, event)
+                    relayHintStore?.extractHintsFromTags(event)
+                    relayFeedBinaryInsert(event)
+                }
+            }
+            6 -> {
+                if (event.content.isNotBlank()) {
+                    try {
+                        val inner = NostrEvent.fromJson(event.content)
+                        if (muteRepo?.isBlocked(inner.pubkey) == true) return
+                        if (muteRepo?.containsMutedWord(inner.content) == true) return
+                        // Track repost metadata for badges
+                        val authors = repostAuthors.get(inner.id)
+                            ?: mutableSetOf<String>().also { repostAuthors.put(inner.id, it) }
+                        authors.add(event.pubkey)
+                        if (event.pubkey == currentUserPubkey) {
+                            userReposts.put(inner.id, true)
+                        }
+                        repostDirty = true
+                        markVersionDirty()
+                        val isReply = inner.tags.any { it.size >= 2 && it[0] == "e" }
+                        if (!isReply) {
+                            eventCache.put(inner.id, inner)
+                            relayHintStore?.extractHintsFromTags(inner)
+                            feedSortTime.put(inner.id, event.created_at)
+                            relayFeedBinaryInsert(inner, sortTime = event.created_at)
+                        }
+                    } catch (_: Exception) {}
+                }
+            }
+        }
+    }
+
+    private fun relayFeedBinaryInsert(event: NostrEvent, sortTime: Long = event.created_at) {
+        synchronized(relayFeedList) {
+            if (!relayFeedIds.add(event.id)) return  // already in relay feed
+            var low = 0
+            var high = relayFeedList.size
+            while (low < high) {
+                val mid = (low + high) / 2
+                if (effectiveSortTime(relayFeedList[mid]) > sortTime) low = mid + 1 else high = mid
+            }
+            relayFeedList.add(low, event)
+        }
+        relayFeedInserted.trySend(Unit)
+    }
+
+    fun clearRelayFeed() {
+        synchronized(relayFeedList) {
+            relayFeedList.clear()
+            relayFeedIds.clear()
+        }
+        _relayFeed.value = emptyList()
+    }
+
+    fun getOldestRelayFeedTimestamp(): Long? {
+        return synchronized(relayFeedList) {
+            relayFeedList.lastOrNull()?.let { effectiveSortTime(it) }
+        }
+    }
+
+    fun clearFeed() {
+        resetFeedDisplay()
+        eventCache.evictAll()
+        seenEventIds.clear()
+    }
+
     fun clearAll() {
         _authorFilter.value = null
         clearFeed()
+        clearRelayFeed()
         replyCounts.evictAll()
         zapSats.evictAll()
         eventRelays.evictAll()

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -56,6 +56,7 @@ class EventRouter(
     private val getUserPubkey: () -> String?,
     private val getSigner: () -> NostrSigner?,
     private val getFeedSubId: () -> String,
+    private val getRelayFeedSubId: () -> String,
     private val onRelayFeedEventReceived: () -> Unit
 ) {
     // Track newest created_at per (pubkey, kind) to prevent stale overwrites
@@ -295,16 +296,15 @@ class EventRouter(
             }
 
             val feedSubId = getFeedSubId()
+            val relayFeedSubId = getRelayFeedSubId()
             val isFeedSub = subscriptionId == feedSubId ||
                 subscriptionId == "loadmore" ||
                 subscriptionId == "feed-backfill"
-            if (isFeedSub) {
-                val feedSizeBefore = eventRepo.feed.value.size
-                eventRepo.addEvent(event)
-                val feedSizeAfter = eventRepo.feed.value.size
-                if (feedSizeAfter > feedSizeBefore) {
-                    Log.d("RLC", "[EventRouter] feed event added: kind=${event.kind} from=${event.pubkey.take(8)} feedSize=$feedSizeAfter sub=$subscriptionId")
-                }
+            val isRelayFeedSub = subscriptionId == relayFeedSubId ||
+                subscriptionId == "relay-loadmore"
+            if (isRelayFeedSub) {
+                eventRepo.cacheEvent(event)
+                eventRepo.addRelayFeedEvent(event)
                 onRelayFeedEventReceived()
                 if (event.kind == 1) eventRepo.addEventRelay(event.id, relayUrl)
                 if (event.kind == 1) {
@@ -314,7 +314,24 @@ class EventRouter(
                     }
                 }
                 if (event.kind == 6 && event.content.isNotBlank()) {
-                    // Fetch profile for the reposted event's original author
+                    try {
+                        val inner = NostrEvent.fromJson(event.content)
+                        if (eventRepo.getProfileData(inner.pubkey) == null) {
+                            metadataFetcher.addToPendingProfiles(inner.pubkey)
+                        }
+                        metadataFetcher.fetchQuotedEvents(inner)
+                    } catch (_: Exception) {}
+                }
+            } else if (isFeedSub) {
+                eventRepo.addEvent(event)
+                if (event.kind == 1) eventRepo.addEventRelay(event.id, relayUrl)
+                if (event.kind == 1) {
+                    metadataFetcher.fetchQuotedEvents(event)
+                    if (eventRepo.getProfileData(event.pubkey) == null) {
+                        metadataFetcher.addToPendingProfiles(event.pubkey)
+                    }
+                }
+                if (event.kind == 6 && event.content.isNotBlank()) {
                     try {
                         val inner = NostrEvent.fromJson(event.content)
                         if (eventRepo.getProfileData(inner.pubkey) == null) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -54,6 +54,13 @@ class FeedSubscriptionManager(
     private val processingContext: CoroutineContext,
     private val pubkeyHex: String?
 ) {
+    init {
+        // Relay feed subs bypass RelayPool's seen-event dedup so events already
+        // received by the main feed subscription can still appear in relay feeds.
+        relayPool.registerDedupBypass("relay-feed-")
+        relayPool.registerDedupBypass("relay-loadmore")
+    }
+
     private val _feedType = MutableStateFlow(FeedType.FOLLOWS)
     val feedType: StateFlow<FeedType> = _feedType
 
@@ -79,10 +86,15 @@ class FeedSubscriptionManager(
     private val _loadingScreenComplete = MutableStateFlow(false)
     val loadingScreenComplete: StateFlow<Boolean> = _loadingScreenComplete
 
+    private var feedGeneration = 0
     var feedSubId = "feed"
+        private set
+    private var relayFeedGeneration = 0
+    var relayFeedSubId = "relay-feed"
         private set
     val activeEngagementSubIds = java.util.concurrent.CopyOnWriteArrayList<String>()
     private var feedEoseJob: Job? = null
+    private var relayFeedEoseJob: Job? = null
     private var relayStatusMonitorJob: Job? = null
     private var isLoadingMore = false
 
@@ -114,18 +126,29 @@ class FeedSubscriptionManager(
         Log.d("RLC", "[FeedSub] setFeedType $prev → $type feedSize=${eventRepo.feed.value.size}")
         _feedType.value = type
         applyAuthorFilterForFeedType(type)
+
+        // Tear down relay feed when leaving RELAY mode
+        if (prev == FeedType.RELAY && type != FeedType.RELAY) {
+            unsubscribeRelayFeed()
+        }
+
         when (type) {
             FeedType.FOLLOWS, FeedType.EXTENDED_FOLLOWS -> {
-                if (prev == FeedType.LIST || prev == FeedType.RELAY) {
+                if (prev == FeedType.LIST) {
                     Log.d("RLC", "[FeedSub] switching from $prev to $type — clearing feed and resubscribing")
-                    eventRepo.clearFeed()
+                    eventRepo.resetFeedDisplay()
                     resubscribeFeed()
                 } else {
+                    // Switching from RELAY or between FOLLOWS/EXTENDED — main feed still running
                     Log.d("RLC", "[FeedSub] setFeedType $prev → $type — filter-only switch, no resubscribe needed, feedSize=${eventRepo.feed.value.size}")
                 }
             }
-            FeedType.RELAY, FeedType.LIST -> {
-                eventRepo.clearFeed()
+            FeedType.RELAY -> {
+                eventRepo.clearRelayFeed()
+                subscribeRelayFeed()
+            }
+            FeedType.LIST -> {
+                eventRepo.resetFeedDisplay()
                 resubscribeFeed()
             }
         }
@@ -135,8 +158,8 @@ class FeedSubscriptionManager(
         _selectedRelaySet.value = null
         _selectedRelay.value = url
         if (_feedType.value == FeedType.RELAY) {
-            eventRepo.clearFeed()
-            resubscribeFeed()
+            eventRepo.clearRelayFeed()
+            subscribeRelayFeed()
         }
     }
 
@@ -144,31 +167,38 @@ class FeedSubscriptionManager(
         _selectedRelaySet.value = relaySet
         _selectedRelay.value = null
         if (_feedType.value == FeedType.RELAY) {
-            eventRepo.clearFeed()
-            resubscribeFeed()
+            eventRepo.clearRelayFeed()
+            subscribeRelayFeed()
         }
     }
 
     fun retryRelayFeed() {
         val url = _selectedRelay.value ?: return
         healthTracker.clearBadRelay(url)
-        eventRepo.clearFeed()
+        relayPool.clearCooldown(url)
+        eventRepo.clearRelayFeed()
         _relayFeedStatus.value = RelayFeedStatus.Connecting
-        resubscribeFeed()
+        subscribeRelayFeed()
     }
 
     fun subscribeFeed() {
         resubscribeFeed()
+        if (_feedType.value == FeedType.RELAY) {
+            eventRepo.clearRelayFeed()
+            subscribeRelayFeed()
+        }
     }
 
     fun refreshFeed() {
         _isRefreshing.value = true
-        eventRepo.clearFeed()
-        resubscribeFeed()
+        if (_feedType.value == FeedType.RELAY) {
+            eventRepo.clearRelayFeed()
+            subscribeRelayFeed()
+        } else {
+            eventRepo.resetFeedDisplay()
+            resubscribeFeed()
+        }
         scope.launch {
-            // Don't wait for full EOSE — just show the spinner briefly so the
-            // user gets tactile feedback that the refresh fired. Events will
-            // stream in as relays respond.
             delay(3000)
             _isRefreshing.value = false
         }
@@ -176,7 +206,11 @@ class FeedSubscriptionManager(
 
     fun resubscribeFeed() {
         Log.d("RLC", "[FeedSub] resubscribeFeed() feedType=${_feedType.value} connectedCount=${relayPool.connectedCount.value}")
-        relayPool.closeOnAllRelays(feedSubId)
+        val oldSubId = feedSubId
+        feedGeneration++
+        feedSubId = "feed-$feedGeneration"
+        Log.d("RLC", "[FeedSub] feed generation $feedGeneration: $oldSubId → $feedSubId")
+        relayPool.closeOnAllRelays(oldSubId)
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()
         eventRepo.countNewNotes = false
@@ -193,8 +227,6 @@ class FeedSubscriptionManager(
         val excludedUrls = getExcludedRelayUrls()
         val targetedRelays: Set<String> = when (_feedType.value) {
             FeedType.FOLLOWS, FeedType.EXTENDED_FOLLOWS -> {
-                relayStatusMonitorJob?.cancel()
-                _relayFeedStatus.value = RelayFeedStatus.Idle
                 val cache = extendedNetworkRepo.cachedNetwork.value
                 val firstDegree = contactRepo.getFollowList().map { it.pubkey }
                 val allAuthors = if (cache != null) {
@@ -214,43 +246,9 @@ class FeedSubscriptionManager(
                 )
             }
             FeedType.RELAY -> {
-                // Clear seen events so relays can re-send events we've already seen
-                // from other feeds (e.g. FOLLOWS). Without this, seenEvents dedup in
-                // RelayPool drops events and the relay feed appears empty.
-                relayPool.clearSeenEvents()
-                val relaySet = _selectedRelaySet.value
-                if (relaySet != null) {
-                    // Combined relay set feed — subscribe to all relays in the set
-                    relayStatusMonitorJob?.cancel()
-                    _relayFeedStatus.value = RelayFeedStatus.Subscribing
-                    val filter = Filter(kinds = listOf(1, 6), since = sinceTimestamp)
-                    val msg = ClientMessage.req(feedSubId, filter)
-                    val sentUrls = mutableSetOf<String>()
-                    for (setUrl in relaySet.relays) {
-                        val sent = relayPool.sendToRelayOrEphemeral(setUrl, msg, skipBadCheck = true)
-                        if (sent) sentUrls.add(setUrl)
-                    }
-                    if (sentUrls.isEmpty()) {
-                        _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Failed to connect to any relay in set")
-                        return
-                    }
-                    sentUrls
-                } else {
-                    val url = _selectedRelay.value ?: return
-                    startRelayStatusMonitor(url)
-                    val status = _relayFeedStatus.value
-                    if (status is RelayFeedStatus.Cooldown || status is RelayFeedStatus.BadRelay) {
-                        return
-                    }
-                    val filter = Filter(kinds = listOf(1, 6), since = sinceTimestamp)
-                    val msg = ClientMessage.req(feedSubId, filter)
-                    val sent = relayPool.sendToRelayOrEphemeral(url, msg, skipBadCheck = true)
-                    if (!sent) {
-                        _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Failed to connect to relay")
-                        return
-                    }
-                    setOf(url)
-                }
+                // RELAY feeds use subscribeRelayFeed() — should not reach here
+                Log.w("RLC", "[FeedSub] resubscribeFeed() called for RELAY type, skipping")
+                return
             }
             FeedType.LIST -> {
                 relayStatusMonitorJob?.cancel()
@@ -337,12 +335,12 @@ class FeedSubscriptionManager(
     fun loadMore() {
         if (isLoadingMore) return
         isLoadingMore = true
-        val oldest = eventRepo.getOldestTimestamp() ?: run { isLoadingMore = false; return }
 
         val indexerRelays = getIndexerRelays()
         val excludedUrls = getExcludedRelayUrls()
         when (_feedType.value) {
             FeedType.FOLLOWS, FeedType.EXTENDED_FOLLOWS -> {
+                val oldest = eventRepo.getOldestTimestamp() ?: run { isLoadingMore = false; return }
                 val cache = extendedNetworkRepo.cachedNetwork.value
                 val firstDegree = contactRepo.getFollowList().map { it.pubkey }
                 val allAuthors = if (cache != null) {
@@ -358,10 +356,11 @@ class FeedSubscriptionManager(
                 )
             }
             FeedType.RELAY -> {
+                val oldest = eventRepo.getOldestRelayFeedTimestamp() ?: run { isLoadingMore = false; return }
                 val relaySet = _selectedRelaySet.value
                 if (relaySet != null) {
                     val filter = Filter(kinds = listOf(1, 6), until = oldest - 1, limit = 50)
-                    val msg = ClientMessage.req("loadmore", filter)
+                    val msg = ClientMessage.req("relay-loadmore", filter)
                     for (setUrl in relaySet.relays) {
                         relayPool.sendToRelayOrEphemeral(setUrl, msg, skipBadCheck = true)
                     }
@@ -369,11 +368,12 @@ class FeedSubscriptionManager(
                     val url = _selectedRelay.value
                     if (url != null) {
                         val filter = Filter(kinds = listOf(1, 6), until = oldest - 1, limit = 50)
-                        relayPool.sendToRelayOrEphemeral(url, ClientMessage.req("loadmore", filter), skipBadCheck = true)
+                        relayPool.sendToRelayOrEphemeral(url, ClientMessage.req("relay-loadmore", filter), skipBadCheck = true)
                     } else { isLoadingMore = false; return }
                 }
             }
             FeedType.LIST -> {
+                val oldest = eventRepo.getOldestTimestamp() ?: run { isLoadingMore = false; return }
                 val list = listRepo.selectedList.value ?: run { isLoadingMore = false; return }
                 val authors = list.members.toList()
                 if (authors.isEmpty()) { isLoadingMore = false; return }
@@ -410,12 +410,22 @@ class FeedSubscriptionManager(
             }
         }
 
+        val loadMoreSubId = if (_feedType.value == FeedType.RELAY) "relay-loadmore" else "loadmore"
         scope.launch {
-            val feedSizeBefore = eventRepo.feed.value.size
-            subManager.awaitEoseWithTimeout("loadmore")
-            subManager.closeSubscription("loadmore")
+            val feedSizeBefore = if (_feedType.value == FeedType.RELAY) {
+                eventRepo.relayFeed.value.size
+            } else {
+                eventRepo.feed.value.size
+            }
+            subManager.awaitEoseWithTimeout(loadMoreSubId)
+            subManager.closeSubscription(loadMoreSubId)
 
-            if (eventRepo.feed.value.size > feedSizeBefore) {
+            val feedSizeAfter = if (_feedType.value == FeedType.RELAY) {
+                eventRepo.relayFeed.value.size
+            } else {
+                eventRepo.feed.value.size
+            }
+            if (feedSizeAfter > feedSizeBefore) {
                 subscribeEngagementForFeed()
             }
 
@@ -434,6 +444,76 @@ class FeedSubscriptionManager(
         }
     }
 
+    // -- Isolated relay feed subscription --
+
+    private fun subscribeRelayFeed() {
+        Log.d("RLC", "[FeedSub] subscribeRelayFeed()")
+        val oldSubId = relayFeedSubId
+        relayFeedGeneration++
+        relayFeedSubId = "relay-feed-$relayFeedGeneration"
+        relayPool.closeOnAllRelays(oldSubId)
+        relayFeedEoseJob?.cancel()
+
+        // Always request the latest 100 notes per relay — no since timestamp.
+        // Using a since timestamp caused empty feeds on switch because RelayPool's
+        // seen-event dedup interacts with the shared timestamp state.
+        val relaySet = _selectedRelaySet.value
+        if (relaySet != null) {
+            relayStatusMonitorJob?.cancel()
+            _relayFeedStatus.value = RelayFeedStatus.Subscribing
+            val filter = Filter(kinds = listOf(1, 6), limit = 100)
+            val msg = ClientMessage.req(relayFeedSubId, filter)
+            val sentUrls = mutableSetOf<String>()
+            for (setUrl in relaySet.relays) {
+                val sent = relayPool.sendToRelayOrEphemeral(setUrl, msg, skipBadCheck = true)
+                if (sent) sentUrls.add(setUrl)
+            }
+            if (sentUrls.isEmpty()) {
+                _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Failed to connect to any relay in set")
+                return
+            }
+            relayFeedEoseJob = scope.launch {
+                val eoseTarget = maxOf(1, (sentUrls.size * 0.3).toInt()).coerceIn(1, sentUrls.size)
+                subManager.awaitEoseCount(relayFeedSubId, eoseTarget)
+                onRelayFeedEose()
+                subscribeEngagementForFeed()
+                withContext(processingContext) {
+                    metadataFetcher.sweepMissingProfiles()
+                }
+            }
+        } else {
+            val url = _selectedRelay.value ?: return
+            startRelayStatusMonitor(url)
+            val status = _relayFeedStatus.value
+            if (status is RelayFeedStatus.Cooldown || status is RelayFeedStatus.BadRelay) {
+                return
+            }
+            val filter = Filter(kinds = listOf(1, 6), limit = 100)
+            val msg = ClientMessage.req(relayFeedSubId, filter)
+            val sent = relayPool.sendToRelayOrEphemeral(url, msg, skipBadCheck = true)
+            if (!sent) {
+                _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Failed to connect to relay")
+                return
+            }
+            relayFeedEoseJob = scope.launch {
+                subManager.awaitEoseCount(relayFeedSubId, 1)
+                onRelayFeedEose()
+                subscribeEngagementForFeed()
+                withContext(processingContext) {
+                    metadataFetcher.sweepMissingProfiles()
+                }
+            }
+        }
+    }
+
+    private fun unsubscribeRelayFeed() {
+        relayFeedEoseJob?.cancel()
+        relayStatusMonitorJob?.cancel()
+        relayPool.closeOnAllRelays(relayFeedSubId)
+        eventRepo.clearRelayFeed()
+        _relayFeedStatus.value = RelayFeedStatus.Idle
+    }
+
     // -- Relay status monitoring --
 
     private fun startRelayStatusMonitor(url: String) {
@@ -450,8 +530,8 @@ class FeedSubscriptionManager(
                     remaining = relayPool.getRelayCooldownRemaining(url)
                 }
                 _relayFeedStatus.value = RelayFeedStatus.Idle
-                eventRepo.clearFeed()
-                resubscribeFeed()
+                eventRepo.clearRelayFeed()
+                subscribeRelayFeed()
             }
             return
         }
@@ -469,8 +549,17 @@ class FeedSubscriptionManager(
 
         relayStatusMonitorJob = scope.launch {
             launch {
+                // Track the current console log size so we only react to NEW entries,
+                // not stale CONN_FAILURE entries from previous connection attempts.
+                var baselineSize = relayPool.consoleLog.value.size
                 relayPool.consoleLog.collectLatest { entries ->
-                    val latest = entries.lastOrNull { it.relayUrl == url } ?: return@collectLatest
+                    if (entries.size <= baselineSize) {
+                        baselineSize = entries.size
+                        return@collectLatest
+                    }
+                    // Only check entries added since the monitor started
+                    val newEntries = entries.subList(baselineSize, entries.size)
+                    val latest = newEntries.lastOrNull { it.relayUrl == url } ?: return@collectLatest
                     val currentStatus = _relayFeedStatus.value
                     if (currentStatus is RelayFeedStatus.Connecting ||
                         currentStatus is RelayFeedStatus.Subscribing) {
@@ -505,15 +594,25 @@ class FeedSubscriptionManager(
                 }
             }
 
+            // Two-phase timeout: connection (10s) then data (15s)
             launch {
-                delay(15_000)
-                val currentStatus = _relayFeedStatus.value
-                if (currentStatus is RelayFeedStatus.Connecting ||
-                    currentStatus is RelayFeedStatus.Subscribing) {
+                // Phase 1 — Connection timeout
+                delay(10_000)
+                if (_relayFeedStatus.value is RelayFeedStatus.Connecting) {
                     val isPersistent = relayPool.getRelayUrls().contains(url)
-                    Log.d("RLC", "[FeedSub] relay feed TIMEOUT for $url (was $currentStatus, persistent=$isPersistent) — closing sub")
+                    Log.d("RLC", "[FeedSub] relay feed CONNECTION TIMEOUT for $url (persistent=$isPersistent) — closing sub")
+                    _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Connection timed out")
+                    relayPool.closeOnAllRelays(relayFeedSubId)
+                    if (!isPersistent) relayPool.disconnectRelay(url)
+                    return@launch
+                }
+                // Phase 2 — Data timeout (15s after connection phase)
+                delay(15_000)
+                if (_relayFeedStatus.value is RelayFeedStatus.Subscribing) {
+                    val isPersistent = relayPool.getRelayUrls().contains(url)
+                    Log.d("RLC", "[FeedSub] relay feed DATA TIMEOUT for $url (persistent=$isPersistent) — closing sub")
                     _relayFeedStatus.value = RelayFeedStatus.TimedOut
-                    relayPool.closeOnAllRelays(feedSubId)
+                    relayPool.closeOnAllRelays(relayFeedSubId)
                     if (!isPersistent) relayPool.disconnectRelay(url)
                 }
             }
@@ -524,7 +623,7 @@ class FeedSubscriptionManager(
         if (_feedType.value != FeedType.RELAY) return
         val status = _relayFeedStatus.value
         if (status is RelayFeedStatus.Connecting || status is RelayFeedStatus.Subscribing) {
-            _relayFeedStatus.value = if (eventRepo.feed.value.isEmpty()) {
+            _relayFeedStatus.value = if (eventRepo.relayFeed.value.isEmpty()) {
                 RelayFeedStatus.NoEvents
             } else {
                 RelayFeedStatus.Streaming
@@ -547,7 +646,7 @@ class FeedSubscriptionManager(
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()
 
-        val feedEvents = eventRepo.feed.value
+        val feedEvents = if (_feedType.value == FeedType.RELAY) eventRepo.relayFeed.value else eventRepo.feed.value
         if (feedEvents.isEmpty()) return
 
         val eventsByAuthor = mutableMapOf<String, MutableList<String>>()
@@ -599,8 +698,7 @@ class FeedSubscriptionManager(
     /** Reset state for account switch. */
     fun reset() {
         feedEoseJob?.cancel()
-        relayStatusMonitorJob?.cancel()
-        _relayFeedStatus.value = RelayFeedStatus.Idle
+        unsubscribeRelayFeed()
         relayPool.closeOnAllRelays(feedSubId)
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -46,8 +46,11 @@ import kotlinx.coroutines.Dispatchers
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.RelaySet
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 enum class FeedType { FOLLOWS, EXTENDED_FOLLOWS, RELAY, LIST }
@@ -186,6 +189,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         getUserPubkey = { getUserPubkey() },
         getSigner = { signer },
         getFeedSubId = { feedSub.feedSubId },
+        getRelayFeedSubId = { feedSub.relayFeedSubId },
         onRelayFeedEventReceived = { feedSub.onRelayFeedEventReceived() }
     )
 
@@ -216,7 +220,11 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     )
 
     // -- Exposed state --
-    val feed: StateFlow<List<NostrEvent>> = eventRepo.feed
+    val feed: StateFlow<List<NostrEvent>> = combine(
+        feedSub.feedType, eventRepo.feed, eventRepo.relayFeed
+    ) { type, main, relay ->
+        if (type == FeedType.RELAY) relay else main
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
     val newNoteCount: StateFlow<Int> = eventRepo.newNoteCount
     val initialLoadDone: StateFlow<Boolean> = feedSub.initialLoadDone
     val initLoadingState: StateFlow<InitLoadingState> = feedSub.initLoadingState


### PR DESCRIPTION
## Summary
- Relay feeds get their own isolated event list, dedup state, and subscription lifecycle — completely separate from the follows/notifications/engagement pipeline
- Main feed subscription **keeps running** while viewing a relay feed — switching back is instant (no reconnection, no re-fetching)
- EventRouter routes events by subscription ID (`relay-feed-*` vs `feed-*`), not feed type — deterministic when both subs run simultaneously
- Relay feed subs registered as dedup bypass prefixes in RelayPool so events already seen by the main feed still reach the relay feed

## Test plan
- [ ] FOLLOWS feed loads normally
- [ ] Switch to relay feed → only that relay's events appear, no stale follows notes
- [ ] Switch back to FOLLOWS → instant, feed is already there
- [ ] Switch to different relay feed → previous relay cleared, new relay's notes appear
- [ ] Switch back to FOLLOWS again → still instant
- [ ] Load-more on relay feed works
- [ ] Pull-to-refresh on relay feed works
- [ ] Engagement counts display on relay feed items