### PR TITLE
Fix: chunk eTags to prevent relay rejections, refresh after publish

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -572,7 +572,8 @@ fun WispNavHost(
                 eventRepo = feedViewModel.eventRepo,
                 profileRepo = feedViewModel.profileRepo,
                 userPubkey = feedViewModel.getUserPubkey(),
-                signer = activeSigner
+                signer = activeSigner,
+                onNotePublished = { feedViewModel.refreshNotifRepliesEtag() }
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -17,6 +17,12 @@ class OutboxRouter(
          * their limit. Keeping author lists ≤200 per REQ avoids "total filter items too large".
          */
         private const val MAX_AUTHORS_PER_FILTER = 200
+
+        /**
+         * Maximum number of e-tags per filter. Relays reject REQs when total filter items
+         * exceed their limit. Chunking e-tags into multi-filter REQs avoids silent rejections.
+         */
+        const val MAX_ETAGS_PER_FILTER = 150
     }
 
     /**
@@ -387,8 +393,12 @@ class OutboxRouter(
 
         for ((relayUrl, eventIds) in relayToEventIds) {
             val uniqueIds = eventIds.distinct()
-            val filter = Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = uniqueIds, limit = 500)
-            if (relayPool.sendToRelayOrEphemeral(relayUrl, ClientMessage.req(prefix, filter))) {
+            val filters = uniqueIds.chunked(MAX_ETAGS_PER_FILTER).map { chunk ->
+                Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = chunk, limit = 500)
+            }
+            val msg = if (filters.size == 1) ClientMessage.req(prefix, filters[0])
+            else ClientMessage.req(prefix, filters)
+            if (relayPool.sendToRelayOrEphemeral(relayUrl, msg)) {
                 targetedRelays.add(relayUrl)
             }
         }
@@ -396,8 +406,12 @@ class OutboxRouter(
         // Fallback: authors without known relay lists → send to our read relays
         if (fallbackEventIds.isNotEmpty()) {
             val uniqueIds = fallbackEventIds.distinct()
-            val filter = Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = uniqueIds, limit = 500)
-            relayPool.sendToReadRelays(ClientMessage.req(prefix, filter))
+            val filters = uniqueIds.chunked(MAX_ETAGS_PER_FILTER).map { chunk ->
+                Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = chunk, limit = 500)
+            }
+            val msg = if (filters.size == 1) ClientMessage.req(prefix, filters[0])
+            else ClientMessage.req(prefix, filters)
+            relayPool.sendToReadRelays(msg)
         }
 
         // Safety net: send engagement queries for ALL event IDs to high-coverage relays.
@@ -405,8 +419,11 @@ class OutboxRouter(
         if (safetyNetRelays.isNotEmpty()) {
             val allEventIds = eventsByAuthor.values.flatten().distinct()
             if (allEventIds.isNotEmpty()) {
-                val filter = Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = allEventIds, limit = 500)
-                val msg = ClientMessage.req(prefix, filter)
+                val filters = allEventIds.chunked(MAX_ETAGS_PER_FILTER).map { chunk ->
+                    Filter(kinds = listOf(1, 5, 6, 7, 9735), eTags = chunk, limit = 500)
+                }
+                val msg = if (filters.size == 1) ClientMessage.req(prefix, filters[0])
+                else ClientMessage.req(prefix, filters)
                 for (url in safetyNetRelays) {
                     if (relayPool.sendToRelayOrEphemeral(url, msg)) {
                         targetedRelays.add(url)

--- a/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
@@ -141,7 +141,7 @@ class MetadataFetcher(
     fun addToPendingReplyCounts(eventId: String) {
         synchronized(pendingReplyCountIds) {
             pendingReplyCountIds.add(eventId)
-            val shouldFlushNow = pendingReplyCountIds.size >= 200
+            val shouldFlushNow = pendingReplyCountIds.size >= 150
             if (shouldFlushNow) {
                 replyCountBatchJob?.cancel()
                 flushReplyCountBatch()
@@ -157,7 +157,7 @@ class MetadataFetcher(
     fun addToPendingZapCounts(eventId: String) {
         synchronized(pendingZapCountIds) {
             pendingZapCountIds.add(eventId)
-            val shouldFlushNow = pendingZapCountIds.size >= 200
+            val shouldFlushNow = pendingZapCountIds.size >= 150
             if (shouldFlushNow) {
                 zapCountBatchJob?.cancel()
                 flushZapCountBatch()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -100,7 +100,8 @@ fun ComposeScreen(
     eventRepo: EventRepository? = null,
     profileRepo: ProfileRepository? = null,
     userPubkey: String? = null,
-    signer: com.wisp.app.nostr.NostrSigner? = null
+    signer: com.wisp.app.nostr.NostrSigner? = null,
+    onNotePublished: (() -> Unit)? = null
 ) {
     val content by viewModel.content.collectAsState()
     val publishing by viewModel.publishing.collectAsState()
@@ -522,7 +523,8 @@ fun ComposeScreen(
                                 quoteTo = quoteTo,
                                 onSuccess = { onBack() },
                                 outboxRouter = outboxRouter,
-                                signer = signer
+                                signer = signer,
+                                onNotePublished = onNotePublished
                             )
                         },
                         enabled = !publishing,

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -238,7 +238,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         quoteTo: NostrEvent? = null,
         onSuccess: () -> Unit = {},
         outboxRouter: OutboxRouter? = null,
-        signer: NostrSigner? = null
+        signer: NostrSigner? = null,
+        onNotePublished: (() -> Unit)? = null
     ) {
         val text = _content.value.text.trim()
 
@@ -254,7 +255,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         }
 
         _publishing.value = true
-        startCountdown(text, s, relayPool, replyTo, quoteTo, outboxRouter, onSuccess)
+        startCountdown(text, s, relayPool, replyTo, quoteTo, outboxRouter, onSuccess, onNotePublished)
     }
 
     private fun startCountdown(
@@ -264,7 +265,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         replyTo: NostrEvent?,
         quoteTo: NostrEvent?,
         outboxRouter: OutboxRouter?,
-        onSuccess: () -> Unit
+        onSuccess: () -> Unit,
+        onNotePublished: (() -> Unit)? = null
     ) {
         countdownJob?.cancel()
         pendingPublish = {
@@ -272,6 +274,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
                 try {
                     val sentCount = publishNote(content, signer, relayPool, replyTo, quoteTo, outboxRouter)
                     if (sentCount == 0) return@launch
+                    onNotePublished?.invoke()
                     onSuccess()
                 } catch (e: Exception) {
                     _error.value = "Failed to publish: ${e.message}"

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -690,9 +690,12 @@ class FeedSubscriptionManager(
 
         val zapSubId = "engage-notif-zap"
         activeEngagementSubIds.add(zapSubId)
-        relayPool.sendToReadRelays(
-            ClientMessage.req(zapSubId, Filter(kinds = listOf(9735), eTags = eventIds))
-        )
+        val zapFilters = eventIds.chunked(OutboxRouter.MAX_ETAGS_PER_FILTER).map { chunk ->
+            Filter(kinds = listOf(9735), eTags = chunk)
+        }
+        val zapMsg = if (zapFilters.size == 1) ClientMessage.req(zapSubId, zapFilters[0])
+        else ClientMessage.req(zapSubId, zapFilters)
+        relayPool.sendToReadRelays(zapMsg)
     }
 
     /** Reset state for account switch. */

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -254,6 +254,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun onAppResume(pausedMs: Long) = startup.onAppResume(pausedMs)
     fun refreshRelays() = startup.refreshRelays()
     fun refreshDmsAndNotifications() = startup.refreshDmsAndNotifications()
+    fun refreshNotifRepliesEtag() = startup.refreshNotifRepliesEtag()
 
     // -- Feed subscription delegates --
     fun setFeedType(type: FeedType) = feedSub.setFeedType(type)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -563,32 +563,45 @@ class StartupCoordinator(
             subManager.awaitEoseWithTimeout("self-notes", timeoutMs = 5_000)
             subManager.closeSubscription("self-notes")
 
-            // Subscribe for replies via e-tags on our own posts.
-            // Catches replies where the replier's client omits the p-tag.
-            val myEventIds = eventRepo.getRecentEventIdsByAuthor(myPubkey, limit = 100)
-            if (myEventIds.isNotEmpty()) {
-                val replyReqMsg = ClientMessage.req(
-                    "notif-replies-etag",
-                    Filter(kinds = listOf(1), eTags = myEventIds, limit = 200)
-                )
-                relayPool.sendToReadRelays(replyReqMsg)
-                // Replies often land on the relay where the original note was posted
-                val readUrls2 = relayPool.getReadRelayUrls().toSet()
-                val writeNotInRead = relayPool.getWriteRelayUrls().filter { it !in readUrls2 }
-                for (url in writeNotInRead) {
-                    relayPool.sendToRelay(url, replyReqMsg)
-                }
-                val topScored2 = relayScoreBoard.getScoredRelays()
-                    .take(5)
-                    .map { it.url }
-                    .filter { it !in readUrls2 && it !in writeNotInRead.toSet() }
-                for (url in topScored2) {
-                    relayPool.sendToRelay(url, replyReqMsg)
-                }
-                subManager.awaitEoseWithTimeout("notif-replies-etag", timeoutMs = 5_000)
-            }
+            refreshNotifRepliesEtag(myPubkey)
 
             feedSub.subscribeNotifEngagement()
+        }
+    }
+
+    /**
+     * Subscribe for replies via e-tags on our own posts.
+     * Catches replies where the replier's client omits the p-tag.
+     * Extracted so it can be re-called after publishing a note without
+     * re-running the full DM/notification setup.
+     */
+    fun refreshNotifRepliesEtag(myPubkey: String? = pubkeyHex) {
+        val pk = myPubkey ?: return
+        val myEventIds = eventRepo.getRecentEventIdsByAuthor(pk, limit = 100)
+        if (myEventIds.isEmpty()) return
+
+        val filters = myEventIds.chunked(OutboxRouter.MAX_ETAGS_PER_FILTER).map { chunk ->
+            Filter(kinds = listOf(1), eTags = chunk, limit = 200)
+        }
+        val replyReqMsg = if (filters.size == 1) ClientMessage.req("notif-replies-etag", filters[0])
+        else ClientMessage.req("notif-replies-etag", filters)
+
+        relayPool.sendToReadRelays(replyReqMsg)
+        // Replies often land on the relay where the original note was posted
+        val readUrls2 = relayPool.getReadRelayUrls().toSet()
+        val writeNotInRead = relayPool.getWriteRelayUrls().filter { it !in readUrls2 }
+        for (url in writeNotInRead) {
+            relayPool.sendToRelay(url, replyReqMsg)
+        }
+        val topScored2 = relayScoreBoard.getScoredRelays()
+            .take(5)
+            .map { it.url }
+            .filter { it !in readUrls2 && it !in writeNotInRead.toSet() }
+        for (url in topScored2) {
+            relayPool.sendToRelay(url, replyReqMsg)
+        }
+        scope.launch {
+            subManager.awaitEoseWithTimeout("notif-replies-etag", timeoutMs = 5_000)
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `MAX_ETAGS_PER_FILTER = 150` and chunks all unbounded e-tag arrays into multi-filter REQs across `OutboxRouter`, `FeedSubscriptionManager`, and `StartupCoordinator` — prevents relays from silently rejecting engagement/notification subscriptions when the feed has 200+ events
- Extracts `refreshNotifRepliesEtag()` from `subscribeDmsAndNotifications()` so it can be called independently after publishing a note, closing the 3-minute gap where new posts had no e-tag notification coverage
- Lowers `MetadataFetcher` flush thresholds from 200 → 150 to stay within the new limit

## Test plan
- [ ] Build with `./gradlew assembleDebug`
- [ ] With an account following 100+ users, check logcat for relay NOTICE errors about filter size (should be gone)
- [ ] Publish a note, have another account reply — verify the reply appears in notifications without waiting for the 3-min refresh cycle
- [ ] Verify engagement counts still populate on feed PostCards