### PR TITLE
fix: resolve race condition in follow list loading during onboarding

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
@@ -477,12 +478,11 @@ class StartupCoordinator(
 
         // EOSE and events travel on separate SharedFlows, so the kind 3 event may still
         // be buffered in relayEvents waiting for the processing loop on Dispatchers.Default.
-        // Poll briefly to let it catch up before the caller reads the follow list.
-        if (contactRepo.getFollowList().isEmpty() && eoseCount > 0) {
-            withTimeoutOrNull(2_000) {
-                while (contactRepo.getFollowList().isEmpty()) {
-                    delay(50)
-                }
+        // Wait reactively for the follow list to arrive rather than polling — this handles
+        // both slow event processing and cases where EOSE times out but events still arrive.
+        if (contactRepo.getFollowList().isEmpty()) {
+            withTimeoutOrNull(5_000) {
+                contactRepo.followList.first { it.isNotEmpty() }
             }
         }
 


### PR DESCRIPTION
## Summary
- Replace poll-based wait (50ms loop, 2s timeout) with reactive `StateFlow.first {}` wait (5s timeout) for follow list arrival in `subscribeSelfData()`
- Remove `eoseCount > 0` guard so we always wait for the follow list, even if all indexer relays timed out without sending EOSE
- Fixes intermittent (~10%) cold start failure where the kind 3 event was still buffered in the event processing pipeline when the startup flow read the follow list, resulting in an empty author filter and blank feed

## Root cause
EOSE and events travel on separate SharedFlows. After `awaitEoseCount` returns, the kind 3 event may still be queued in `relayPool.relayEvents` waiting for the processing loop on `Dispatchers.Default`. The old polling approach had two problems:
1. Only polled if `eoseCount > 0` — skipped entirely when indexer relays timed out
2. 2-second polling window wasn't always sufficient for slow event processing

## Test plan
- [ ] Cold start with existing account — feed should load reliably
- [ ] Warm start (app relaunch) — no regression, feed loads instantly
- [ ] Slow network simulation — verify 5s timeout doesn't block startup indefinitely