### PR TITLE
feat: add NIP-13 proof of work for notes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip13.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip13.kt
@@ -1,0 +1,100 @@
+package com.wisp.app.nostr
+
+import kotlinx.coroutines.ensureActive
+import kotlin.coroutines.coroutineContext
+
+/**
+ * NIP-13: Proof of Work
+ *
+ * Mining a nonce that makes the event ID hash start with a target number
+ * of leading zero bits, used as a spam-deterrence signal.
+ */
+object Nip13 {
+
+    data class MineResult(val tags: List<List<String>>, val createdAt: Long)
+
+    /**
+     * Count leading zero bits from a hex event ID.
+     * Each '0' hex char = 4 zero bits. First non-zero nibble contributes
+     * partial bits via leading zeros of that nibble.
+     */
+    fun countLeadingZeroBits(eventIdHex: String): Int {
+        var bits = 0
+        for (c in eventIdHex) {
+            val nibble = Character.digit(c, 16)
+            if (nibble == 0) {
+                bits += 4
+            } else {
+                // Count leading zeros of the 4-bit nibble
+                bits += when {
+                    nibble < 2 -> 3  // 0001
+                    nibble < 4 -> 2  // 001x
+                    nibble < 8 -> 1  // 01xx
+                    else -> 0        // 1xxx
+                }
+                break
+            }
+        }
+        return bits
+    }
+
+    /**
+     * Extract the committed difficulty from a nonce tag: ["nonce", "<value>", "<difficulty>"]
+     * Returns null if no valid nonce tag is present.
+     */
+    fun getCommittedDifficulty(event: NostrEvent): Int? {
+        val nonceTag = event.tags.firstOrNull { it.size >= 3 && it[0] == "nonce" }
+            ?: return null
+        return nonceTag[2].toIntOrNull()
+    }
+
+    /**
+     * Verify proof of work on an event. Returns actual leading zero bits
+     * if the event has a nonce tag and meets its committed difficulty, else 0.
+     */
+    fun verifyDifficulty(event: NostrEvent): Int {
+        val committed = getCommittedDifficulty(event) ?: return 0
+        val actual = countLeadingZeroBits(event.id)
+        return if (actual >= committed) actual else 0
+    }
+
+    /**
+     * Mine a nonce that produces an event ID with at least [targetDifficulty] leading zero bits.
+     *
+     * Iterates nonce values, computes event IDs via [NostrEvent.computeId], and checks
+     * leading zeros. Supports cancellation via coroutine cancellation (checks every 1024 iterations).
+     * Calls [onProgress] every 10,000 iterations with the current attempt count.
+     *
+     * @return [MineResult] with final tags (including winning nonce) and the pinned createdAt.
+     */
+    suspend fun mine(
+        pubkeyHex: String,
+        kind: Int,
+        content: String,
+        tags: List<List<String>>,
+        targetDifficulty: Int,
+        createdAt: Long = System.currentTimeMillis() / 1000,
+        onProgress: ((attempts: Long) -> Unit)? = null
+    ): MineResult {
+        var nonce = 0L
+        while (true) {
+            // Check cancellation periodically
+            if (nonce % 1024 == 0L) {
+                coroutineContext.ensureActive()
+            }
+            if (nonce % 10_000 == 0L && nonce > 0) {
+                onProgress?.invoke(nonce)
+            }
+
+            val mineTags = tags + listOf(listOf("nonce", nonce.toString(), targetDifficulty.toString()))
+            val id = NostrEvent.computeId(pubkeyHex, createdAt, kind, mineTags, content)
+            val bits = countLeadingZeroBits(id)
+
+            if (bits >= targetDifficulty) {
+                return MineResult(tags = mineTags, createdAt = createdAt)
+            }
+
+            nonce++
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -56,6 +56,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Surface
+import com.wisp.app.nostr.Nip13
 import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.ProfileData
@@ -273,6 +274,21 @@ fun PostCard(
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
             )
+            val powBits = remember(event.id) { Nip13.verifyDifficulty(event) }
+            if (powBits >= 16) {
+                Spacer(Modifier.width(4.dp))
+                Surface(
+                    shape = RoundedCornerShape(4.dp),
+                    color = Color(0xFFFF9800).copy(alpha = 0.15f)
+                ) {
+                    Text(
+                        text = "PoW $powBits",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color(0xFFFF9800),
+                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp)
+                    )
+                }
+            }
             Box {
                 var menuExpanded by remember { mutableStateOf(false) }
                 val context = LocalContext.current

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.content.contentReceiver
 import androidx.compose.foundation.content.hasMediaType
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
@@ -48,6 +49,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -112,6 +114,9 @@ fun ComposeScreen(
     val mentionCandidates by viewModel.mentionCandidates.collectAsState()
     val mentionQuery by viewModel.mentionQuery.collectAsState()
     val explicit by viewModel.explicit.collectAsState()
+    val powEnabled by viewModel.powEnabled.collectAsState()
+    val powDifficulty by viewModel.powDifficulty.collectAsState()
+    val miningProgress by viewModel.miningProgress.collectAsState()
     val context = LocalContext.current
 
     val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
@@ -386,6 +391,15 @@ fun ComposeScreen(
                         )
                     }
 
+                    IconButton(onClick = { viewModel.togglePow() }) {
+                        Icon(
+                            Icons.Outlined.Shield,
+                            contentDescription = "Proof of Work",
+                            tint = if (powEnabled) Color(0xFFFF9800)
+                                   else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
                     if (uploadProgress != null) {
                         Spacer(Modifier.width(8.dp))
                         CircularProgressIndicator(
@@ -432,6 +446,83 @@ fun ComposeScreen(
                                 color = MaterialTheme.colorScheme.onErrorContainer
                             )
                         }
+                    }
+                }
+
+                // PoW settings banner
+                AnimatedVisibility(
+                    visible = powEnabled,
+                    enter = expandVertically() + fadeIn(),
+                    exit = shrinkVertically() + fadeOut()
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(8.dp),
+                        color = Color(0xFFFF9800).copy(alpha = 0.12f),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp)
+                    ) {
+                        val orange = Color(0xFFFF9800)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                        ) {
+                            Icon(
+                                Icons.Outlined.Shield,
+                                contentDescription = null,
+                                tint = orange,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = "PoW: $powDifficulty bits",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = orange,
+                                modifier = Modifier.weight(1f)
+                            )
+                            IconButton(
+                                onClick = { viewModel.setPowDifficulty(powDifficulty - 1) },
+                                enabled = powDifficulty > 16,
+                                modifier = Modifier.size(32.dp)
+                            ) {
+                                Text(
+                                    "\u2212",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = orange
+                                )
+                            }
+                            IconButton(
+                                onClick = { viewModel.setPowDifficulty(powDifficulty + 1) },
+                                enabled = powDifficulty < 32,
+                                modifier = Modifier.size(32.dp)
+                            ) {
+                                Text(
+                                    "+",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = orange
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Mining progress
+                if (miningProgress != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = miningProgress ?: "",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                 }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Keys
 import com.wisp.app.nostr.Nip10
+import com.wisp.app.nostr.Nip13
 import com.wisp.app.nostr.Nip18
 import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.Nip37
@@ -27,11 +28,13 @@ import com.wisp.app.repo.MentionCandidate
 import com.wisp.app.repo.MentionSearchRepository
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.ProfileRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
 // Matches bare bech32 IDs not already preceded by "nostr:"
@@ -76,6 +79,23 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
 
     fun toggleExplicit() {
         _explicit.value = !_explicit.value
+    }
+
+    private val _powEnabled = MutableStateFlow(false)
+    val powEnabled: StateFlow<Boolean> = _powEnabled
+
+    private val _powDifficulty = MutableStateFlow(21)
+    val powDifficulty: StateFlow<Int> = _powDifficulty
+
+    private val _miningProgress = MutableStateFlow<String?>(null)
+    val miningProgress: StateFlow<String?> = _miningProgress
+
+    fun togglePow() {
+        _powEnabled.value = !_powEnabled.value
+    }
+
+    fun setPowDifficulty(bits: Int) {
+        _powDifficulty.value = bits.coerceIn(16, 32)
     }
 
     private var mentionStartIndex: Int = -1
@@ -350,7 +370,43 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         } else {
             content
         }
-        val event = signer.signEvent(kind = 1, content = finalContent, tags = tags)
+
+        // Mine proof of work if enabled
+        val finalTags: List<List<String>>
+        val finalCreatedAt: Long?
+        if (_powEnabled.value) {
+            val difficulty = _powDifficulty.value
+            val createdAt = System.currentTimeMillis() / 1000
+            _miningProgress.value = "Mining PoW ($difficulty bits)..."
+            try {
+                val result = withContext(Dispatchers.Default) {
+                    Nip13.mine(
+                        pubkeyHex = signer.pubkeyHex,
+                        kind = 1,
+                        content = finalContent,
+                        tags = tags,
+                        targetDifficulty = difficulty,
+                        createdAt = createdAt,
+                        onProgress = { attempts ->
+                            _miningProgress.value = "Mining PoW... ${attempts / 1000}k attempts"
+                        }
+                    )
+                }
+                finalTags = result.tags
+                finalCreatedAt = result.createdAt
+            } finally {
+                _miningProgress.value = null
+            }
+        } else {
+            finalTags = tags
+            finalCreatedAt = null
+        }
+
+        val event = if (finalCreatedAt != null) {
+            signer.signEvent(kind = 1, content = finalContent, tags = finalTags, createdAt = finalCreatedAt)
+        } else {
+            signer.signEvent(kind = 1, content = finalContent, tags = finalTags)
+        }
         val msg = ClientMessage.event(event)
         var sentCount = if (replyTo != null && outboxRouter != null) {
             outboxRouter.publishToInbox(msg, replyTo.pubkey)
@@ -495,6 +551,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         _uploadedUrls.value = emptyList()
         _uploadProgress.value = null
         _explicit.value = false
+        _powEnabled.value = false
+        _miningProgress.value = null
         clearMentionState()
     }
 }


### PR DESCRIPTION
## Summary
- Add `Nip13.kt` with mining algorithm (iterates nonces against `computeId()`) and verification (`countLeadingZeroBits`, `verifyDifficulty`)
- Add PoW toggle + difficulty slider (16–32 bits) to compose screen with orange themed UI
- Mine nonce before signing in `publishNote()`, cancellable via coroutine cancellation
- Display orange "PoW N" badge on notes with verified difficulty >= 16 bits in the feed

## Test plan
- [ ] Compose a note, enable PoW toggle, adjust difficulty, publish
- [ ] Verify published event JSON contains `["nonce", "<value>", "<difficulty>"]` tag
- [ ] Verify orange PoW badge appears on the note in the feed
- [ ] Verify cancel during mining works without crash
- [ ] Verify notes from other users with nonce tags show the badge
- [ ] Build: `./gradlew assembleDebug`