### PR TITLE
fix: reject future-dated notes from all feeds

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -177,6 +177,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     fun addEvent(event: NostrEvent) {
         if (!seenEventIds.add(event.id)) return  // atomic dedup across all relay threads
+        if (event.created_at > System.currentTimeMillis() / 1000) return  // reject future-dated notes
         if (muteRepo?.isBlocked(event.pubkey) == true) return
         if (event.kind == 1 && muteRepo?.containsMutedWord(event.content) == true) return
         if (deletedEventsRepo?.isDeleted(event.id) == true) return
@@ -669,6 +670,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     // -- Isolated relay feed methods --
 
     fun addRelayFeedEvent(event: NostrEvent) {
+        if (event.created_at > System.currentTimeMillis() / 1000) return  // reject future-dated notes
         if (muteRepo?.isBlocked(event.pubkey) == true) return
         if (deletedEventsRepo?.isDeleted(event.id) == true) return
 


### PR DESCRIPTION
## Summary
- Drop events with `created_at` timestamps ahead of the current time in `addEvent()` and `addRelayFeedEvent()`, preventing future-dated notes from appearing in follows, extended, and relay feeds

## Test plan
- [ ] Verify normal notes still appear in all three feeds (follows, extended, relay)
- [ ] Confirm notes with future timestamps are silently dropped and do not appear in any feed