### PR TITLE
fix: bypass relay dedup for notification subscriptions

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -79,7 +79,7 @@ class RelayPool {
 
     /** Subscription prefixes that bypass event deduplication. */
     private val dedupBypassPrefixes = java.util.concurrent.CopyOnWriteArrayList(
-        listOf("thread-", "user", "quote-", "editprofile")
+        listOf("thread-", "user", "quote-", "editprofile", "notif")
     )
 
     /** Signing lambda for NIP-42 AUTH — set via [setAuthSigner]. */


### PR DESCRIPTION
## Summary
- Notification events (replies, reactions, zaps, reposts) from followed users were silently dropped because RelayPool's global dedup marked them as seen when they arrived via the `feed` subscription first, preventing them from being routed to `NotificationRepository` when they arrived via `notif`
- Added `"notif"` to the dedup bypass prefix list, covering all notification subscriptions (`notif`, `notif-replies-etag`, `notif-quotes-qtag`)
- Each downstream layer (`EventRepository`, `NotificationRepository`) has its own dedup, so double-processing is safe

## Test plan
- [ ] Log in with an account that follows active users
- [ ] Verify replies from followed users appear in notifications without needing to open the thread first
- [ ] Verify reactions, zaps, and reposts still show up correctly
- [ ] Verify no duplicate entries in the notification list