### PR TITLE
fix: use generic avatar in onboarding long-press demo

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ExistingUserOnboardingScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ExistingUserOnboardingScreen.kt
@@ -52,7 +52,7 @@ private enum class OnboardingStep {
     WELCOME, DECENTRALIZATION, LONG_PRESS_DEMO, NWC_SETUP, WAITING
 }
 
-private const val UTXO_PICTURE = "https://nostr.build/i/p/e2ccf7cf20403f3f2a4a55b328f0de3be38558a7d5f33632fdaaefc726c1c8eb/pfp/1710366908.webp"
+private val UTXO_PICTURE: String? = null  // Generic avatar — avoids stale relay images
 
 @Composable
 fun ExistingUserOnboardingScreen(


### PR DESCRIPTION
## Summary
- Replace hardcoded nostr.build profile picture URL with a generic avatar in the onboarding long-press demo step
- The old URL was returning a stale/incorrect image on first login

## Test plan
- [ ] Fresh login flow shows the app's default avatar in the long-press demo step
- [ ] Long-press follow/unfollow interaction still works correctly