### PR TITLE
fix: exclude quoted event from e-tag extraction

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -356,8 +356,9 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             }
         }
         val existingEventIds = tags.filter { it.firstOrNull() == "e" }.map { it[1] }.toSet()
+        val quoteEventId = quoteTo?.id
         for (eventId in mentionedEventIds) {
-            if (eventId !in existingEventIds) {
+            if (eventId !in existingEventIds && eventId != quoteEventId) {
                 tags.add(listOf("e", eventId, "", "mention"))
             }
         }


### PR DESCRIPTION
## Summary
- When quoting a note, the quoted event ID was being added as both a `q` tag (correct) and an `e` tag with `mention` marker (incorrect)
- Skip the quoted event ID during mention extraction so only `p` and `q` tags are included on quote notes

## Test plan
- [ ] Quote a note and verify the published event contains `q` and `p` tags but no `e` tag for the quoted event
- [ ] Reply to a note and verify `e` tags are still added correctly
- [ ] Mention a `nostr:nevent1...` URI in a regular note and verify `e` tag is still added