### PR TITLE
fix: add 30s grace period to future-dated note rejection

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -177,7 +177,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     fun addEvent(event: NostrEvent) {
         if (!seenEventIds.add(event.id)) return  // atomic dedup across all relay threads
-        if (event.created_at > System.currentTimeMillis() / 1000) return  // reject future-dated notes
+        if (event.created_at > System.currentTimeMillis() / 1000 + 30) return  // reject future-dated notes (30s grace for clock skew)
         if (muteRepo?.isBlocked(event.pubkey) == true) return
         if (event.kind == 1 && muteRepo?.containsMutedWord(event.content) == true) return
         if (deletedEventsRepo?.isDeleted(event.id) == true) return
@@ -670,7 +670,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     // -- Isolated relay feed methods --
 
     fun addRelayFeedEvent(event: NostrEvent) {
-        if (event.created_at > System.currentTimeMillis() / 1000) return  // reject future-dated notes
+        if (event.created_at > System.currentTimeMillis() / 1000 + 30) return  // reject future-dated notes (30s grace for clock skew)
         if (muteRepo?.isBlocked(event.pubkey) == true) return
         if (deletedEventsRepo?.isDeleted(event.id) == true) return
 


### PR DESCRIPTION
## Summary
- Adds a 30-second grace period to the future-dated note rejection check in both `addEvent()` and `addRelayFeedEvent()`
- Fixes an issue where own posts were silently dropped due to minor clock skew between device and relay

## Test plan
- [x] Post a note and verify it appears in your own feed and profile immediately
- [ ] Verify notes dated more than 30 seconds in the future are still rejected