### PR TITLE
fix: improve blocked user safety

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/ProfilePicture.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ProfilePicture.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -43,14 +44,15 @@ fun ProfilePicture(
     modifier: Modifier = Modifier,
     size: Int = 40,
     showFollowBadge: Boolean = false,
+    showBlockedBadge: Boolean = false,
     highlighted: Boolean = false,
     onClick: (() -> Unit)? = null,
     onLongPress: (() -> Unit)? = null
 ) {
     if (highlighted) {
-        HighlightedProfilePicture(url, modifier, size, showFollowBadge, onClick, onLongPress)
+        HighlightedProfilePicture(url, modifier, size, showFollowBadge, showBlockedBadge, onClick, onLongPress)
     } else {
-        BaseProfilePicture(url, modifier, size, showFollowBadge, onClick, onLongPress)
+        BaseProfilePicture(url, modifier, size, showFollowBadge, showBlockedBadge, onClick, onLongPress)
     }
 }
 
@@ -61,6 +63,7 @@ private fun HighlightedProfilePicture(
     modifier: Modifier,
     size: Int,
     showFollowBadge: Boolean,
+    showBlockedBadge: Boolean,
     onClick: (() -> Unit)?,
     onLongPress: (() -> Unit)?
 ) {
@@ -137,7 +140,9 @@ private fun HighlightedProfilePicture(
                 )
         )
 
-        if (showFollowBadge) {
+        if (showBlockedBadge) {
+            BlockedBadge(size, Modifier.align(Alignment.BottomEnd))
+        } else if (showFollowBadge) {
             FollowBadge(size, Modifier.align(Alignment.BottomEnd))
         }
     }
@@ -150,6 +155,7 @@ private fun BaseProfilePicture(
     modifier: Modifier,
     size: Int,
     showFollowBadge: Boolean,
+    showBlockedBadge: Boolean,
     onClick: (() -> Unit)?,
     onLongPress: (() -> Unit)?
 ) {
@@ -178,7 +184,9 @@ private fun BaseProfilePicture(
                     } else Modifier
                 )
         )
-        if (showFollowBadge) {
+        if (showBlockedBadge) {
+            BlockedBadge(size, Modifier.align(Alignment.BottomEnd))
+        } else if (showFollowBadge) {
             FollowBadge(size, Modifier.align(Alignment.BottomEnd))
         }
     }
