### PR TITLE
fix: reload ComposeViewModel's BlossomRepository on account switch

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -411,6 +411,7 @@ fun WispNavHost(
                         feedViewModel.reloadForNewAccount()
                         relayViewModel.reload()
                         blossomServersViewModel.reload()
+                        composeViewModel.reloadBlossomRepo()
                         // Start relay connections immediately so TCP/TLS handshakes
                         // run in parallel with the onboarding welcome animation
                         feedViewModel.initRelays()
@@ -1279,6 +1280,7 @@ fun WispNavHost(
                     feedViewModel.reloadForNewAccount()
                     relayViewModel.reload()
                     blossomServersViewModel.reload()
+                    composeViewModel.reloadBlossomRepo()
                     feedViewModel.initRelays()
                     walletViewModel.refreshState()
                     navController.navigate(Routes.LOADING) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -41,6 +41,10 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
     private val keyRepo = KeyRepository(app)
     val blossomRepo = BlossomRepository(app, keyRepo.getPubkeyHex())
 
+    fun reloadBlossomRepo() {
+        blossomRepo.reload(keyRepo.getPubkeyHex())
+    }
+
     private val _content = MutableStateFlow(
         TextFieldValue(savedStateHandle.get<String>("draft_content") ?: "")
     )


### PR DESCRIPTION
## Summary
- ComposeViewModel's `BlossomRepository` was created once at ViewModel init and never reloaded on account switch, causing it to read from the wrong SharedPreferences file (`wisp_prefs` instead of `wisp_prefs_<pubkeyhex>`)
- This meant the user's configured media server was missed, falling back to the Primal default
- Added `reloadBlossomRepo()` to ComposeViewModel and call it in both account switch paths in Navigation.kt

## Test plan
- [ ] Set a custom blossom media server in settings
- [ ] Upload media when composing a post — verify it uses the configured server, not Primal
- [ ] Log out and log in to a different account — verify the correct media server is used