### PR TITLE
fix: show year in timestamps for older notes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -752,6 +752,7 @@ private fun formatZapAmount(sats: Long): String = when {
 }
 
 private val dateTimeFormat = SimpleDateFormat("MMM d, HH:mm", Locale.US)
+private val dateTimeYearFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
 
 /**
  * Format an epoch timestamp into a relative or absolute time string.
@@ -775,5 +776,15 @@ private fun formatTimestamp(epoch: Long): String {
     val days = diff / (24 * 60 * 60 * 1000L)
     if (days == 1L) return "yesterday"
 
-    return dateTimeFormat.format(Date(millis))
+    val date = Date(millis)
+    val cal = java.util.Calendar.getInstance()
+    val currentYear = cal.get(java.util.Calendar.YEAR)
+    cal.time = date
+    val dateYear = cal.get(java.util.Calendar.YEAR)
+
+    return if (dateYear != currentYear) {
+        dateTimeYearFormat.format(date)
+    } else {
+        dateTimeFormat.format(date)
+    }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
@@ -138,8 +138,17 @@ fun DmListScreen(
 }
 
 private val timeFormat = SimpleDateFormat("MMM d", Locale.US)
+private val timeYearFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
 
 private fun formatTimestamp(epoch: Long): String {
     if (epoch == 0L) return ""
-    return timeFormat.format(Date(epoch * 1000))
+    val date = Date(epoch * 1000)
+    val cal = java.util.Calendar.getInstance()
+    val currentYear = cal.get(java.util.Calendar.YEAR)
+    cal.time = date
+    return if (cal.get(java.util.Calendar.YEAR) != currentYear) {
+        timeYearFormat.format(date)
+    } else {
+        timeFormat.format(date)
+    }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -1011,6 +1011,7 @@ private fun ReferencedNotePostCard(
 }
 
 private val notifDateTimeFormat = SimpleDateFormat("MMM d, HH:mm", Locale.US)
+private val notifDateTimeYearFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
 
 private fun formatNotifTimestamp(epoch: Long): String {
     if (epoch == 0L) return ""
@@ -1031,7 +1032,17 @@ private fun formatNotifTimestamp(epoch: Long): String {
     val days = diff / (24 * 60 * 60 * 1000L)
     if (days == 1L) return "yesterday"
 
-    return notifDateTimeFormat.format(Date(millis))
+    val date = Date(millis)
+    val cal = java.util.Calendar.getInstance()
+    val currentYear = cal.get(java.util.Calendar.YEAR)
+    cal.time = date
+    val dateYear = cal.get(java.util.Calendar.YEAR)
+
+    return if (dateYear != currentYear) {
+        notifDateTimeYearFormat.format(date)
+    } else {
+        notifDateTimeFormat.format(date)
+    }
 }
 
 private fun formatSats(sats: Long): String = when {


### PR DESCRIPTION
## Summary
- Timestamps for notes not in the current year now display the year (e.g., "Jan 5, 2024" instead of "Jan 5, 14:30")
- Applied consistently across post cards, notifications, and DM list