### PR TITLE
fix: resolve relay feed connection failures on first attempt

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
@@ -1,5 +1,6 @@
 package com.wisp.app.relay
 
+import okhttp3.Dispatcher
 import okhttp3.Dns
 import okhttp3.OkHttpClient
 import java.net.InetAddress
@@ -25,7 +26,16 @@ object HttpClientFactory {
         val isTor = TorManager.isEnabled()
         val connectTimeout = if (isTor) 30L else 10L
 
+        // OkHttp's default Dispatcher.maxRequests is 64, which caps concurrent
+        // WebSocket upgrade requests. With outbox routing creating 50+ ephemeral
+        // connections, new user-initiated connections get queued and time out.
+        val dispatcher = Dispatcher().apply {
+            maxRequests = 256
+            maxRequestsPerHost = 10
+        }
+
         val builder = OkHttpClient.Builder()
+            .dispatcher(dispatcher)
             .connectTimeout(connectTimeout, TimeUnit.SECONDS)
             .pingInterval(30, TimeUnit.SECONDS)
             .readTimeout(0, TimeUnit.MILLISECONDS)

--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -219,10 +219,15 @@ class Relay(
 
     private fun drainPendingMessages(ws: WebSocket) {
         synchronized(sendLock) {
+            var count = 0
             var msg = pendingMessages.poll()
             while (msg != null) {
                 ws.send(msg)
+                count++
                 msg = pendingMessages.poll()
+            }
+            if (count > 0) {
+                Log.d("RLC", "[Relay] drainPendingMessages(${config.url}): $count msgs drained")
             }
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -606,10 +606,26 @@ class RelayPool {
             }
         }
 
-        // Cap ephemeral relays to prevent connection explosion
+        // Cap ephemeral relays to prevent connection explosion.
+        // Evict the least-recently-used ephemeral relay to make room — user-initiated
+        // connections (relay feed, thread views) shouldn't fail because stale outbox
+        // routing connections filled the pool.
         if (!ephemeralRelays.containsKey(url) && ephemeralRelays.size >= MAX_EPHEMERAL) {
-            Log.d("RLC", "[Pool] sendToRelayOrEphemeral($url) SKIPPED — ephemeral cap ($MAX_EPHEMERAL) reached")
-            return false
+            val lruEntry = ephemeralLastUsed.minByOrNull { it.value }
+            if (lruEntry != null) {
+                val evictUrl = lruEntry.key
+                Log.d("RLC", "[Pool] ephemeral cap reached — evicting LRU ephemeral $evictUrl")
+                ephemeralRelays.remove(evictUrl)?.disconnect()
+                ephemeralLastUsed.remove(evictUrl)
+                relayIndex.remove(evictUrl)
+                cancelRelayJobs(evictUrl)
+                activeSubscriptions.remove(evictUrl)
+                subscriptionTracker.untrackRelay(evictUrl)
+                updateConnectedCount()
+            } else {
+                Log.d("RLC", "[Pool] sendToRelayOrEphemeral($url) SKIPPED — ephemeral cap ($MAX_EPHEMERAL) reached")
+                return false
+            }
         }
 
         // Create ephemeral relay if needed — computeIfAbsent is atomic on ConcurrentHashMap
@@ -632,7 +648,11 @@ class RelayPool {
         }
         ephemeralLastUsed[url] = System.currentTimeMillis()
         val sent = ephemeral.send(message)
-        return sent || isNew  // new relays will drain queue on connect
+        // Return true if: message was sent immediately, OR relay is new (will drain
+        // queue on connect), OR relay exists but is still connecting (message was queued
+        // and will drain on connect — returning false here would incorrectly signal failure).
+        val isConnecting = !ephemeral.isConnected
+        return sent || isNew || isConnecting
     }
 
     private fun cooldownForFailure(httpCode: Int?): Long {

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -670,7 +670,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     // -- Isolated relay feed methods --
 
     fun addRelayFeedEvent(event: NostrEvent) {
-        if (event.created_at > System.currentTimeMillis() / 1000 + 30) return  // reject future-dated notes (30s grace for clock skew)
+        if (event.created_at > System.currentTimeMillis() / 1000 + 30) return
         if (muteRepo?.isBlocked(event.pubkey) == true) return
         if (deletedEventsRepo?.isDeleted(event.id) == true) return
 
@@ -713,7 +713,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     private fun relayFeedBinaryInsert(event: NostrEvent, sortTime: Long = event.created_at) {
         synchronized(relayFeedList) {
-            if (!relayFeedIds.add(event.id)) return  // already in relay feed
+            if (!relayFeedIds.add(event.id)) return
             var low = 0
             var high = relayFeedList.size
             while (low < high) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -144,6 +144,13 @@ class FeedSubscriptionManager(
                 }
             }
             FeedType.RELAY -> {
+                // Skip if already in RELAY mode — setSelectedRelay() already triggered
+                // subscribeRelayFeed(). Double-subscribing causes a race where the second
+                // call finds the ephemeral relay still connecting and fails.
+                if (prev == FeedType.RELAY) {
+                    Log.d("RLC", "[FeedSub] setFeedType RELAY → RELAY — skipping, already subscribed")
+                    return
+                }
                 eventRepo.clearRelayFeed()
                 subscribeRelayFeed()
             }
@@ -447,7 +454,6 @@ class FeedSubscriptionManager(
     // -- Isolated relay feed subscription --
 
     private fun subscribeRelayFeed() {
-        Log.d("RLC", "[FeedSub] subscribeRelayFeed()")
         val oldSubId = relayFeedSubId
         relayFeedGeneration++
         relayFeedSubId = "relay-feed-$relayFeedGeneration"


### PR DESCRIPTION
## Summary
- Raised OkHttp Dispatcher limits (maxRequests=256, maxRequestsPerHost=10) to prevent WebSocket upgrade starvation when 50+ outbox connections are active
- Added LRU eviction to ephemeral relay pool so new connections succeed instead of hard-failing at the cap
- Fixed double-subscribe race in `setFeedType(RELAY)` and corrected return value for connecting-but-queued ephemeral relays

## Test plan
- [ ] Browse relay feeds that previously failed on first attempt (e.g. `wss://news.utxo.one`) — should load immediately
- [ ] Verify main feed still loads correctly with outbox routing
- [ ] Minimize and resume app — relay feeds should still reconnect properly