### PR TITLE
Fix Tor connection switching & add pre-login toggle

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -224,7 +224,7 @@ fun WispNavHost(
         if (torStatus == com.wisp.app.relay.TorStatus.CONNECTED ||
             torStatus == com.wisp.app.relay.TorStatus.DISABLED) {
             if (authViewModel.isLoggedIn) {
-                feedViewModel.relayPool.swapClientAndReconnect()
+                feedViewModel.lifecycleManager.onTorSwitch()
             }
         }
     }
@@ -399,6 +399,9 @@ fun WispNavHost(
         composable(Routes.AUTH) {
             AuthScreen(
                 viewModel = authViewModel,
+                isTorEnabled = isTorEnabled,
+                torStatus = torStatus,
+                onToggleTor = onToggleTor,
                 onAuthenticated = { isNewAccount ->
                     if (isNewAccount) {
                         navController.navigate(Routes.ONBOARDING_PROFILE) {

--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -247,6 +247,20 @@ class Relay(
         }
     }
 
+    /** Immediate TCP teardown — no graceful close handshake. Use when replacing the
+     *  OkHttpClient (e.g. Tor switch) to avoid duplicate connections from the server's
+     *  perspective while the graceful close waits for server ACK. */
+    fun forceDisconnect() {
+        synchronized(connectLock) {
+            val ws = webSocket
+            isConnected = false
+            webSocket = null
+            pendingReconnect?.cancel(false)
+            pendingReconnect = null
+            ws?.cancel()
+        }
+    }
+
     /** Reset backoff state — call when user explicitly reconnects */
     fun resetBackoff() {
         cooldownUntil = 0L

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
@@ -140,6 +140,21 @@ class RelayLifecycleManager(
     }
 
     /**
+     * Handle Tor on/off switch. Swaps the OkHttpClient, reconnects all relays,
+     * and re-establishes subscriptions via [onReconnected].
+     * Uses a longer timeout since Tor connections are slower.
+     */
+    fun onTorSwitch() {
+        reconnectJob?.cancel()
+        reconnectJob = scope.launch {
+            relayPool.swapClientAndReconnect()
+            relayPool.awaitAnyConnected(minCount = 3, timeoutMs = 10_000)
+            relayPool.appIsActive = true
+            onReconnected(true)
+        }
+    }
+
+    /**
      * Stop observing. Call on account switch or cleanup.
      */
     fun stop() {

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -892,11 +892,11 @@ class RelayPool {
     }
 
     fun disconnectAll() {
-        relays.forEach { it.disconnect() }
+        relays.forEach { it.forceDisconnect() }
         relays.clear()
-        dmRelays.forEach { it.disconnect() }
+        dmRelays.forEach { it.forceDisconnect() }
         dmRelays.clear()
-        ephemeralRelays.values.forEach { it.disconnect() }
+        ephemeralRelays.values.forEach { it.forceDisconnect() }
         ephemeralRelays.clear()
         ephemeralLastUsed.clear()
         relayCooldowns.clear()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/AuthScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/AuthScreen.kt
@@ -3,19 +3,26 @@ package com.wisp.app.ui.screen
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -42,11 +49,15 @@ import androidx.compose.ui.unit.sp
 import com.wisp.app.R
 import com.wisp.app.nostr.RemoteSignerBridge
 import com.wisp.app.nostr.toHex
+import com.wisp.app.relay.TorStatus
 import com.wisp.app.viewmodel.AuthViewModel
 
 @Composable
 fun AuthScreen(
     viewModel: AuthViewModel,
+    isTorEnabled: Boolean = false,
+    torStatus: TorStatus = TorStatus.DISABLED,
+    onToggleTor: (Boolean) -> Unit = {},
     onAuthenticated: (isNewAccount: Boolean) -> Unit
 ) {
     val context = LocalContext.current
@@ -99,7 +110,59 @@ fun AuthScreen(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
-        Spacer(Modifier.height(48.dp))
+        Spacer(Modifier.height(16.dp))
+
+        val pillBorderColor = when (torStatus) {
+            TorStatus.CONNECTED -> MaterialTheme.colorScheme.primary
+            TorStatus.ERROR -> MaterialTheme.colorScheme.error
+            else -> MaterialTheme.colorScheme.outlineVariant
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .border(1.dp, pillBorderColor, RoundedCornerShape(24.dp))
+                .clickable { onToggleTor(!isTorEnabled) }
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.size(20.dp)) {
+                if (torStatus == TorStatus.STARTING) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                } else {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_tor_onion),
+                        contentDescription = "Toggle Tor",
+                        modifier = Modifier.size(18.dp),
+                        tint = when (torStatus) {
+                            TorStatus.CONNECTED -> MaterialTheme.colorScheme.primary
+                            TorStatus.ERROR -> MaterialTheme.colorScheme.error
+                            else -> MaterialTheme.colorScheme.onSurfaceVariant
+                        }
+                    )
+                }
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = when (torStatus) {
+                    TorStatus.STARTING -> "Connecting to Tor..."
+                    TorStatus.CONNECTED -> "Connected via Tor"
+                    TorStatus.ERROR -> "Tor error"
+                    else -> "Connect via Tor"
+                },
+                style = MaterialTheme.typography.labelMedium,
+                color = when (torStatus) {
+                    TorStatus.CONNECTED -> MaterialTheme.colorScheme.primary
+                    TorStatus.ERROR -> MaterialTheme.colorScheme.error
+                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                }
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
 
         Button(
             onClick = {


### PR DESCRIPTION
## Summary
- **No duplicate connections**: `disconnectAll()` now uses `forceDisconnect()` (immediate TCP teardown via `ws.cancel()`) instead of graceful close, preventing relay operators from seeing two concurrent connections during Tor client swap
- **Subscriptions restored after Tor switch**: New `RelayLifecycleManager.onTorSwitch()` ensures `onReconnected` fires after client swap, so feed/notification/DM subscriptions are re-established instead of leaving relays idle
- **Pre-login Tor toggle**: Clickable pill on the auth screen lets users enable Tor before logging in, so all relay connections go through Tor from the start

## Test plan
- [ ] Enable Tor on auth screen → verify spinner then connected state → log in → verify feed loads over Tor
- [ ] Post-login toggle: Tor on → verify feed reloads with subscriptions → Tor off → verify clearnet reconnect
- [ ] Check relay console logs for clean disconnect/reconnect cycle (no duplicate connections)