### PR TITLE
fix: improve reply notification reliability

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -552,23 +552,27 @@ class StartupCoordinator(
 
             // Subscribe for replies via e-tags on our own posts.
             // Catches replies where the replier's client omits the p-tag.
-            val myEventIds = eventRepo.getRecentEventIdsByAuthor(myPubkey, limit = 50)
+            val myEventIds = eventRepo.getRecentEventIdsByAuthor(myPubkey, limit = 100)
             if (myEventIds.isNotEmpty()) {
                 val replyReqMsg = ClientMessage.req(
                     "notif-replies-etag",
-                    Filter(kinds = listOf(1), eTags = myEventIds, limit = 50)
+                    Filter(kinds = listOf(1), eTags = myEventIds, limit = 200)
                 )
                 relayPool.sendToReadRelays(replyReqMsg)
+                // Replies often land on the relay where the original note was posted
                 val readUrls2 = relayPool.getReadRelayUrls().toSet()
+                val writeNotInRead = relayPool.getWriteRelayUrls().filter { it !in readUrls2 }
+                for (url in writeNotInRead) {
+                    relayPool.sendToRelay(url, replyReqMsg)
+                }
                 val topScored2 = relayScoreBoard.getScoredRelays()
                     .take(5)
                     .map { it.url }
-                    .filter { it !in readUrls2 }
+                    .filter { it !in readUrls2 && it !in writeNotInRead.toSet() }
                 for (url in topScored2) {
                     relayPool.sendToRelay(url, replyReqMsg)
                 }
                 subManager.awaitEoseWithTimeout("notif-replies-etag", timeoutMs = 5_000)
-                subManager.closeSubscription("notif-replies-etag")
             }
 
             feedSub.subscribeNotifEngagement()


### PR DESCRIPTION
## Summary
- Keep `notif-replies-etag` subscription open for continuous streaming instead of closing after initial 5s EOSE window — replies now arrive in real-time instead of waiting for the 3-minute refresh
- Increase e-tag coverage from 50 to 100 event IDs and result limit from 50 to 200
- Send e-tag subscription to write relays (where original notes were posted) for better reply discovery

## Test plan
- [ ] Verify `notif-replies-etag` subscription stays open after EOSE (no `closeOnAllRelays` in logs)
- [ ] Have another account reply to a recent note without p-tag — should appear in notifications within seconds
- [ ] Verify 3-minute refresh replaces the subscription cleanly (no duplicate notifications)
- [ ] Confirm write relays receive the e-tag subscription in logs