@@ -199,6 +207,26 @@ private fun FollowBadge(size: Int, modifier: Modifier = Modifier) {
             Icons.Default.Check,
             contentDescription = "Following",
             tint = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.size((badgeSize * 0.65f).dp)
+        )
+    }
+}
+
+@Composable
+private fun BlockedBadge(size: Int, modifier: Modifier = Modifier) {
+    val badgeSize = (size * 0.3f).coerceIn(10f, 16f)
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .offset(x = 1.dp, y = 1.dp)
+            .size(badgeSize.dp)
+            .background(MaterialTheme.colorScheme.error, CircleShape)
+            .border(1.dp, MaterialTheme.colorScheme.surface, CircleShape)
+    ) {
+        Icon(
+            Icons.Default.Block,
+            contentDescription = "Blocked",
+            tint = MaterialTheme.colorScheme.onError,
             modifier = Modifier.size((badgeSize * 0.65f).dp)
         )
     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.CheckCircle
@@ -217,6 +218,7 @@ fun UserProfileScreen(
     }
 
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+    var blockedContentRevealed by remember { mutableStateOf(false) }
     val tabTitles = listOf("Notes", "Replies", "Following", "Relays")
 
     Scaffold(
@@ -322,7 +324,8 @@ fun UserProfileScreen(
                     onSendDm = onSendDm,
                     followingCount = followList.size,
                     followedBy = followedBy,
-                    followsYou = !isOwnProfile && userPubkey != null && followList.any { it.pubkey == userPubkey }
+                    followsYou = !isOwnProfile && userPubkey != null && followList.any { it.pubkey == userPubkey },
+                    isBlocked = isBlocked
                 )
             }
 
@@ -342,7 +345,9 @@ fun UserProfileScreen(
             }
 
             when (selectedTab) {
-                0 -> {
+                0 -> if (isBlocked && !blockedContentRevealed) {
+                    item { BlockedContentOverlay(onReveal = { blockedContentRevealed = true }) }
+                } else {
                     // Pinned notes at the top of the Notes tab
                     val pinnedEvents = pinnedIds.mapNotNull { id -> eventRepo?.getEvent(id) }
                         .sortedByDescending { it.created_at }
@@ -461,7 +466,9 @@ fun UserProfileScreen(
                         }
                     }
                 }
-                1 -> {
+                1 -> if (isBlocked && !blockedContentRevealed) {
+                    item { BlockedContentOverlay(onReveal = { blockedContentRevealed = true }) }
+                } else {
                     if (replies.isEmpty()) {
                         item { EmptyTabContent("No replies yet") }
                     } else {
@@ -596,7 +603,8 @@ private fun ProfileHeader(
     onSendDm: (() -> Unit)? = null,
     followingCount: Int = 0,
     followedBy: List<String> = emptyList(),
-    followsYou: Boolean = false
+    followsYou: Boolean = false,
+    isBlocked: Boolean = false
 ) {
     var fullScreenImageUrl by remember { mutableStateOf<String?>(null) }
 
@@ -639,6 +647,7 @@ private fun ProfileHeader(
             ProfilePicture(
                 url = profile?.picture,
                 size = 72,
+                showBlockedBadge = isBlocked,
                 onClick = profile?.picture?.let { url -> { fullScreenImageUrl = url } }
             )
             Spacer(Modifier.weight(1f))
@@ -1122,5 +1131,42 @@ private fun EmptyTabContent(message: String) {
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+    }
+}
+
+@Composable
+private fun BlockedContentOverlay(onReveal: () -> Unit) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp)
+            .padding(16.dp)
+            .background(
+                MaterialTheme.colorScheme.errorContainer,
+                RoundedCornerShape(12.dp)
+            )
+            .clickable(onClick = onReveal)
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Default.Block,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "This user is blocked",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "Tap to reveal content",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.7f)
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -167,7 +167,8 @@ class EventRouter(
             // (engagement subs fetch reposts for all viewed posts, not just ours).
             val myPubkey = getUserPubkey()
             val isNotifEligible = myPubkey != null && event.pubkey != myPubkey &&
-                event.kind in intArrayOf(1, 6, 7, 9735)
+                event.kind in intArrayOf(1, 6, 7, 9735) &&
+                !muteRepo.isBlocked(event.pubkey)
             val isRepostOfOther = event.kind == 6 && run {
                 val repostedId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
                 val repostedEvent = repostedId?.let { eventRepo.getEvent(it) }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
@@ -49,6 +49,7 @@ class ThreadViewModel : ViewModel() {
     private var loadJob: Job? = null
     private var rebuildJob: Job? = null
     private var metadataBatchJob: Job? = null
+    private var muteObserverJob: Job? = null
 
     // Incremental metadata tracking
     private val metadataSubscribedIds = mutableSetOf<String>()
@@ -72,6 +73,13 @@ class ThreadViewModel : ViewModel() {
         relayHintStore: RelayHintStore? = null
     ) {
         this.muteRepo = muteRepo
+        // Reactively rebuild thread when blocked users change (e.g. blocking mid-thread)
+        muteObserverJob?.cancel()
+        muteObserverJob = muteRepo?.let { repo ->
+            viewModelScope.launch {
+                repo.blockedPubkeys.collect { scheduleRebuild() }
+            }
+        }
         this.relayPoolRef = relayPool
         this.topRelayUrls = topRelayUrls
         this.relayListRepoRef = relayListRepo
@@ -309,6 +317,7 @@ class ThreadViewModel : ViewModel() {
         loadJob?.cancel()
         rebuildJob?.cancel()
         metadataBatchJob?.cancel()
+        muteObserverJob?.cancel()
         relayPoolRef?.let { pool ->
             pool.closeOnAllRelays("thread-root")
             pool.closeOnAllRelays("thread-replies")


### PR DESCRIPTION
## Summary
- Thread replies from blocked users disappear reactively when blocking mid-thread (ThreadViewModel observes mute list changes)
- Engage subscription notifications now filter blocked users, closing a gap where only `notif` and `notif-replies-etag` subs checked blocked status
- Blocked user profiles show a red blocked badge on their avatar and a content overlay on Notes/Replies tabs (tap to reveal)

## Test plan
- [ ] Open a thread, block a reply author from the 3-dot menu — their replies should immediately disappear
- [ ] Check notifications after blocking a user — their reactions/replies/zaps should not appear
- [ ] Visit a blocked user's profile — see blocked badge on avatar, Notes/Replies tabs show overlay
- [ ] Tap overlay to reveal blocked user's content
- [ ] Unblock user — badge disappears, content shows normally
- [ ] Following and Relays tabs remain unaffected on blocked profiles