### PR TITLE
feat: PoW overhaul — background mining, persistent settings, reaction PoW

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -68,6 +68,7 @@ import com.wisp.app.ui.screen.ListScreen
 import com.wisp.app.ui.screen.ExistingUserOnboardingScreen
 import com.wisp.app.ui.screen.LoadingScreen
 import com.wisp.app.ui.screen.ListsHubScreen
+import com.wisp.app.ui.screen.PowSettingsScreen
 import com.wisp.app.ui.screen.OnboardingScreen
 import com.wisp.app.ui.component.AddNoteToListDialog
 import com.wisp.app.ui.screen.OnboardingSuggestionsScreen
@@ -90,6 +91,7 @@ import com.wisp.app.viewmodel.DraftsViewModel
 import com.wisp.app.viewmodel.SearchViewModel
 import com.wisp.app.viewmodel.HashtagFeedViewModel
 import com.wisp.app.viewmodel.OnboardingViewModel
+import com.wisp.app.viewmodel.PowStatus
 import com.wisp.app.viewmodel.WalletViewModel
 import kotlinx.coroutines.launch
 
@@ -122,6 +124,7 @@ object Routes {
     const val EXISTING_USER_ONBOARDING = "onboarding/existing"
     const val DRAFTS = "drafts"
     const val SOCIAL_GRAPH = "social_graph"
+    const val POW_SETTINGS = "pow_settings"
 }
 
 @Composable
