### PR TITLE
fix: show user's own notes in follow feed after publishing

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -367,8 +367,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             return 0
         }
         relayPool.trackPublish(event.id, sentCount)
-        // Cache locally so reply appears immediately without waiting for relay echo
-        eventRepo?.cacheEvent(event)
+        // Insert into feed so the note appears immediately without waiting for relay echo
+        eventRepo?.addEvent(event)
         if (replyTo != null) {
             // Increment on direct parent so the PostCard showing replyTo updates
             eventRepo?.addReplyCount(replyTo.id, event.id)


### PR DESCRIPTION
## Summary
- User's own published notes were not appearing in the follow feed
- `cacheEvent()` added the event ID to `seenEventIds` without inserting into the feed list, causing `addEvent()` to reject the relay echo as a duplicate
- Replaced `cacheEvent()` with `addEvent()` in `ComposeViewModel.publishNote()` so the note is both cached and inserted into the feed immediately

Closes #114