### PR TITLE
fix: filter quotes from threads and add #q notification subscription

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Filter.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Filter.kt
@@ -13,6 +13,7 @@ data class Filter(
     val pTags: List<String>? = null,
     val dTags: List<String>? = null,
     val tTags: List<String>? = null,
+    val qTags: List<String>? = null,
     val since: Long? = null,
     val until: Long? = null,
     val limit: Int? = null,
@@ -26,6 +27,7 @@ data class Filter(
         pTags?.let { put("#p", buildJsonArray { it.forEach { p -> add(JsonPrimitive(p)) } }) }
         dTags?.let { put("#d", buildJsonArray { it.forEach { d -> add(JsonPrimitive(d)) } }) }
         tTags?.let { put("#t", buildJsonArray { it.forEach { t -> add(JsonPrimitive(t)) } }) }
+        qTags?.let { put("#q", buildJsonArray { it.forEach { q -> add(JsonPrimitive(q)) } }) }
         since?.let { put("since", JsonPrimitive(it)) }
         until?.let { put("until", JsonPrimitive(it)) }
         limit?.let { put("limit", JsonPrimitive(it)) }

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip10.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip10.kt
@@ -31,6 +31,19 @@ object Nip10 {
         return eTags.firstOrNull()?.get(1)
     }
 
+    /**
+     * Returns true if the event is a standalone quote (has a `q` tag but no marked
+     * `e` tags with root/reply markers). These should not appear in thread views.
+     */
+    fun isStandaloneQuote(event: NostrEvent): Boolean {
+        val hasQTag = event.tags.any { it.size >= 2 && it[0] == "q" }
+        if (!hasQTag) return false
+        val hasMarkedETag = event.tags.any {
+            it.size >= 4 && it[0] == "e" && (it[3] == "root" || it[3] == "reply")
+        }
+        return !hasMarkedETag
+    }
+
     fun buildReplyTags(replyTo: NostrEvent, relayHint: String = ""): List<List<String>> {
         val tags = mutableListOf<List<String>>()
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -114,6 +114,16 @@ class EventRouter(
                     metadataFetcher.addToPendingProfiles(event.pubkey)
                 }
             }
+        } else if (subscriptionId == "notif-quotes-qtag") {
+            if (muteRepo.isBlocked(event.pubkey)) return
+            val myPubkey = getUserPubkey()
+            if (myPubkey != null && event.kind == 1) {
+                eventRepo.cacheEvent(event)
+                notifRepo.addEvent(event, myPubkey)
+                if (eventRepo.getProfileData(event.pubkey) == null) {
+                    metadataFetcher.addToPendingProfiles(event.pubkey)
+                }
+            }
         } else if (subscriptionId == "self-notes") {
             eventRepo.cacheEvent(event)
             if (event.kind == 1) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -600,8 +600,19 @@ class StartupCoordinator(
         for (url in topScored2) {
             relayPool.sendToRelay(url, replyReqMsg)
         }
+        // Also subscribe for quotes of our posts via #q tags
+        val quoteFilters = myEventIds.chunked(OutboxRouter.MAX_ETAGS_PER_FILTER).map { chunk ->
+            Filter(kinds = listOf(1), qTags = chunk, limit = 200)
+        }
+        val quoteReqMsg = if (quoteFilters.size == 1) ClientMessage.req("notif-quotes-qtag", quoteFilters[0])
+        else ClientMessage.req("notif-quotes-qtag", quoteFilters)
+        relayPool.sendToReadRelays(quoteReqMsg)
+        for (url in writeNotInRead) relayPool.sendToRelay(url, quoteReqMsg)
+        for (url in topScored2) relayPool.sendToRelay(url, quoteReqMsg)
+
         scope.launch {
             subManager.awaitEoseWithTimeout("notif-replies-etag", timeoutMs = 5_000)
+            subManager.awaitEoseWithTimeout("notif-quotes-qtag", timeoutMs = 5_000)
         }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
@@ -127,6 +127,7 @@ class ThreadViewModel : ViewModel() {
                 eventRepo.cacheEvent(event)
                 eventRepo.addEventRelay(event.id, relayUrl)
 
+                if (Nip10.isStandaloneQuote(event)) return@collect
                 val isNew = event.id !in threadEvents
                 threadEvents[event.id] = event
                 if (event.id == rootId) {
@@ -332,6 +333,7 @@ class ThreadViewModel : ViewModel() {
         for (event in threadEvents.values) {
             if (event.id == rootId) continue
             if (muteRepo?.isBlocked(event.pubkey) == true) continue
+            if (Nip10.isStandaloneQuote(event)) continue
             var parentId = Nip10.getReplyTarget(event) ?: rootId
             if (parentId != rootId && parentId !in threadEvents) {
                 parentId = rootId


### PR DESCRIPTION
## Summary
- Filter standalone quotes (events with `q` tag but no `root`/`reply` e-tags) from thread views so they don't appear as replies
- Add `qTags` field to `Filter` for `#q` tag filtering
- Add `notif-quotes-qtag` subscription to catch quotes of our posts via `#q` tags, even when the quoter omits a `p` tag
- Route `notif-quotes-qtag` events through `EventRouter` to notifications

## Test plan
- [ ] Open a thread where someone quoted the root note — quote should NOT appear as a reply in the thread
- [ ] Have another account quote your note — should appear in notifications
- [ ] Verify replies that also contain quotes still show in threads (they have marked e-tags)
- [ ] Verify build succeeds with `./gradlew assembleDebug`