### PR TITLE
perf: add baseline profile installer and shrink resources

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,7 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
@@ -67,6 +68,7 @@ dependencies {
     implementation(libs.media3.ui)
     implementation(libs.biometric)
     implementation(libs.splashscreen)
+    implementation(libs.profileinstaller)
     implementation(libs.zxing.core)
     implementation(libs.kmp.tor.runtime)
     implementation(libs.kmp.tor.resource.exec)

--- a/app/src/main/baseline-prof.txt
+++ b/app/src/main/baseline-prof.txt
@@ -1,0 +1,13 @@
+HSPLcom/wisp/app/MainActivity;->**(**)**
+HSPLcom/wisp/app/MainActivityKt;->**(**)**
+
+HSPLcom/wisp/app/viewmodel/**;->**(**)**
+HSPLcom/wisp/app/repo/**;->**(**)**
+HSPLcom/wisp/app/relay/**;->**(**)**
+HSPLcom/wisp/app/nostr/**;->**(**)**
+
+HSPLcom/wisp/app/ui/screen/FeedScreenKt;->**(**)**
+HSPLcom/wisp/app/ui/screen/AuthScreenKt;->**(**)**
+HSPLcom/wisp/app/ui/screen/LoadingScreenKt;->**(**)**
+HSPLcom/wisp/app/ui/component/**;->**(**)**
+HSPLcom/wisp/app/ui/navigation/**;->**(**)**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ bouncycastle = "1.78.1"
 media3 = "1.5.1"
 biometric = "1.1.0"
 coroutines = "1.9.0"
+profileinstaller = "1.4.1"
 splashscreen = "1.0.1"
 zxing = "3.5.3"
 kmp-tor = "2.0.0"
@@ -45,6 +46,7 @@ media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", versi
 media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3" }
 media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
 biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
+profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
 splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing" }
 kmp-tor-runtime = { group = "io.matthewnelson.kmp-tor", name = "runtime", version.ref = "kmp-tor" }


### PR DESCRIPTION
## Summary
- Add `profileinstaller` library so baseline profiles are AOT-compiled on sideloaded APKs (previously only applied via Play Store cloud delivery)
- Add app-specific `baseline-prof.txt` covering startup-critical paths (MainActivity, ViewModels, repositories, relay/protocol layers, core UI screens)
- Enable `isShrinkResources` for release builds to strip unused resources

## Test plan
- [ ] Install release APK via sideload and verify app launches and runs normally
- [ ] Confirm improved startup performance on second launch (after ProfileInstaller runs)