@@ -390,6 +393,7 @@ fun WispNavHost(
     ) { innerPadding ->
 
     val broadcastState by feedViewModel.relayPool.broadcastState.collectAsState()
+    val powStatus by feedViewModel.powManager.status.collectAsState()
 
     Box(modifier = Modifier.padding(innerPadding)) {
     NavHost(
@@ -543,6 +547,9 @@ fun WispNavHost(
                 onKeys = {
                     navController.navigate(Routes.KEYS)
                 },
+                onPowSettings = {
+                    navController.navigate(Routes.POW_SETTINGS)
+                },
                 onAddToList = { eventId -> addToListEventId = eventId },
                 onRelayDetail = { url ->
                     navController.navigate("relay_detail/${java.net.URLEncoder.encode(url, "UTF-8")}")
@@ -554,6 +561,10 @@ fun WispNavHost(
         }
 
         composable(Routes.COMPOSE) {
+            // Initialize PoW toggle from persisted preferences
+            LaunchedEffect(Unit) {
+                composeViewModel.initPowState(feedViewModel.powPrefs.isNotePowEnabled())
+            }
             // Auto-save draft when leaving compose screen (back button, navigation, etc.)
             DisposableEffect(Unit) {
                 onDispose {
@@ -573,7 +584,9 @@ fun WispNavHost(
                 profileRepo = feedViewModel.profileRepo,
                 userPubkey = feedViewModel.getUserPubkey(),
                 signer = activeSigner,
-                onNotePublished = { feedViewModel.refreshNotifRepliesEtag() }
+                onNotePublished = { feedViewModel.refreshNotifRepliesEtag() },
+                powManager = feedViewModel.powManager,
+                powPrefs = feedViewModel.powPrefs
             )
         }
 
@@ -1039,6 +1052,13 @@ fun WispNavHost(
             )
         }
 
+        composable(Routes.POW_SETTINGS) {
+            PowSettingsScreen(
+                powPrefs = feedViewModel.powPrefs,
+                onBack = { navController.popBackStack() }
+            )
+        }
+
         composable(Routes.CUSTOM_EMOJIS) {
             val emojiUploadScope = androidx.compose.runtime.rememberCoroutineScope()
             CustomEmojiScreen(
@@ -1410,6 +1430,8 @@ fun WispNavHost(
 
     BroadcastStatusBar(
         broadcastState = broadcastState,
+        powStatus = powStatus,
+        onCancelMining = { feedViewModel.powManager.cancel() },
         modifier = Modifier
             .align(Alignment.BottomCenter)
             .padding(bottom = 16.dp)

--- a/app/src/main/kotlin/com/wisp/app/repo/PowPreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/PowPreferences.kt
@@ -1,0 +1,19 @@
+package com.wisp.app.repo
+
+import android.content.Context
+
+class PowPreferences(context: Context) {
+    private val prefs = context.getSharedPreferences("wisp_settings", Context.MODE_PRIVATE)
+
+    fun isNotePowEnabled(): Boolean = prefs.getBoolean("pow_note_enabled", true)
+    fun setNotePowEnabled(enabled: Boolean) = prefs.edit().putBoolean("pow_note_enabled", enabled).apply()
+
+    fun getNoteDifficulty(): Int = prefs.getInt("pow_note_difficulty", 16)
+    fun setNoteDifficulty(bits: Int) = prefs.edit().putInt("pow_note_difficulty", bits.coerceIn(8, 32)).apply()
+
+    fun isReactionPowEnabled(): Boolean = prefs.getBoolean("pow_reaction_enabled", true)
+    fun setReactionPowEnabled(enabled: Boolean) = prefs.edit().putBoolean("pow_reaction_enabled", enabled).apply()
+
+    fun getReactionDifficulty(): Int = prefs.getInt("pow_reaction_difficulty", 12)
+    fun setReactionDifficulty(bits: Int) = prefs.edit().putInt("pow_reaction_difficulty", bits.coerceIn(8, 32)).apply()
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Hub
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
@@ -75,6 +76,7 @@ fun WispDrawerContent(
     onKeys: () -> Unit = {},
     onSocialGraph: () -> Unit = {},
     onSafety: () -> Unit = {},
+    onPowSettings: () -> Unit = {},
     onCustomEmojis: () -> Unit = {},
     onConsole: () -> Unit = {},
     onRelaySettings: () -> Unit,
@@ -269,6 +271,13 @@ fun WispDrawerContent(
                     label = { Text("Safety") },
                     selected = false,
                     onClick = onSafety,
+                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                )
+                NavigationDrawerItem(
+                    icon = { Icon(Icons.Outlined.Shield, contentDescription = null) },
+                    label = { Text("Proof of Work") },
+                    selected = false,
+                    onClick = onPowSettings,
                     modifier = Modifier.padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -88,6 +88,9 @@ import com.wisp.app.ui.component.MentionVisualTransformation
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.component.RichContent
 import com.wisp.app.viewmodel.ComposeViewModel
+import com.wisp.app.viewmodel.PowManager
+import com.wisp.app.viewmodel.PowStatus
+import com.wisp.app.repo.PowPreferences
 import androidx.compose.foundation.border
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -103,7 +106,9 @@ fun ComposeScreen(
     profileRepo: ProfileRepository? = null,
     userPubkey: String? = null,
     signer: com.wisp.app.nostr.NostrSigner? = null,
-    onNotePublished: (() -> Unit)? = null
+    onNotePublished: (() -> Unit)? = null,
+    powManager: PowManager? = null,
+    powPrefs: PowPreferences? = null
 ) {
     val content by viewModel.content.collectAsState()
     val publishing by viewModel.publishing.collectAsState()
@@ -115,8 +120,8 @@ fun ComposeScreen(
     val mentionQuery by viewModel.mentionQuery.collectAsState()
     val explicit by viewModel.explicit.collectAsState()
     val powEnabled by viewModel.powEnabled.collectAsState()
-    val powDifficulty by viewModel.powDifficulty.collectAsState()
-    val miningProgress by viewModel.miningProgress.collectAsState()
+    val powStatus = powManager?.status?.collectAsState()?.value ?: PowStatus.Idle
+    val isMiningBusy = powStatus is PowStatus.Mining
     val context = LocalContext.current
 
     val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
@@ -391,7 +396,7 @@ fun ComposeScreen(
                         )
                     }
 
-                    IconButton(onClick = { viewModel.togglePow() }) {
+                    IconButton(onClick = { powPrefs?.let { viewModel.togglePow(it) } }) {
                         Icon(
                             Icons.Outlined.Shield,
                             contentDescription = "Proof of Work",
@@ -449,12 +454,13 @@ fun ComposeScreen(
                     }
                 }
 
-                // PoW settings banner
+                // PoW enabled banner
                 AnimatedVisibility(
                     visible = powEnabled,
                     enter = expandVertically() + fadeIn(),
                     exit = shrinkVertically() + fadeOut()
                 ) {
+                    val difficulty = powPrefs?.getNoteDifficulty() ?: 16
                     Surface(
                         shape = RoundedCornerShape(8.dp),
                         color = Color(0xFFFF9800).copy(alpha = 0.12f),
@@ -475,54 +481,11 @@ fun ComposeScreen(
                             )
                             Spacer(Modifier.width(8.dp))
                             Text(
-                                text = "PoW: $powDifficulty bits",
+                                text = "PoW: $difficulty bits (mined in background)",
                                 style = MaterialTheme.typography.bodySmall,
-                                color = orange,
-                                modifier = Modifier.weight(1f)
+                                color = orange
                             )
-                            IconButton(
-                                onClick = { viewModel.setPowDifficulty(powDifficulty - 1) },
-                                enabled = powDifficulty > 16,
-                                modifier = Modifier.size(32.dp)
-                            ) {
-                                Text(
-                                    "\u2212",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    color = orange
-                                )
-                            }
-                            IconButton(
-                                onClick = { viewModel.setPowDifficulty(powDifficulty + 1) },
-                                enabled = powDifficulty < 32,
-                                modifier = Modifier.size(32.dp)
-                            ) {
-                                Text(
-                                    "+",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    color = orange
-                                )
-                            }
                         }
-                    }
-                }
-
-                // Mining progress
-                if (miningProgress != null) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(vertical = 4.dp)
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(20.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            text = miningProgress ?: "",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
                     }
                 }
 
@@ -615,13 +578,20 @@ fun ComposeScreen(
                                 onSuccess = { onBack() },
                                 outboxRouter = outboxRouter,
                                 signer = signer,
-                                onNotePublished = onNotePublished
+                                onNotePublished = onNotePublished,
+                                powManager = powManager
                             )
                         },
-                        enabled = !publishing,
+                        enabled = !publishing && !isMiningBusy,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text(if (publishing) "Publishing..." else "Publish")
+                        Text(
+                            when {
+                                isMiningBusy -> "Mining in progress..."
+                                publishing -> "Publishing..."
+                                else -> "Publish"
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -77,7 +77,9 @@ import com.wisp.app.relay.BroadcastState
 import com.wisp.app.viewmodel.FeedType
 import com.wisp.app.viewmodel.FeedViewModel
 import com.wisp.app.viewmodel.InitLoadingState
+import com.wisp.app.viewmodel.PowStatus
 import com.wisp.app.viewmodel.RelayFeedStatus
+import androidx.compose.material.icons.filled.Close
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -112,6 +114,7 @@ fun FeedScreen(
     onCustomEmojis: () -> Unit = {},
     onConsole: () -> Unit = {},
     onKeys: () -> Unit = {},
+    onPowSettings: () -> Unit = {},
     onAddToList: (String) -> Unit = {},
     onRelayDetail: (String) -> Unit = {},
     onHashtagClick: ((String) -> Unit)? = null,
@@ -338,6 +341,10 @@ fun FeedScreen(
                 onKeys = {
                     scope.launch { drawerState.close() }
                     onKeys()
+                },
+                onPowSettings = {
+                    scope.launch { drawerState.close() }
+                    onPowSettings()
                 },
                 onConsole = {
                     scope.launch { drawerState.close() }
@@ -1658,15 +1665,19 @@ private fun RelayFeedEmptyState(
 @Composable
 fun BroadcastStatusBar(
     broadcastState: BroadcastState?,
+    powStatus: PowStatus = PowStatus.Idle,
+    onCancelMining: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
+    val showPow = powStatus !is PowStatus.Idle
+    val showBroadcast = broadcastState != null && !showPow
+
     AnimatedVisibility(
-        visible = broadcastState != null,
+        visible = showPow || showBroadcast,
         enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
         exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
         modifier = modifier
     ) {
-        val state = broadcastState ?: return@AnimatedVisibility
         Surface(
             shape = RoundedCornerShape(20.dp),
             color = MaterialTheme.colorScheme.surfaceContainer,
@@ -1676,23 +1687,70 @@ fun BroadcastStatusBar(
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (state.accepted < state.sent) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(14.dp),
-                        strokeWidth = 1.5.dp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(Modifier.width(8.dp))
+                when (powStatus) {
+                    is PowStatus.Mining -> {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(14.dp),
+                            strokeWidth = 1.5.dp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = "Mining PoW (${powStatus.attempts / 1000}k)...",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        if (onCancelMining != null) {
+                            Spacer(Modifier.width(8.dp))
+                            IconButton(
+                                onClick = onCancelMining,
+                                modifier = Modifier.size(20.dp)
+                            ) {
+                                Icon(
+                                    Icons.Default.Close,
+                                    contentDescription = "Cancel mining",
+                                    modifier = Modifier.size(14.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                    is PowStatus.Done -> {
+                        Text(
+                            text = powStatus.message,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    is PowStatus.Failed -> {
+                        Text(
+                            text = powStatus.message,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                    is PowStatus.Idle -> {
+                        // Show broadcast state
+                        val state = broadcastState ?: return@Row
+                        if (state.accepted < state.sent) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(14.dp),
+                                strokeWidth = 1.5.dp,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(Modifier.width(8.dp))
+                        }
+                        Text(
+                            text = if (state.accepted < state.sent) {
+                                "Broadcasting (${state.accepted}/${state.sent})"
+                            } else {
+                                "Published to ${state.accepted} relay${if (state.accepted != 1) "s" else ""}"
+                            },
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
-                Text(
-                    text = if (state.accepted < state.sent) {
-                        "Broadcasting (${state.accepted}/${state.sent})"
-                    } else {
-                        "Published to ${state.accepted} relay${if (state.accepted != 1) "s" else ""}"
-                    },
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
             }
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/PowSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/PowSettingsScreen.kt
@@ -1,0 +1,196 @@
+package com.wisp.app.ui.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.wisp.app.repo.PowPreferences
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PowSettingsScreen(
+    powPrefs: PowPreferences,
+    onBack: () -> Unit
+) {
+    var noteEnabled by remember { mutableStateOf(powPrefs.isNotePowEnabled()) }
+    var noteDifficulty by remember { mutableIntStateOf(powPrefs.getNoteDifficulty()) }
+    var reactionEnabled by remember { mutableStateOf(powPrefs.isReactionPowEnabled()) }
+    var reactionDifficulty by remember { mutableIntStateOf(powPrefs.getReactionDifficulty()) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Proof of Work") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+        ) {
+            Text(
+                text = "Proof of Work mines a hash prefix on your events, acting as a spam deterrent. Higher difficulty takes longer but signals more effort.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            // Notes section
+            Text(
+                text = "Notes",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Enable PoW for notes", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Mine proof of work before publishing notes",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = noteEnabled,
+                    onCheckedChange = {
+                        noteEnabled = it
+                        powPrefs.setNotePowEnabled(it)
+                    }
+                )
+            }
+            if (noteEnabled) {
+                Spacer(Modifier.height(12.dp))
+                DifficultySelector(
+                    label = "Note difficulty",
+                    value = noteDifficulty,
+                    onValueChange = {
+                        noteDifficulty = it
+                        powPrefs.setNoteDifficulty(it)
+                    }
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Reactions section
+            Text(
+                text = "Reactions",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Enable PoW for reactions", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Mine proof of work on reactions (sub-second at low difficulty)",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = reactionEnabled,
+                    onCheckedChange = {
+                        reactionEnabled = it
+                        powPrefs.setReactionPowEnabled(it)
+                    }
+                )
+            }
+            if (reactionEnabled) {
+                Spacer(Modifier.height(12.dp))
+                DifficultySelector(
+                    label = "Reaction difficulty",
+                    value = reactionDifficulty,
+                    onValueChange = {
+                        reactionDifficulty = it
+                        powPrefs.setReactionDifficulty(it)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DifficultySelector(
+    label: String,
+    value: Int,
+    onValueChange: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f)
+        )
+        IconButton(
+            onClick = { onValueChange((value - 1).coerceIn(8, 32)) },
+            enabled = value > 8,
+            modifier = Modifier.size(36.dp)
+        ) {
+            Text("\u2212", style = MaterialTheme.typography.titleMedium)
+        }
+        Text(
+            text = "$value bits",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.width(56.dp),
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        )
+        IconButton(
+            onClick = { onValueChange((value + 1).coerceIn(8, 32)) },
+            enabled = value < 32,
+            modifier = Modifier.size(36.dp)
+        ) {
+            Text("+", style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.viewModelScope
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Keys
 import com.wisp.app.nostr.Nip10
-import com.wisp.app.nostr.Nip13
 import com.wisp.app.nostr.Nip18
 import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.Nip37
@@ -34,7 +33,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
 // Matches bare bech32 IDs not already preceded by "nostr:"
@@ -84,18 +82,14 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
     private val _powEnabled = MutableStateFlow(false)
     val powEnabled: StateFlow<Boolean> = _powEnabled
 
-    private val _powDifficulty = MutableStateFlow(21)
-    val powDifficulty: StateFlow<Int> = _powDifficulty
-
-    private val _miningProgress = MutableStateFlow<String?>(null)
-    val miningProgress: StateFlow<String?> = _miningProgress
-
-    fun togglePow() {
-        _powEnabled.value = !_powEnabled.value
+    fun initPowState(enabled: Boolean) {
+        _powEnabled.value = enabled
     }
 
-    fun setPowDifficulty(bits: Int) {
-        _powDifficulty.value = bits.coerceIn(16, 32)
+    fun togglePow(powPrefs: com.wisp.app.repo.PowPreferences) {
+        val newValue = !_powEnabled.value
+        _powEnabled.value = newValue
+        powPrefs.setNotePowEnabled(newValue)
     }
 
     private var mentionStartIndex: Int = -1
@@ -259,7 +253,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         onSuccess: () -> Unit = {},
         outboxRouter: OutboxRouter? = null,
         signer: NostrSigner? = null,
-        onNotePublished: (() -> Unit)? = null
+        onNotePublished: (() -> Unit)? = null,
+        powManager: PowManager? = null
     ) {
         val text = _content.value.text.trim()
 
@@ -275,7 +270,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         }
 
         _publishing.value = true
-        startCountdown(text, s, relayPool, replyTo, quoteTo, outboxRouter, onSuccess, onNotePublished)
+        startCountdown(text, s, relayPool, replyTo, quoteTo, outboxRouter, onSuccess, onNotePublished, powManager)
     }
 
     private fun startCountdown(
@@ -286,13 +281,14 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         quoteTo: NostrEvent?,
         outboxRouter: OutboxRouter?,
         onSuccess: () -> Unit,
-        onNotePublished: (() -> Unit)? = null
+        onNotePublished: (() -> Unit)? = null,
+        powManager: PowManager? = null
     ) {
         countdownJob?.cancel()
         pendingPublish = {
             viewModelScope.launch {
                 try {
-                    val sentCount = publishNote(content, signer, relayPool, replyTo, quoteTo, outboxRouter)
+                    val sentCount = publishNote(content, signer, relayPool, replyTo, quoteTo, outboxRouter, powManager)
                     if (sentCount == 0) return@launch
                     onNotePublished?.invoke()
                     onSuccess()
@@ -330,14 +326,15 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         pendingPublish = null
     }
 
-    /** Publishes a note and stores the event ID. Returns the number of relays sent to (0 = failure). */
+    /** Publishes a note and stores the event ID. Returns the number of relays sent to (0 = failure, -1 = handed to PowManager). */
     private suspend fun publishNote(
         content: String,
         signer: NostrSigner,
         relayPool: RelayPool,
         replyTo: NostrEvent?,
         quoteTo: NostrEvent? = null,
-        outboxRouter: OutboxRouter? = null
+        outboxRouter: OutboxRouter? = null,
+        powManager: PowManager? = null
     ): Int {
         val tags = mutableListOf<List<String>>()
         if (_explicit.value) {
@@ -372,42 +369,35 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             content
         }
 
-        // Mine proof of work if enabled
-        val finalTags: List<List<String>>
-        val finalCreatedAt: Long?
-        if (_powEnabled.value) {
-            val difficulty = _powDifficulty.value
-            val createdAt = System.currentTimeMillis() / 1000
-            _miningProgress.value = "Mining PoW ($difficulty bits)..."
-            try {
-                val result = withContext(Dispatchers.Default) {
-                    Nip13.mine(
-                        pubkeyHex = signer.pubkeyHex,
-                        kind = 1,
-                        content = finalContent,
-                        tags = tags,
-                        targetDifficulty = difficulty,
-                        createdAt = createdAt,
-                        onProgress = { attempts ->
-                            _miningProgress.value = "Mining PoW... ${attempts / 1000}k attempts"
+        // Hand off to PowManager for background mining if PoW enabled
+        if (_powEnabled.value && powManager != null) {
+            val replyPubkey = replyTo?.pubkey
+            powManager.submitNote(
+                signer = signer,
+                content = finalContent,
+                tags = tags,
+                kind = 1,
+                replyToPubkey = replyPubkey,
+                onPublished = {
+                    if (replyTo != null) {
+                        eventRepo?.addReplyCount(replyTo.id, "pow-pending")
+                        val rootId = Nip10.getRootId(replyTo)
+                        if (rootId != null && rootId != replyTo.id) {
+                            eventRepo?.addReplyCount(rootId, "pow-pending")
                         }
-                    )
+                    }
                 }
-                finalTags = result.tags
-                finalCreatedAt = result.createdAt
-            } finally {
-                _miningProgress.value = null
-            }
-        } else {
-            finalTags = tags
-            finalCreatedAt = null
+            )
+            deleteDraftOnPublish(relayPool, signer)
+            _content.value = TextFieldValue()
+            savedStateHandle.remove<String>("draft_content")
+            _uploadedUrls.value = emptyList()
+            _error.value = null
+            _publishing.value = false
+            return -1
         }
 
-        val event = if (finalCreatedAt != null) {
-            signer.signEvent(kind = 1, content = finalContent, tags = finalTags, createdAt = finalCreatedAt)
-        } else {
-            signer.signEvent(kind = 1, content = finalContent, tags = finalTags)
-        }
+        val event = signer.signEvent(kind = 1, content = finalContent, tags = tags)
         val msg = ClientMessage.event(event)
         var sentCount = if (replyTo != null && outboxRouter != null) {
             outboxRouter.publishToInbox(msg, replyTo.pubkey)
@@ -553,7 +543,6 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         _uploadProgress.value = null
         _explicit.value = false
         _powEnabled.value = false
-        _miningProgress.value = null
         clearMentionState()
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -35,6 +35,7 @@ import com.wisp.app.repo.PinRepository
 import com.wisp.app.repo.ProfileRepository
 import com.wisp.app.repo.NwcRepository
 import com.wisp.app.repo.CustomEmojiRepository
+import com.wisp.app.repo.PowPreferences
 import com.wisp.app.repo.ZapPreferences
 import com.wisp.app.repo.RelayHintStore
 import com.wisp.app.repo.RelayInfoRepository
@@ -160,6 +161,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val customEmojiRepo = CustomEmojiRepository(app, pubkeyHex)
     val translationRepo = TranslationRepository()
     val zapPrefs = ZapPreferences(app, pubkeyHex)
+    val powPrefs = PowPreferences(app)
     private val processingDispatcher = Dispatchers.Default
 
     val metadataFetcher = MetadataFetcher(
@@ -174,6 +176,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
 
     val nwcRepo = NwcRepository(app, relayPool, pubkeyHex)
     val zapSender = ZapSender(keyRepo, nwcRepo, relayPool, relayListRepo, HttpClientFactory.createRelayClient())
+    val powManager = PowManager(powPrefs, relayPool, outboxRouter, eventRepo, viewModelScope)
 
     // -- Manager classes --
     val feedSub: FeedSubscriptionManager = FeedSubscriptionManager(
@@ -195,7 +198,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
 
     val socialActions: SocialActionManager = SocialActionManager(
         relayPool, outboxRouter, eventRepo, contactRepo, muteRepo, notifRepo, dmRepo,
-        pinRepo, deletedEventsRepo, nwcRepo, customEmojiRepo, zapSender, viewModelScope,
+        pinRepo, deletedEventsRepo, nwcRepo, customEmojiRepo, zapSender, powPrefs, viewModelScope,
         getSigner = { signer },
         getUserPubkey = { getUserPubkey() }
     )

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/PowManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/PowManager.kt
@@ -1,0 +1,126 @@
+package com.wisp.app.viewmodel
+
+import com.wisp.app.nostr.ClientMessage
+import com.wisp.app.nostr.Nip13
+import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.nostr.NostrSigner
+import com.wisp.app.relay.OutboxRouter
+import com.wisp.app.relay.RelayPool
+import com.wisp.app.repo.EventRepository
+import com.wisp.app.repo.PowPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+sealed class PowStatus {
+    data object Idle : PowStatus()
+    data class Mining(val kind: Int, val attempts: Long, val difficulty: Int) : PowStatus()
+    data class Done(val message: String) : PowStatus()
+    data class Failed(val message: String) : PowStatus()
+}
+
+class PowManager(
+    private val powPrefs: PowPreferences,
+    private val relayPool: RelayPool,
+    private val outboxRouter: OutboxRouter,
+    private val eventRepo: EventRepository,
+    private val scope: CoroutineScope
+) {
+    private val _status = MutableStateFlow<PowStatus>(PowStatus.Idle)
+    val status: StateFlow<PowStatus> = _status
+
+    private var miningJob: Job? = null
+
+    val isBusy: Boolean get() = _status.value is PowStatus.Mining
+
+    fun submitNote(
+        signer: NostrSigner,
+        content: String,
+        tags: List<List<String>>,
+        kind: Int = 1,
+        replyToPubkey: String? = null,
+        onPublished: (() -> Unit)? = null
+    ) {
+        miningJob?.cancel()
+        val difficulty = powPrefs.getNoteDifficulty()
+        val createdAt = System.currentTimeMillis() / 1000
+
+        miningJob = scope.launch {
+            try {
+                _status.value = PowStatus.Mining(kind, 0, difficulty)
+
+                val result = withContext(Dispatchers.Default) {
+                    Nip13.mine(
+                        pubkeyHex = signer.pubkeyHex,
+                        kind = kind,
+                        content = content,
+                        tags = tags,
+                        targetDifficulty = difficulty,
+                        createdAt = createdAt,
+                        onProgress = { attempts ->
+                            _status.value = PowStatus.Mining(kind, attempts, difficulty)
+                        }
+                    )
+                }
+
+                val event = signer.signEvent(
+                    kind = kind,
+                    content = content,
+                    tags = result.tags,
+                    createdAt = result.createdAt
+                )
+
+                val msg = ClientMessage.event(event)
+                var sentCount = if (replyToPubkey != null) {
+                    outboxRouter.publishToInbox(msg, replyToPubkey)
+                } else {
+                    relayPool.sendToWriteRelays(msg)
+                }
+
+                if (sentCount == 0) {
+                    val reconnected = relayPool.ensureWriteRelaysConnected()
+                    if (reconnected > 0) {
+                        sentCount = if (replyToPubkey != null) {
+                            outboxRouter.publishToInbox(msg, replyToPubkey)
+                        } else {
+                            relayPool.sendToWriteRelays(msg)
+                        }
+                    }
+                }
+
+                if (sentCount == 0) {
+                    _status.value = PowStatus.Failed("No relays connected")
+                    delay(3000)
+                    _status.value = PowStatus.Idle
+                    return@launch
+                }
+
+                relayPool.trackPublish(event.id, sentCount)
+                eventRepo.addEvent(event)
+                onPublished?.invoke()
+
+                _status.value = PowStatus.Done("Published to $sentCount relay${if (sentCount != 1) "s" else ""}")
+                delay(3000)
+                _status.value = PowStatus.Idle
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                _status.value = PowStatus.Idle
+                throw e
+            } catch (e: Exception) {
+                _status.value = PowStatus.Failed(e.message ?: "Mining failed")
+                delay(3000)
+                _status.value = PowStatus.Idle
+            }
+        }
+    }
+
+    fun cancel() {
+        miningJob?.cancel()
+        miningJob = null
+        _status.value = PowStatus.Idle
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
@@ -4,6 +4,7 @@ import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.CustomEmoji
 import com.wisp.app.nostr.Filter
 import com.wisp.app.nostr.Nip02
+import com.wisp.app.nostr.Nip13
 import com.wisp.app.nostr.Nip25
 import com.wisp.app.nostr.Nip30
 import com.wisp.app.nostr.Nip51
@@ -23,8 +24,11 @@ import com.wisp.app.repo.NwcRepository
 import com.wisp.app.repo.PinRepository
 import com.wisp.app.repo.CustomEmojiRepository
 import com.wisp.app.repo.DeletedEventsRepository
+import com.wisp.app.repo.PowPreferences
 import com.wisp.app.repo.ZapSender
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -48,6 +52,7 @@ class SocialActionManager(
     private val nwcRepo: NwcRepository,
     private val customEmojiRepo: CustomEmojiRepository,
     private val zapSender: ZapSender,
+    private val powPrefs: PowPreferences,
     private val scope: CoroutineScope,
     private val getSigner: () -> NostrSigner?,
     private val getUserPubkey: () -> String?
@@ -153,7 +158,7 @@ class SocialActionManager(
                     eventRepo.removeReaction(event.id, myPubkey, emoji)
                 } else {
                     val shortcodeMatch = Nip30.shortcodeRegex.matchEntire(emoji)
-                    val tags = if (shortcodeMatch != null) {
+                    var tags: List<List<String>> = if (shortcodeMatch != null) {
                         val shortcode = shortcodeMatch.groupValues[1]
                         val url = customEmojiRepo.resolvedEmojis.value[shortcode]
                         if (url != null) {
@@ -166,7 +171,27 @@ class SocialActionManager(
                     } else {
                         Nip25.buildReactionTags(event)
                     }
-                    val reactionEvent = s.signEvent(kind = 7, content = emoji, tags = tags)
+
+                    val createdAt: Long
+                    if (powPrefs.isReactionPowEnabled()) {
+                        val pinned = System.currentTimeMillis() / 1000
+                        val result = withContext(Dispatchers.Default) {
+                            Nip13.mine(
+                                pubkeyHex = myPubkey,
+                                kind = 7,
+                                content = emoji,
+                                tags = tags,
+                                targetDifficulty = powPrefs.getReactionDifficulty(),
+                                createdAt = pinned
+                            )
+                        }
+                        tags = result.tags
+                        createdAt = result.createdAt
+                    } else {
+                        createdAt = System.currentTimeMillis() / 1000
+                    }
+
+                    val reactionEvent = s.signEvent(kind = 7, content = emoji, tags = tags, createdAt = createdAt)
                     val msg = ClientMessage.event(reactionEvent)
                     outboxRouter.publishToInbox(msg, event.pubkey)
                     eventRepo.addEvent(reactionEvent)


### PR DESCRIPTION
## Summary
- **Background mining**: Note PoW now runs in a `PowManager` owned by `FeedViewModel`, so the compose screen navigates back immediately and mining progress shows in the bottom status pill with a cancel button
- **Persistent settings**: PoW enable/difficulty for notes and reactions stored in `SharedPreferences` via `PowPreferences`, with a new settings screen accessible from the drawer
- **Reaction PoW**: `SocialActionManager.toggleReaction()` now mines inline PoW (default 12 bits, sub-second) before signing reactions when enabled

## New files
- `repo/PowPreferences.kt` — SharedPreferences-backed PoW settings (note/reaction enable + difficulty, clamped 8-32)
- `viewmodel/PowManager.kt` — Background mining manager with `PowStatus` sealed class (Idle/Mining/Done/Failed)
- `ui/screen/PowSettingsScreen.kt` — Settings screen with enable switches and difficulty steppers

## Modified files
- `FeedViewModel` — owns `PowPreferences` and `PowManager`, passes `powPrefs` to `SocialActionManager`
- `ComposeViewModel` — removes old blocking PoW mining, hands off to `PowManager.submitNote()` for background mining
- `SocialActionManager` — adds inline reaction PoW via `Nip13.mine()` when enabled
- `ComposeScreen` — removes difficulty adjuster and mining progress UI, shows "mined in background" banner
- `FeedScreen/BroadcastStatusBar` — extended to show `PowStatus` (mining progress + cancel, done, failed states)
- `Navigation.kt` — adds `POW_SETTINGS` route, passes `powManager`/`powPrefs` to compose screen, wires status pill
- `WispDrawerContent` — adds "Proof of Work" entry under Settings

## Test plan
- [ ] Compose a note with PoW on — verify immediate navigation back, mining pill appears, note publishes after mining
- [ ] Start a high-difficulty note, tap cancel on pill — verify mining stops, no note published
- [ ] React to a post with reaction PoW enabled — verify the reaction event has a nonce tag
- [ ] Toggle PoW off in settings, close/reopen app — verify it's still off
- [ ] Start mining a note, try to compose another — verify Post button is disabled
- [ ] Compose with PoW disabled — verify immediate publish (no mining phase)