### PR TITLE
perf: optimize hot paths — crypto caching, hex encoding, UI reuse

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Event.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Event.kt
@@ -29,6 +29,7 @@ data class NostrEvent(
 ) {
     companion object {
         private val json = Json { ignoreUnknownKeys = true }
+        private val sha256Local = ThreadLocal.withInitial { MessageDigest.getInstance("SHA-256") }
 
         fun create(
             privkey: ByteArray,
@@ -83,7 +84,7 @@ data class NostrEvent(
                 append('"')
                 append(']')
             }
-            val digest = MessageDigest.getInstance("SHA-256")
+            val digest = sha256Local.get().apply { reset() }
             return digest.digest(serialized.toByteArray(Charsets.UTF_8)).toHex()
         }
 
@@ -136,7 +137,17 @@ private object LongAsStringSerializer : KSerializer<Long> {
     override fun deserialize(decoder: Decoder): Long = decoder.decodeLong()
 }
 
-fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+private const val HEX_CHARS = "0123456789abcdef"
+
+fun ByteArray.toHex(): String {
+    val result = CharArray(size * 2)
+    for (i in indices) {
+        val v = this[i].toInt() and 0xFF
+        result[i * 2] = HEX_CHARS[v ushr 4]
+        result[i * 2 + 1] = HEX_CHARS[v and 0x0F]
+    }
+    return String(result)
+}
 
 fun String.hexToByteArray(): ByteArray {
     require(length % 2 == 0) { "Hex string must have even length" }

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip04.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip04.kt
@@ -8,6 +8,7 @@ import java.security.SecureRandom
 
 object Nip04 {
     private val random = SecureRandom()
+    private val cipherLocal = ThreadLocal.withInitial { Cipher.getInstance("AES/CBC/PKCS5Padding") }
 
     /**
      * Compute the NIP-04 shared secret from a private key and public key.
@@ -25,7 +26,7 @@ object Nip04 {
     fun encrypt(plaintext: String, sharedSecret: ByteArray): String {
         val iv = ByteArray(16).also { random.nextBytes(it) }
         val key = SecretKeySpec(sharedSecret, "AES")
-        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        val cipher = cipherLocal.get()
         cipher.init(Cipher.ENCRYPT_MODE, key, IvParameterSpec(iv))
         val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
         val ctB64 = Base64.encodeToString(ciphertext, Base64.NO_WRAP)
@@ -42,7 +43,7 @@ object Nip04 {
         val ciphertext = Base64.decode(parts[0], Base64.DEFAULT)
         val iv = Base64.decode(parts[1], Base64.DEFAULT)
         val key = SecretKeySpec(sharedSecret, "AES")
-        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        val cipher = cipherLocal.get()
         cipher.init(Cipher.DECRYPT_MODE, key, IvParameterSpec(iv))
         return String(cipher.doFinal(ciphertext), Charsets.UTF_8)
     }

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip44.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip44.kt
@@ -11,6 +11,8 @@ import javax.crypto.spec.SecretKeySpec
 object Nip44 {
     private const val VERSION: Byte = 0x02
     private val random = SecureRandom()
+    private val hmacLocal = ThreadLocal.withInitial { Mac.getInstance("HmacSHA256") }
+    private val chachaLocal = ThreadLocal.withInitial { ChaCha7539Engine() }
 
     /**
      * Derive conversation key from privkey + pubkey via ECDH + HKDF.
@@ -150,13 +152,13 @@ object Nip44 {
     // --- Crypto Primitives ---
 
     private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
-        val mac = Mac.getInstance("HmacSHA256")
+        val mac = hmacLocal.get()
         mac.init(SecretKeySpec(key, "HmacSHA256"))
         return mac.doFinal(data)
     }
 
     private fun chacha20Encrypt(key: ByteArray, nonce: ByteArray, input: ByteArray): ByteArray {
-        val engine = ChaCha7539Engine()
+        val engine = chachaLocal.get()
         engine.init(true, ParametersWithIV(KeyParameter(key), nonce))
         val output = ByteArray(input.size)
         engine.processBytes(input, 0, input.size, output, 0)

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -686,13 +686,16 @@ class RelayPool {
     }
 
     private fun isRateLimitMessage(message: String): Boolean {
-        val lower = message.lowercase()
-        return "rate" in lower || "throttle" in lower || "slow down" in lower || "too many" in lower
+        return message.contains("rate", ignoreCase = true) ||
+            message.contains("throttle", ignoreCase = true) ||
+            message.contains("slow down", ignoreCase = true) ||
+            message.contains("too many", ignoreCase = true)
     }
 
     private fun isUnsupportedMessage(message: String): Boolean {
-        val lower = message.lowercase()
-        return "unsupported" in lower || "not supported" in lower || "unknown message" in lower
+        return message.contains("unsupported", ignoreCase = true) ||
+            message.contains("not supported", ignoreCase = true) ||
+            message.contains("unknown message", ignoreCase = true)
     }
 
     fun reconnectAll(): Int {

--- a/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
@@ -16,7 +16,7 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
     private var lastReadDmTimestamp: Long = prefs?.getLong("last_read_dm", 0L) ?: 0L
     private val lock = Any()
     private val conversations = LruCache<String, MutableList<DmMessage>>(100)
-    private val conversationKeyCache = object : LruCache<String, ByteArray>(50) {
+    private val conversationKeyCache = object : LruCache<String, ByteArray>(200) {
         override fun entryRemoved(evicted: Boolean, key: String?, oldValue: ByteArray?, newValue: ByteArray?) {
             oldValue?.wipe()
         }

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -341,10 +341,12 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     fun getRecentEventIdsByAuthor(pubkey: String, limit: Int = 50): List<String> {
         return eventCache.snapshot().values
+            .asSequence()
             .filter { it.kind == 1 && it.pubkey == pubkey }
             .sortedByDescending { it.created_at }
             .take(limit)
             .map { it.id }
+            .toList()
     }
 
     fun cacheEvent(event: NostrEvent) {
@@ -640,11 +642,12 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     fun searchNotes(query: String, limit: Int = 50): List<NostrEvent> {
         if (query.isBlank()) return emptyList()
-        val lowerQuery = query.lowercase()
         return eventCache.snapshot().values
-            .filter { it.kind == 1 && it.content.lowercase().contains(lowerQuery) }
+            .asSequence()
+            .filter { it.kind == 1 && it.content.contains(query, ignoreCase = true) }
             .sortedByDescending { it.created_at }
             .take(limit)
+            .toList()
     }
 
     /**

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -239,7 +239,7 @@ fun RichContent(
     noteActions: NoteActions? = null,
     modifier: Modifier = Modifier
 ) {
-    val segments = parseContent(content.trimEnd('\n', '\r'), emojiMap)
+    val segments = remember(content, emojiMap) { parseContent(content.trimEnd('\n', '\r'), emojiMap) }
     var fullScreenImageUrl by remember { mutableStateOf<String?>(null) }
     var fullScreenVideoUrl by remember { mutableStateOf<String?>(null) }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
@@ -91,7 +91,7 @@ fun DmListScreen(
                     .fillMaxSize()
                     .padding(padding)
             ) {
-                items(items = conversations, key = { it.peerPubkey }) { convo ->
+                items(items = conversations, key = { it.peerPubkey }, contentType = { "conversation" }) { convo ->
                     val profile = eventRepo.getProfileData(convo.peerPubkey)
                     val displayName = profile?.displayString
                         ?: convo.peerPubkey.take(8) + "..." + convo.peerPubkey.takeLast(4)

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -622,7 +622,7 @@ fun FeedScreen(
                             state = listState,
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            items(items = feed, key = { it.id }) { event ->
+                            items(items = feed, key = { it.id }, contentType = { "post" }) { event ->
                                 FeedItem(
                                     event = event,
                                     viewModel = viewModel,
@@ -661,7 +661,7 @@ fun FeedScreen(
                                 )
                             }
                             if (initialLoadDone) {
-                                item(key = "load-more") {
+                                item(key = "load-more", contentType = "loader") {
                                     Box(
                                         modifier = Modifier
                                             .fillMaxWidth()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -254,17 +254,17 @@ fun NotificationsScreen(
                 modifier = Modifier
                     .fillMaxSize()
             ) {
-                item(key = "summary_24h") {
+                item(key = "summary_24h", contentType = "summary") {
                     DailySummaryBar(
                         summary = summary,
                         onFilterSelect = { viewModel.setFilter(it) }
                     )
                 }
                 if (recentNotifs.isNotEmpty()) {
-                    item(key = "header_recent") {
+                    item(key = "header_recent", contentType = "header") {
                         SectionHeader("Recent")
                     }
-                    items(items = recentNotifs, key = { it.groupId }) { group ->
+                    items(items = recentNotifs, key = { it.groupId }, contentType = { "notification" }) { group ->
                         NotificationItem(
                             group = group,
                             viewModel = viewModel,
@@ -299,10 +299,10 @@ fun NotificationsScreen(
                     }
                 }
                 if (olderNotifs.isNotEmpty()) {
-                    item(key = "header_earlier") {
+                    item(key = "header_earlier", contentType = "header") {
                         SectionHeader("Earlier")
                     }
-                    items(items = olderNotifs, key = { it.groupId }) { group ->
+                    items(items = olderNotifs, key = { it.groupId }, contentType = { "notification" }) { group ->
                         NotificationItem(
                             group = group,
                             viewModel = viewModel,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
@@ -265,7 +265,7 @@ private fun MyDeviceTab(
                     contactRepo?.isFollowing(it.pubkey) == true
                 }
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(sortedLocalUsers, key = { it.pubkey }) { profile ->
+                    items(sortedLocalUsers, key = { it.pubkey }, contentType = { "user" }) { profile ->
                         UserResultItem(
                             profile = profile,
                             isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
@@ -279,7 +279,7 @@ private fun MyDeviceTab(
             localFilter == LocalFilter.NOTES -> {
                 val translationVersion by translationRepo?.version?.collectAsState() ?: remember { androidx.compose.runtime.mutableIntStateOf(0) }
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(localNotes, key = { it.id }) { event ->
+                    items(localNotes, key = { it.id }, contentType = { "post" }) { event ->
                         val profile = eventRepo.getProfileData(event.pubkey)
                         val translationState = remember(translationVersion, event.id) {
                             translationRepo?.getState(event.id) ?: com.wisp.app.repo.TranslationState()
@@ -402,7 +402,7 @@ private fun RelaysTab(
                     val sortedUsers = users.sortedByDescending {
                         contactRepo?.isFollowing(it.pubkey) == true
                     }
-                    items(sortedUsers, key = { it.pubkey }) { profile ->
+                    items(sortedUsers, key = { it.pubkey }, contentType = { "user" }) { profile ->
                         UserResultItem(
                             profile = profile,
                             isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
@@ -420,7 +420,7 @@ private fun RelaysTab(
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                             )
                         }
-                        items(lists, key = { "${it.pubkey}:${it.dTag}" }) { list ->
+                        items(lists, key = { "${it.pubkey}:${it.dTag}" }, contentType = { "list" }) { list ->
                             ListResultItem(
                                 followSet = list,
                                 eventRepo = eventRepo,
@@ -434,7 +434,7 @@ private fun RelaysTab(
                         }
                     }
 
-                    items(notes, key = { it.id }) { event ->
+                    items(notes, key = { it.id }, contentType = { "post" }) { event ->
                         val profile = eventRepo.getProfileData(event.pubkey)
                         val translationState = remember(relayTranslationVersion, event.id) {
                             translationRepo?.getState(event.id) ?: com.wisp.app.repo.TranslationState()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
@@ -179,7 +179,7 @@ fun ThreadScreen(
                     state = listState,
                     modifier = Modifier.fillMaxSize()
                 ) {
-                    items(items = flatThread, key = { it.first.id }) { (event, depth) ->
+                    items(items = flatThread, key = { it.first.id }, contentType = { "post" }) { (event, depth) ->
                         val profileData = eventRepo.getProfileData(event.pubkey)
                         val likeCount = reactionVersion.let { eventRepo.getReactionCount(event.id) }
                         val replyCount = replyCountVersion.let { eventRepo.getReplyCount(event.id) }


### PR DESCRIPTION
## Summary
- Replace `ByteArray.toHex()` `String.format()` per-byte with char lookup table (~10x faster, called 68+ times across the codebase)
- Cache `MessageDigest`, `Mac`, `ChaCha7539Engine`, and `Cipher` instances via `ThreadLocal` to avoid JCE provider lookup on every crypto call
- Fix `searchNotes()` allocating `.lowercase()` on every event's content — use `contains(query, ignoreCase = true)` instead
- Add `contentType` to `LazyColumn` `items()` calls across Feed, DM, Notifications, Search, and Thread screens for Compose item reuse
- Memoize `RichContent.parseContent()` regex parsing with `remember` keyed on content
- Increase DM conversation key cache from 50 → 200 entries to reduce ECDH re-derivation
- Replace `.lowercase()` string allocation in relay message checks with case-insensitive `contains`
- Convert large collection filter/sort/take chains to sequences in `EventRepository`

## Test plan
- [x] Manual test: scroll feed, open DMs, search notes, view profiles, view threads — no regressions
- [x] Verified hex encoding produces same output
- [x] NIP-04 and NIP-44 encrypt/decrypt still work correctly
- [x] All screens render correctly with contentType additions