### PR TITLE
fix: use theme-aware cursor color in compose screen

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.content.contentReceiver
 import androidx.compose.foundation.content.hasMediaType
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.LaunchedEffect
@@ -295,6 +296,7 @@ fun ComposeScreen(
 
                 BasicTextField(
                     state = textFieldState,
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(160.dp)


### PR DESCRIPTION
## Summary
- Set `cursorBrush` on the compose screen's `BasicTextField` to use `MaterialTheme.colorScheme.primary`, so the cursor adapts to dark/light mode instead of always being black

Closes #113