### PR TITLE
Interactive social graph with force-directed layout

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1080,8 +1080,12 @@ fun WispNavHost(
             SocialGraphScreen(
                 extendedNetworkRepo = feedViewModel.extendedNetworkRepo,
                 profileRepo = feedViewModel.profileRepo,
+                socialGraphDb = feedViewModel.socialGraphDb,
                 userPubkey = feedViewModel.getUserPubkey(),
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                onNavigateToProfile = { pubkey ->
+                    navController.navigate("profile/$pubkey")
+                }
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/repo/SocialGraphDb.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/SocialGraphDb.kt
@@ -61,6 +61,22 @@ class SocialGraphDb(context: Context) : SQLiteOpenHelper(context, "social_graph.
         }
     }
 
+    fun getTopByFollowerCount(limit: Int, fromPubkeys: Set<String>): List<Pair<String, Int>> {
+        if (fromPubkeys.isEmpty()) return emptyList()
+        val result = mutableListOf<Pair<String, Int>>()
+        val db = readableDatabase
+        val placeholders = fromPubkeys.joinToString(",") { "?" }
+        db.rawQuery(
+            "SELECT pubkey, COUNT(*) as cnt FROM followed_by WHERE follower IN ($placeholders) GROUP BY pubkey ORDER BY cnt DESC LIMIT ?",
+            fromPubkeys.toTypedArray() + limit.toString()
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                result.add(cursor.getString(0) to cursor.getInt(1))
+            }
+        }
+        return result
+    }
+
     fun clearAll() {
         try {
             writableDatabase.execSQL("DELETE FROM followed_by")

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SocialGraphScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SocialGraphScreen.kt
@@ -2,9 +2,16 @@ package com.wisp.app.ui.screen
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,65 +20,93 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import android.content.res.Configuration
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.wisp.app.nostr.Nip19
+import com.wisp.app.nostr.hexToByteArray
 import com.wisp.app.repo.DiscoveryState
 import com.wisp.app.repo.ExtendedNetworkCache
 import com.wisp.app.repo.ExtendedNetworkRepository
 import com.wisp.app.repo.NetworkStats
 import com.wisp.app.repo.ProfileRepository
+import com.wisp.app.repo.SocialGraphDb
 import com.wisp.app.ui.component.ProfilePicture
+import com.wisp.app.viewmodel.GraphNode
+import com.wisp.app.viewmodel.RankedAccount
+import com.wisp.app.viewmodel.SocialGraphViewModel
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
+import kotlin.math.roundToInt
 import java.util.Date
 import java.util.Locale
-import kotlin.math.cos
-import kotlin.math.roundToInt
-import kotlin.math.sin
+import kotlin.math.sqrt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SocialGraphScreen(
     extendedNetworkRepo: ExtendedNetworkRepository,
     profileRepo: ProfileRepository,
+    socialGraphDb: SocialGraphDb,
     userPubkey: String?,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onNavigateToProfile: (String) -> Unit
 ) {
     val discoveryState by extendedNetworkRepo.discoveryState.collectAsState()
     val cachedNetwork by extendedNetworkRepo.cachedNetwork.collectAsState()
     val scope = rememberCoroutineScope()
+    val graphViewModel: SocialGraphViewModel = viewModel()
 
     LaunchedEffect(Unit) {
         extendedNetworkRepo.resetDiscoveryState()
+    }
+
+    // Initialize graph when cache is available
+    LaunchedEffect(cachedNetwork) {
+        val cache = cachedNetwork ?: return@LaunchedEffect
+        graphViewModel.init(cache, socialGraphDb, profileRepo, userPubkey)
     }
 
     Scaffold(
@@ -89,57 +124,84 @@ fun SocialGraphScreen(
             )
         }
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            when (val state = discoveryState) {
-                is DiscoveryState.Idle -> {
-                    IdleContent(
-                        cachedNetwork = cachedNetwork,
-                        extendedNetworkRepo = extendedNetworkRepo,
+        when (val state = discoveryState) {
+            is DiscoveryState.Idle -> {
+                if (cachedNetwork != null) {
+                    GraphContent(
+                        cachedNetwork = cachedNetwork!!,
+                        graphViewModel = graphViewModel,
                         profileRepo = profileRepo,
-                        userPubkey = userPubkey,
-                        onRecompute = { scope.launch { extendedNetworkRepo.discoverNetwork() } }
+                        extendedNetworkRepo = extendedNetworkRepo,
+                        socialGraphDb = socialGraphDb,
+                        onNavigateToProfile = onNavigateToProfile,
+                        onRecompute = { scope.launch { extendedNetworkRepo.discoverNetwork() } },
+                        modifier = Modifier.padding(padding)
                     )
+                } else {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding)
+                            .padding(horizontal = 16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Spacer(modifier = Modifier.height(48.dp))
+                        Text(
+                            text = "Social graph has not been computed yet.",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Button(onClick = { scope.launch { extendedNetworkRepo.discoverNetwork() } }) {
+                            Text("Compute Now")
+                        }
+                    }
                 }
-                is DiscoveryState.FetchingFollowLists -> {
+            }
+            is DiscoveryState.FetchingFollowLists -> {
+                ProgressColumn(padding) {
                     ProgressContent(
                         label = "Fetching follow lists...",
                         progress = if (state.total > 0) state.fetched.toFloat() / state.total else 0f,
                         detail = "${state.fetched} / ${state.total}"
                     )
                 }
-                is DiscoveryState.ComputingNetwork -> {
+            }
+            is DiscoveryState.ComputingNetwork -> {
+                ProgressColumn(padding) {
                     ProgressContent(
                         label = "Computing network...",
                         detail = "${state.uniqueUsers} unique users"
                     )
                 }
-                is DiscoveryState.Filtering -> {
+            }
+            is DiscoveryState.Filtering -> {
+                ProgressColumn(padding) {
                     ProgressContent(
                         label = "Filtering...",
                         detail = "${state.qualified} qualified"
                     )
                 }
-                is DiscoveryState.FetchingRelayLists -> {
+            }
+            is DiscoveryState.FetchingRelayLists -> {
+                ProgressColumn(padding) {
                     ProgressContent(
                         label = "Fetching relay lists...",
                         progress = if (state.total > 0) state.fetched.toFloat() / state.total else 0f,
                         detail = "${state.fetched} / ${state.total}"
                     )
                 }
-                is DiscoveryState.Complete -> {
+            }
+            is DiscoveryState.Complete -> {
+                ProgressColumn(padding) {
                     CompleteContent(
                         stats = state.stats,
                         onDone = { extendedNetworkRepo.resetDiscoveryState() }
                     )
                 }
-                is DiscoveryState.Failed -> {
+            }
+            is DiscoveryState.Failed -> {
+                ProgressColumn(padding) {
                     FailedContent(
                         reason = state.reason,
                         onRetry = { scope.launch { extendedNetworkRepo.discoverNetwork() } }
@@ -150,303 +212,455 @@ fun SocialGraphScreen(
     }
 }
 
-// --- Graph data model ---
-
-private data class GraphNode(
-    val pubkey: String,
-    val pictureUrl: String?,
-    val x: Float, // offset from center in dp
-    val y: Float,
-    val size: Int  // dp
-)
-
-private data class GraphEdge(
-    val from: GraphNode,
-    val to: GraphNode
-)
-
-private data class GraphLayout(
-    val center: GraphNode,
-    val innerNodes: List<GraphNode>,
-    val outerNodes: List<GraphNode>,
-    val edges: List<GraphEdge>
-)
-
-private fun computeGraphLayout(
-    cache: ExtendedNetworkCache,
-    extendedNetworkRepo: ExtendedNetworkRepository,
-    profileRepo: ProfileRepository,
-    userPubkey: String?
-): GraphLayout {
-    val centerSize = 56
-    val innerSize = 36
-    val outerSize = 28
-    val innerRadius = 90f  // dp from center
-    val outerRadius = 155f // dp from center
-
-    // Center node
-    val centerPic = userPubkey?.let { profileRepo.get(it)?.picture }
-    val centerNode = GraphNode(
-        pubkey = userPubkey ?: "",
-        pictureUrl = centerPic,
-        x = 0f, y = 0f,
-        size = centerSize
-    )
-
-    // Pick up to 8 first-degree follows, preferring those with profile pictures
-    val firstDegree = cache.firstDegreePubkeys.toList()
-    val withPics = firstDegree.filter { profileRepo.get(it)?.picture != null }
-    val withoutPics = firstDegree.filter { profileRepo.get(it)?.picture == null }
-    val selectedInner = (withPics.shuffled() + withoutPics.shuffled()).take(8)
-
-    val innerNodes = selectedInner.mapIndexed { i, pk ->
-        val angle = (2.0 * Math.PI * i / selectedInner.size) - Math.PI / 2
-        GraphNode(
-            pubkey = pk,
-            pictureUrl = profileRepo.get(pk)?.picture,
-            x = (innerRadius * cos(angle)).toFloat(),
-            y = (innerRadius * sin(angle)).toFloat(),
-            size = innerSize
-        )
-    }
-
-    // Pick up to 14 qualified (2nd-degree) pubkeys, clustered near the inner node that connects them
-    val qualified = cache.qualifiedPubkeys.toList()
-    val qualWithPics = qualified.filter { profileRepo.get(it)?.picture != null }
-    val qualWithoutPics = qualified.filter { profileRepo.get(it)?.picture == null }
-    val candidateOuter = (qualWithPics.shuffled() + qualWithoutPics.shuffled()).take(14)
-
-    val outerNodes = mutableListOf<GraphNode>()
-    val outerEdges = mutableListOf<GraphEdge>()
-
-    // Track how many outer nodes are assigned to each inner node for angular spread
-    val innerAssignCount = mutableMapOf<Int, Int>()
-
-    for (pk in candidateOuter) {
-        // Find which inner node follows this pubkey
-        val followers = extendedNetworkRepo.getFollowedBy(pk)
-        val parentIdx = innerNodes.indexOfFirst { it.pubkey in followers }
-        val parent = if (parentIdx >= 0) innerNodes[parentIdx] else innerNodes.randomOrNull() ?: continue
-        val pIdx = if (parentIdx >= 0) parentIdx else 0
-
-        val assignNum = innerAssignCount.getOrDefault(pIdx, 0)
-        innerAssignCount[pIdx] = assignNum + 1
-
-        // Angle from center to parent, then spread outer nodes around it
-        val parentAngle = Math.atan2(parent.y.toDouble(), parent.x.toDouble())
-        val spreadAngle = (assignNum - 0.5) * 0.35 // ~20 degree spread between siblings
-        val angle = parentAngle + spreadAngle
-
-        val node = GraphNode(
-            pubkey = pk,
-            pictureUrl = profileRepo.get(pk)?.picture,
-            x = (outerRadius * cos(angle)).toFloat(),
-            y = (outerRadius * sin(angle)).toFloat(),
-            size = outerSize
-        )
-        outerNodes.add(node)
-        outerEdges.add(GraphEdge(parent, node))
-    }
-
-    // Edges from center to inner nodes
-    val centerEdges = innerNodes.map { GraphEdge(centerNode, it) }
-
-    return GraphLayout(
-        center = centerNode,
-        innerNodes = innerNodes,
-        outerNodes = outerNodes,
-        edges = centerEdges + outerEdges
-    )
-}
-
-// --- Composables ---
-
 @Composable
-private fun IdleContent(
-    cachedNetwork: ExtendedNetworkCache?,
-    extendedNetworkRepo: ExtendedNetworkRepository,
-    profileRepo: ProfileRepository,
-    userPubkey: String?,
-    onRecompute: () -> Unit
+private fun ProgressColumn(
+    padding: PaddingValues,
+    content: @Composable () -> Unit
 ) {
-    Spacer(modifier = Modifier.height(16.dp))
-
-    if (cachedNetwork != null) {
-        SocialGraphVisualization(
-            cachedNetwork = cachedNetwork,
-            extendedNetworkRepo = extendedNetworkRepo,
-            profileRepo = profileRepo,
-            userPubkey = userPubkey
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        StatsCard(cachedNetwork.stats)
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        val date = Date(cachedNetwork.computedAtEpoch * 1000)
-        val fmt = SimpleDateFormat("MMM d, yyyy  h:mm a", Locale.getDefault())
-        Text(
-            text = "Last computed: ${fmt.format(date)}",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        OutlinedButton(onClick = onRecompute) {
-            Text("Recompute")
-        }
-    } else {
-        Text(
-            text = "Social graph has not been computed yet.",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Button(onClick = onRecompute) {
-            Text("Compute Now")
-        }
-    }
-}
-
-@Composable
-private fun SocialGraphVisualization(
-    cachedNetwork: ExtendedNetworkCache,
-    extendedNetworkRepo: ExtendedNetworkRepository,
-    profileRepo: ProfileRepository,
-    userPubkey: String?
-) {
-    val layout = remember(cachedNetwork) {
-        computeGraphLayout(cachedNetwork, extendedNetworkRepo, profileRepo, userPubkey)
-    }
-
-    val boxSize = 340.dp
-    val density = LocalDensity.current
-    val primaryColor = MaterialTheme.colorScheme.primary
-    val surfaceVariantColor = MaterialTheme.colorScheme.surfaceVariant
-
-    Box(
-        modifier = Modifier.size(boxSize),
-        contentAlignment = Alignment.Center
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Connection lines drawn on Canvas
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            val centerX = size.width / 2f
-            val centerY = size.height / 2f
+        content()
+    }
+}
 
-            for (edge in layout.edges) {
-                val fromX = centerX + with(density) { edge.from.x.dp.toPx() }
-                val fromY = centerY + with(density) { edge.from.y.dp.toPx() }
-                val toX = centerX + with(density) { edge.to.x.dp.toPx() }
-                val toY = centerY + with(density) { edge.to.y.dp.toPx() }
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GraphContent(
+    cachedNetwork: ExtendedNetworkCache,
+    graphViewModel: SocialGraphViewModel,
+    profileRepo: ProfileRepository,
+    extendedNetworkRepo: ExtendedNetworkRepository,
+    socialGraphDb: SocialGraphDb,
+    onNavigateToProfile: (String) -> Unit,
+    onRecompute: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val nodes by graphViewModel.nodes.collectAsState()
+    val edges by graphViewModel.edges.collectAsState()
+    val selectedNode by graphViewModel.selectedNode.collectAsState()
+    val topAccounts by graphViewModel.topAccounts.collectAsState()
 
-                // Cubic bezier curving slightly toward center
-                val midX = (fromX + toX) / 2f
-                val midY = (fromY + toY) / 2f
-                val ctrlOffsetX = (centerX - midX) * 0.2f
-                val ctrlOffsetY = (centerY - midY) * 0.2f
+    val nodeDetailSheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
 
-                val path = Path().apply {
-                    moveTo(fromX, fromY)
-                    cubicTo(
-                        fromX + ctrlOffsetX, fromY + ctrlOffsetY,
-                        toX + ctrlOffsetX, toY + ctrlOffsetY,
-                        toX, toY
+    val scaffoldState = rememberBottomSheetScaffoldState(
+        bottomSheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.PartiallyExpanded
+        )
+    )
+
+    val configuration = LocalConfiguration.current
+    val sheetMaxHeight = (configuration.screenHeightDp * 0.7f).dp
+
+    BottomSheetScaffold(
+        scaffoldState = scaffoldState,
+        sheetPeekHeight = 100.dp,
+        sheetDragHandle = {
+            // Compact drag handle — just the pill
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, bottom = 4.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(width = 32.dp, height = 4.dp)
+                        .background(
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                            shape = MaterialTheme.shapes.extraSmall
+                        )
+                )
+            }
+        },
+        sheetContainerColor = MaterialTheme.colorScheme.surface,
+        sheetContent = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = sheetMaxHeight)
+            ) {
+                // Compact header: title + stats inline
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 6.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Top Accounts",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text = "${cachedNetwork.stats.qualifiedCount} qualified from ${cachedNetwork.stats.firstDegreeCount} follows",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
 
-                drawPath(
-                    path = path,
-                    brush = Brush.linearGradient(
-                        colors = listOf(
-                            primaryColor.copy(alpha = 0.4f),
-                            surfaceVariantColor.copy(alpha = 0.15f)
-                        ),
-                        start = Offset(fromX, fromY),
-                        end = Offset(toX, toY)
-                    ),
-                    style = Stroke(width = 1.5f.dp.toPx(), cap = StrokeCap.Round)
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+
+                // Top accounts list
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(top = 4.dp, bottom = 16.dp)
+                ) {
+                    itemsIndexed(topAccounts) { index, account ->
+                        TopAccountRow(
+                            rank = index + 1,
+                            account = account,
+                            profileRepo = profileRepo,
+                            onClick = { onNavigateToProfile(account.pubkey) }
+                        )
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            OutlinedButton(onClick = onRecompute) {
+                                Text("Recompute")
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        modifier = modifier
+    ) { innerPadding ->
+        // Graph fills the background behind the sheet
+        InteractiveGraphCanvas(
+            nodes = nodes,
+            edges = edges,
+            profileRepo = profileRepo,
+            onNodeTapped = { node -> graphViewModel.selectNode(node) },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        )
+    }
+
+    // Node detail bottom sheet (separate modal, on top of everything)
+    if (selectedNode != null) {
+        val node = selectedNode!!
+        ModalBottomSheet(
+            onDismissRequest = { graphViewModel.selectNode(null) },
+            sheetState = nodeDetailSheetState
+        ) {
+            NodeDetailSheet(
+                node = node,
+                profileRepo = profileRepo,
+                socialGraphDb = socialGraphDb,
+                onViewProfile = {
+                    scope.launch {
+                        nodeDetailSheetState.hide()
+                        graphViewModel.selectNode(null)
+                        onNavigateToProfile(node.pubkey)
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun InteractiveGraphCanvas(
+    nodes: List<GraphNode>,
+    edges: List<com.wisp.app.viewmodel.GraphEdge>,
+    profileRepo: ProfileRepository,
+    onNodeTapped: (GraphNode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+
+    val transformableState = rememberTransformableState { zoomChange, panChange, _ ->
+        scale = (scale * zoomChange).coerceIn(0.3f, 5f)
+        offset += panChange
+    }
+
+    val density = LocalDensity.current
+    val edgeColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.15f)
+
+    Box(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.surfaceContainerLowest)
+            .clipToBounds()
+            .transformable(state = transformableState)
+            .pointerInput(nodes) {
+                detectTapGestures { tapOffset ->
+                    val centerX = size.width / 2f
+                    val centerY = size.height / 2f
+                    val graphX = (tapOffset.x - centerX - offset.x) / scale
+                    val graphY = (tapOffset.y - centerY - offset.y) / scale
+
+                    var nearest: GraphNode? = null
+                    var nearestDist = Float.MAX_VALUE
+                    for (node in nodes) {
+                        val nodePx = with(density) { node.x.dp.toPx() }
+                        val nodePy = with(density) { node.y.dp.toPx() }
+                        val dx = graphX - nodePx
+                        val dy = graphY - nodePy
+                        val dist = sqrt(dx * dx + dy * dy)
+                        val radiusPx = with(density) { (node.radius + 8f).dp.toPx() }
+                        if (dist < radiusPx && dist < nearestDist) {
+                            nearest = node
+                            nearestDist = dist
+                        }
+                    }
+                    if (nearest != null) {
+                        onNodeTapped(nearest)
+                    }
+                }
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        // Edge lines drawn on Canvas
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                    translationX = offset.x
+                    translationY = offset.y
+                }
+        ) {
+            val centerX = size.width / 2f
+            val centerY = size.height / 2f
+
+            val nodePositions = HashMap<String, Offset>(nodes.size)
+            for (node in nodes) {
+                nodePositions[node.pubkey] = Offset(
+                    centerX + node.x.dp.toPx(),
+                    centerY + node.y.dp.toPx()
+                )
+            }
+
+            for (edge in edges) {
+                val from = nodePositions[edge.fromPubkey] ?: continue
+                val to = nodePositions[edge.toPubkey] ?: continue
+                drawLine(
+                    color = edgeColor,
+                    start = from,
+                    end = to,
+                    strokeWidth = 1f.dp.toPx()
                 )
             }
         }
 
-        // Center node
-        ProfilePicture(
-            url = layout.center.pictureUrl,
-            size = layout.center.size,
-            highlighted = true,
-            modifier = Modifier.align(Alignment.Center)
+        // Profile picture nodes overlaid on top
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                    translationX = offset.x
+                    translationY = offset.y
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            for (node in nodes) {
+                val profile = remember(node.pubkey) { profileRepo.get(node.pubkey) }
+                val sizeDp = (node.radius * 2).toInt()
+
+                ProfilePicture(
+                    url = profile?.picture,
+                    size = sizeDp,
+                    highlighted = node.degree == 0,
+                    modifier = Modifier.offset {
+                        IntOffset(
+                            x = (node.x.dp.toPx() - sizeDp.dp.toPx() / 2f).roundToInt(),
+                            y = (node.y.dp.toPx() - sizeDp.dp.toPx() / 2f).roundToInt()
+                        )
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatsRow(stats: NetworkStats) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        StatChip("Follows", stats.firstDegreeCount.toString())
+        StatChip("2nd degree", stats.totalSecondDegree.toString())
+        StatChip("Qualified", stats.qualifiedCount.toString())
+        StatChip("Relays", stats.relaysCovered.toString())
+    }
+}
+
+@Composable
+private fun StatChip(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun TopAccountRow(
+    rank: Int,
+    account: RankedAccount,
+    profileRepo: ProfileRepository,
+    onClick: () -> Unit
+) {
+    val profile = remember(account.pubkey) { profileRepo.get(account.pubkey) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "#$rank",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(32.dp)
         )
 
-        // Inner ring nodes
-        for (node in layout.innerNodes) {
-            val halfSize = node.size / 2
-            ProfilePicture(
-                url = node.pictureUrl,
-                size = node.size,
-                modifier = Modifier.offset {
-                    IntOffset(
-                        x = (node.x.dp.toPx() - halfSize.dp.toPx()).roundToInt(),
-                        y = (node.y.dp.toPx() - halfSize.dp.toPx()).roundToInt()
-                    )
-                }
-            )
-        }
+        ProfilePicture(
+            url = profile?.picture,
+            size = 36
+        )
 
-        // Outer ring nodes
-        for (node in layout.outerNodes) {
-            val halfSize = node.size / 2
-            ProfilePicture(
-                url = node.pictureUrl,
-                size = node.size,
-                modifier = Modifier.offset {
-                    IntOffset(
-                        x = (node.x.dp.toPx() - halfSize.dp.toPx()).roundToInt(),
-                        y = (node.y.dp.toPx() - halfSize.dp.toPx()).roundToInt()
-                    )
-                }
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = profile?.displayName
+                    ?: profile?.name
+                    ?: "${account.pubkey.take(8)}...",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = "followed by ${account.followerCount}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     }
 }
 
 @Composable
-private fun StatsCard(stats: NetworkStats) {
+private fun NodeDetailSheet(
+    node: GraphNode,
+    profileRepo: ProfileRepository,
+    socialGraphDb: SocialGraphDb,
+    onViewProfile: () -> Unit
+) {
+    val profile = remember(node.pubkey) { profileRepo.get(node.pubkey) }
+    val followers = remember(node.pubkey) { socialGraphDb.getFollowers(node.pubkey) }
+    val npub = remember(node.pubkey) {
+        try {
+            Nip19.npubEncode(node.pubkey.hexToByteArray())
+        } catch (_: Exception) {
+            node.pubkey.take(16) + "..."
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .animateContentSize(),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        StatRow("Follows (1st degree)", stats.firstDegreeCount.toString())
-        StatRow("2nd degree users", stats.totalSecondDegree.toString())
-        StatRow("Qualified (threshold)", stats.qualifiedCount.toString())
-        StatRow("Relays covered", stats.relaysCovered.toString())
-    }
-}
+        ProfilePicture(
+            url = profile?.picture,
+            size = 72
+        )
 
-@Composable
-private fun StatRow(label: String, value: String) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
+        Spacer(modifier = Modifier.height(12.dp))
+
         Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
+            text = profile?.displayName
+                ?: profile?.name
+                ?: "${node.pubkey.take(8)}...",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Text(
+            text = "${npub.take(12)}...${npub.takeLast(8)}",
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
         Text(
-            text = value,
+            text = "Followed by ${node.followerCount} of your follows",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface
         )
+
+        // Show small avatar row of followers (up to 6)
+        val followerProfiles = remember(followers) {
+            followers.take(6).map { pk -> pk to profileRepo.get(pk) }
+        }
+
+        if (followerProfiles.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy((-4).dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                for ((pk, fp) in followerProfiles) {
+                    ProfilePicture(
+                        url = fp?.picture,
+                        size = 28
+                    )
+                }
+                if (followers.size > 6) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "+${followers.size - 6}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Button(onClick = onViewProfile) {
+            Text("View Profile")
+        }
     }
 }
+
+// --- Progress / Complete / Failed states ---
 
 @Composable
 private fun ProgressContent(
@@ -497,12 +711,41 @@ private fun CompleteContent(
 
     Spacer(modifier = Modifier.height(16.dp))
 
-    StatsCard(stats)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        StatDetailRow("Follows (1st degree)", stats.firstDegreeCount.toString())
+        StatDetailRow("2nd degree users", stats.totalSecondDegree.toString())
+        StatDetailRow("Qualified (threshold)", stats.qualifiedCount.toString())
+        StatDetailRow("Relays covered", stats.relaysCovered.toString())
+    }
 
     Spacer(modifier = Modifier.height(24.dp))
 
     OutlinedButton(onClick = onDone) {
         Text("Done")
+    }
+}
+
+@Composable
+private fun StatDetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialGraphViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialGraphViewModel.kt
@@ -1,0 +1,318 @@
+package com.wisp.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wisp.app.repo.ExtendedNetworkCache
+import com.wisp.app.repo.ProfileRepository
+import com.wisp.app.repo.SocialGraphDb
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.math.ln
+import kotlin.math.min
+import kotlin.math.sqrt
+
+data class GraphNode(
+    val pubkey: String,
+    val degree: Int, // 0 = user, 1 = first-degree, 2 = second-degree
+    val followerCount: Int,
+    val radius: Float,
+    var x: Float,
+    var y: Float,
+    var vx: Float = 0f,
+    var vy: Float = 0f
+)
+
+data class GraphEdge(
+    val fromPubkey: String,
+    val toPubkey: String
+)
+
+data class RankedAccount(
+    val pubkey: String,
+    val followerCount: Int
+)
+
+class SocialGraphViewModel : ViewModel() {
+
+    private val _nodes = MutableStateFlow<List<GraphNode>>(emptyList())
+    val nodes: StateFlow<List<GraphNode>> = _nodes
+
+    private val _edges = MutableStateFlow<List<GraphEdge>>(emptyList())
+    val edges: StateFlow<List<GraphEdge>> = _edges
+
+    private val _selectedNode = MutableStateFlow<GraphNode?>(null)
+    val selectedNode: StateFlow<GraphNode?> = _selectedNode
+
+    private val _topAccounts = MutableStateFlow<List<RankedAccount>>(emptyList())
+    val topAccounts: StateFlow<List<RankedAccount>> = _topAccounts
+
+    private val _simulationSettled = MutableStateFlow(false)
+    val simulationSettled: StateFlow<Boolean> = _simulationSettled
+
+    private var simulationJob: Job? = null
+    private var initialized = false
+
+    fun selectNode(node: GraphNode?) {
+        _selectedNode.value = node
+    }
+
+    fun init(
+        cache: ExtendedNetworkCache,
+        socialGraphDb: SocialGraphDb,
+        profileRepo: ProfileRepository,
+        userPubkey: String?
+    ) {
+        if (initialized) return
+        initialized = true
+
+        viewModelScope.launch(Dispatchers.Default) {
+            val firstDegree = cache.firstDegreePubkeys.toList()
+            val firstDegreeSet = cache.firstDegreePubkeys
+
+            // Get top accounts ranked by within-network follower count
+            val topRanked = socialGraphDb.getTopByFollowerCount(200, firstDegreeSet)
+            val followerCountMap = topRanked.associate { it.first to it.second }
+
+            // Select nodes: top 15 first-degree by follower count
+            val top1stDegree = firstDegree
+                .sortedByDescending { followerCountMap[it] ?: 0 }
+                .take(15)
+            val top1stSet = top1stDegree.toSet()
+
+            // Top 64 second-degree (qualified) by follower count, excluding first-degree and user
+            val excludeSet = firstDegreeSet + setOfNotNull(userPubkey)
+            val top2ndDegree = topRanked
+                .filter { it.first !in excludeSet }
+                .take(64)
+                .map { it.first }
+
+            // Build nodes
+            val nodeList = mutableListOf<GraphNode>()
+
+            // User at center
+            if (userPubkey != null) {
+                nodeList.add(GraphNode(
+                    pubkey = userPubkey,
+                    degree = 0,
+                    followerCount = followerCountMap[userPubkey] ?: 0,
+                    radius = 24f,
+                    x = 0f, y = 0f
+                ))
+            }
+
+            // First-degree in a ring at radius 200
+            top1stDegree.forEachIndexed { i, pk ->
+                val angle = (2.0 * Math.PI * i / top1stDegree.size) - Math.PI / 2
+                val fc = followerCountMap[pk] ?: 0
+                val r = computeRadius(fc, degree = 1)
+                nodeList.add(GraphNode(
+                    pubkey = pk,
+                    degree = 1,
+                    followerCount = fc,
+                    radius = r,
+                    x = (200f * Math.cos(angle)).toFloat(),
+                    y = (200f * Math.sin(angle)).toFloat()
+                ))
+            }
+
+            // Second-degree at radius 400 near their strongest 1st-degree connection
+            val nodesByPubkey = nodeList.associateBy { it.pubkey }
+            val edgeList = mutableListOf<GraphEdge>()
+
+            for (pk in top2ndDegree) {
+                val followers = socialGraphDb.getFollowers(pk)
+                // Find which 1st-degree nodes follow this pubkey
+                val connecting1st = followers.filter { it in top1stSet }
+                val parent = connecting1st
+                    .mapNotNull { nodesByPubkey[it] }
+                    .maxByOrNull { it.followerCount }
+
+                val parentX = parent?.x ?: 0f
+                val parentY = parent?.y ?: 0f
+                val parentAngle = Math.atan2(parentY.toDouble(), parentX.toDouble())
+                val jitter = (Math.random() - 0.5) * 0.8
+                val angle = parentAngle + jitter
+
+                val fc = followerCountMap[pk] ?: 0
+                val r = computeRadius(fc, degree = 2)
+                val node = GraphNode(
+                    pubkey = pk,
+                    degree = 2,
+                    followerCount = fc,
+                    radius = r,
+                    x = (400f * Math.cos(angle)).toFloat(),
+                    y = (400f * Math.sin(angle)).toFloat()
+                )
+                nodeList.add(node)
+
+                // Add edges from connecting 1st-degree nodes
+                for (conn in connecting1st) {
+                    if (conn in top1stSet) {
+                        edgeList.add(GraphEdge(conn, pk))
+                    }
+                }
+            }
+
+            // Add edges from user to 1st-degree
+            if (userPubkey != null) {
+                for (pk in top1stDegree) {
+                    edgeList.add(GraphEdge(userPubkey, pk))
+                }
+            }
+
+            // Top accounts list (top 30)
+            _topAccounts.value = topRanked
+                .filter { it.first !in setOfNotNull(userPubkey) }
+                .take(30)
+                .map { RankedAccount(it.first, it.second) }
+
+            _nodes.value = nodeList
+            _edges.value = edgeList
+
+            // Start force simulation
+            runSimulation()
+        }
+    }
+
+    private fun computeRadius(followerCount: Int, degree: Int): Float {
+        val base = when (degree) {
+            0 -> 24f
+            1 -> 12f
+            else -> 7f
+        }
+        val maxR = when (degree) {
+            0 -> 24f
+            1 -> 22f
+            else -> 16f
+        }
+        val scale = when (degree) {
+            1 -> 2.5f
+            else -> 2.0f
+        }
+        val r = base + (ln((followerCount + 1).toDouble()) / ln(2.0)).toFloat() * scale
+        return min(r, maxR)
+    }
+
+    private fun runSimulation() {
+        simulationJob?.cancel()
+        simulationJob = viewModelScope.launch(Dispatchers.Default) {
+            val maxTicks = 300
+            val settleThreshold = 0.5f
+            val damping = 0.88f
+            val repulsionK = 8000f
+            val attractionK = 0.005f
+            val restLength = 120f
+            val centerGravity = 0.01f
+            val frameDelay = 33L // ~30fps
+
+            for (tick in 0 until maxTicks) {
+                if (!isActive) break
+
+                val currentNodes = _nodes.value.toMutableList()
+                val edges = _edges.value
+                val n = currentNodes.size
+                if (n == 0) break
+
+                // Build pubkey -> index map
+                val indexMap = HashMap<String, Int>(n)
+                for (i in currentNodes.indices) {
+                    indexMap[currentNodes[i].pubkey] = i
+                }
+
+                // Reset forces
+                val fx = FloatArray(n)
+                val fy = FloatArray(n)
+
+                // Repulsion between all pairs
+                for (i in 0 until n) {
+                    val ni = currentNodes[i]
+                    for (j in i + 1 until n) {
+                        val nj = currentNodes[j]
+                        var dx = ni.x - nj.x
+                        var dy = ni.y - nj.y
+                        var distSq = dx * dx + dy * dy
+                        if (distSq < 1f) {
+                            dx = (Math.random().toFloat() - 0.5f) * 2f
+                            dy = (Math.random().toFloat() - 0.5f) * 2f
+                            distSq = dx * dx + dy * dy
+                        }
+                        val dist = sqrt(distSq)
+                        val radiusScale = (ni.radius + nj.radius) / 20f
+                        val force = repulsionK * radiusScale / distSq
+                        val forceX = force * dx / dist
+                        val forceY = force * dy / dist
+                        fx[i] += forceX
+                        fy[i] += forceY
+                        fx[j] -= forceX
+                        fy[j] -= forceY
+                    }
+                }
+
+                // Attraction along edges
+                for (edge in edges) {
+                    val iFrom = indexMap[edge.fromPubkey] ?: continue
+                    val iTo = indexMap[edge.toPubkey] ?: continue
+                    val nFrom = currentNodes[iFrom]
+                    val nTo = currentNodes[iTo]
+                    val dx = nTo.x - nFrom.x
+                    val dy = nTo.y - nFrom.y
+                    val dist = sqrt(dx * dx + dy * dy)
+                    if (dist < 0.01f) continue
+                    val displacement = dist - restLength
+                    val force = attractionK * displacement
+                    val forceX = force * dx / dist
+                    val forceY = force * dy / dist
+                    fx[iFrom] += forceX
+                    fy[iFrom] += forceY
+                    fx[iTo] -= forceX
+                    fy[iTo] -= forceY
+                }
+
+                // Center gravity
+                for (i in 0 until n) {
+                    val ni = currentNodes[i]
+                    fx[i] -= centerGravity * ni.x
+                    fy[i] -= centerGravity * ni.y
+                }
+
+                // Apply forces, update velocities and positions
+                var maxVelocity = 0f
+                for (i in 0 until n) {
+                    val node = currentNodes[i]
+                    if (node.degree == 0) {
+                        // Pin user at center
+                        currentNodes[i] = node.copy(x = 0f, y = 0f, vx = 0f, vy = 0f)
+                        continue
+                    }
+                    val newVx = (node.vx + fx[i]) * damping
+                    val newVy = (node.vy + fy[i]) * damping
+                    val newX = node.x + newVx
+                    val newY = node.y + newVy
+                    currentNodes[i] = node.copy(x = newX, y = newY, vx = newVx, vy = newVy)
+                    val vel = sqrt(newVx * newVx + newVy * newVy)
+                    if (vel > maxVelocity) maxVelocity = vel
+                }
+
+                _nodes.value = currentNodes
+
+                if (maxVelocity < settleThreshold && tick > 50) {
+                    _simulationSettled.value = true
+                    break
+                }
+
+                delay(frameDelay)
+            }
+            _simulationSettled.value = true
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        simulationJob?.cancel()
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the static 22-node graph with an interactive force-directed layout (~80 nodes)
- Add `SocialGraphViewModel` with velocity Verlet physics simulation running at ~30fps
- Add `getTopByFollowerCount()` batch ranking query to `SocialGraphDb`
- Rewrite `SocialGraphScreen` with pinch-to-zoom, pan, tap-to-inspect nodes (profile picture avatars), and a pull-up `BottomSheetScaffold` drawer showing ranked top accounts
- Tap a node to see a detail sheet with profile info, mutual followers, and "View Profile" navigation

## Test plan
- [ ] Open Social Graph from drawer menu
- [ ] Verify graph animates into a force-directed layout with profile picture nodes
- [ ] Pinch to zoom and pan to explore the graph
- [ ] Tap a node — detail sheet shows profile pic, name, npub, follower count, and avatar row
- [ ] Tap "View Profile" in the detail sheet — navigates to the profile screen
- [ ] Pull up the bottom drawer — top accounts list scrolls smoothly
- [ ] Tap a row in the top accounts list — navigates to profile
- [ ] Verify discovery progress/complete/failed states still work when recomputing