### PR TITLE
fix: coverage-based waiting for social graph discovery

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -515,7 +515,7 @@ class RelayPool {
      * Send to only the first [maxRelays] connected relays (prioritizing pinned relays).
      * Used for metadata fetches where full broadcast is wasteful.
      */
-    fun sendToTopRelays(message: String, maxRelays: Int = 10) {
+    fun sendToTopRelays(message: String, maxRelays: Int = 10): Int {
         val subId = extractSubId(message)
         var sentCount = 0
         // Send to pinned relays first
@@ -545,6 +545,7 @@ class RelayPool {
             }
         }
         if (subId != null) Log.d("RLC", "[Pool] sendToTopRelays sub=$subId → $sentCount/$maxRelays relays")
+        return sentCount
     }
 
     fun sendToRelay(url: String, message: String) {

--- a/app/src/main/kotlin/com/wisp/app/repo/ExtendedNetworkRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/ExtendedNetworkRepository.kt
@@ -12,6 +12,8 @@ import com.wisp.app.relay.RelayPool
 import com.wisp.app.relay.RelayScoreBoard
 import com.wisp.app.relay.SubscriptionManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
@@ -79,7 +81,7 @@ class ExtendedNetworkRepository(
     companion object {
         private const val TAG = "ExtendedNetworkRepo"
         private const val THRESHOLD = 10
-        private const val FOLLOW_LIST_TIMEOUT_MS = 3_000L
+        private const val FOLLOW_LIST_TIMEOUT_MS = 8_000L
         private const val RELAY_LIST_CHUNK_SIZE = 500
         private const val RELAY_LIST_TIMEOUT_MS = 8_000L
         private const val MAX_EXTENDED_RELAYS = 100
@@ -165,10 +167,32 @@ class ExtendedNetworkRepository(
             val allFilters = chunks.map { chunk -> Filter(kinds = listOf(3), authors = chunk) }
             val msg = if (allFilters.size == 1) ClientMessage.req(subId, allFilters[0])
             else ClientMessage.req(subId, allFilters)
-            relayPool.sendToTopRelays(msg, maxRelays = 15)
+            val sentCount = relayPool.sendToTopRelays(msg, maxRelays = 15)
 
-            // Wait with timeout, then close the single subscription
-            kotlinx.coroutines.delay(FOLLOW_LIST_TIMEOUT_MS)
+            // Coverage-based waiting: poll until 70% of follow lists received,
+            // EOSE from all relays, or hard timeout (8s).
+            val coverageTarget = (firstDegree.size * 0.7).toInt()
+            val deadline = System.currentTimeMillis() + FOLLOW_LIST_TIMEOUT_MS
+            coroutineScope {
+                val eoseDeferred = async {
+                    subManager.awaitEoseCount(subId, sentCount, FOLLOW_LIST_TIMEOUT_MS)
+                }
+                while (System.currentTimeMillis() < deadline) {
+                    val fetched = pendingFollowLists.size
+                    if (fetched >= coverageTarget) {
+                        Log.d(TAG, "Follow list coverage target met: $fetched/$coverageTarget")
+                        break
+                    }
+                    if (eoseDeferred.isCompleted) {
+                        Log.d(TAG, "All EOSE received, $fetched follow lists collected")
+                        break
+                    }
+                    kotlinx.coroutines.delay(200)
+                }
+                // Grace period for buffered events to flush through the processing pipeline
+                kotlinx.coroutines.delay(300)
+                eoseDeferred.cancel()
+            }
             subManager.closeSubscription(subId)
             discoveryTotal = 0
 
@@ -244,20 +268,41 @@ class ExtendedNetworkRepository(
                 val rlSubIds = mutableListOf<String>()
                 _discoveryState.value = DiscoveryState.FetchingRelayLists(0, missingRelayLists.size)
 
+                val sentCounts = mutableListOf<Pair<String, Int>>()
                 for ((i, chunk) in chunks.withIndex()) {
                     val rlSubId = "extnet-rl-$i"
                     rlSubIds.add(rlSubId)
                     val filter = Filter(kinds = listOf(10002), authors = chunk)
-                    relayPool.sendToTopRelays(ClientMessage.req(rlSubId, filter), maxRelays = 10)
+                    val sent = relayPool.sendToTopRelays(ClientMessage.req(rlSubId, filter), maxRelays = 10)
+                    sentCounts.add(rlSubId to sent)
                 }
 
-                kotlinx.coroutines.delay(RELAY_LIST_TIMEOUT_MS)
+                // Coverage-based waiting: poll until 70% of relay lists received,
+                // EOSE from all relays, or hard timeout.
+                val rlCoverageTarget = (missingRelayLists.size * 0.7).toInt()
+                val rlDeadline = System.currentTimeMillis() + RELAY_LIST_TIMEOUT_MS
+                coroutineScope {
+                    val eoseDeferreds = sentCounts.map { (subId, count) ->
+                        async { subManager.awaitEoseCount(subId, count, RELAY_LIST_TIMEOUT_MS) }
+                    }
+                    while (System.currentTimeMillis() < rlDeadline) {
+                        val stillMissing = relayListRepo.getMissingPubkeys(qualified.toList()).size
+                        val fetched = missingRelayLists.size - stillMissing
+                        _discoveryState.value = DiscoveryState.FetchingRelayLists(fetched, missingRelayLists.size)
+                        if (fetched >= rlCoverageTarget) {
+                            Log.d(TAG, "Relay list coverage target met: $fetched/$rlCoverageTarget")
+                            break
+                        }
+                        if (eoseDeferreds.all { it.isCompleted }) {
+                            Log.d(TAG, "All relay list EOSE received, $fetched relay lists collected")
+                            break
+                        }
+                        kotlinx.coroutines.delay(200)
+                    }
+                    kotlinx.coroutines.delay(300)
+                    eoseDeferreds.forEach { it.cancel() }
+                }
                 for (rlSubId in rlSubIds) subManager.closeSubscription(rlSubId)
-
-                _discoveryState.value = DiscoveryState.FetchingRelayLists(
-                    fetched = missingRelayLists.size,
-                    total = missingRelayLists.size
-                )
             }
 
             // Step 5: Greedy set-cover to find optimal relays for the extended network

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -340,7 +340,7 @@ class StartupCoordinator(
 
                     val subscriptionSent = fetchRelayListsForFollows(includeProfiles = true)
                     if (subscriptionSent) {
-                        val target = (follows.size * 0.7).toInt()
+                        val target = (follows.size * 0.8).toInt()
                         val deadline = System.currentTimeMillis() + 7_000
                         while (System.currentTimeMillis() < deadline) {
                             val covered = follows.size - relayListRepo.getMissingPubkeys(follows).size


### PR DESCRIPTION
## Summary
- Replace blind delay timeouts with coverage-based polling during extended network discovery (`discoverNetwork()`)
- `sendToTopRelays()` now returns relay count so callers can use EOSE-based early exit
- Follow list and relay list fetches poll every 200ms, early-exiting at 70% coverage or when all EOSE signals arrive, with an 8s hard timeout (up from 3s for follow lists) and a 300ms grace period for buffered events
- StartupCoordinator relay list coverage target increased from 70% to 80% for more consistent relay routing on cold start

## Test plan
- [ ] Clear app data, log in as existing user with a non-trivial follow list
- [ ] Observe onboarding loading screen completes with consistent follower counts across multiple cold starts
- [ ] Check logcat `ExtendedNetworkRepo` logs for higher follow list coverage
- [ ] Verify feed loads correctly after onboarding