### PR TITLE
feat: mute thread notifications

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1403,6 +1403,7 @@ fun WispNavHost(
                 onZap = { event -> notifZapTarget = event },
                 onFollowToggle = { pubkey -> feedViewModel.toggleFollow(pubkey) },
                 onBlockUser = { pubkey -> feedViewModel.blockUser(pubkey) },
+                onMuteThread = { rootEventId -> feedViewModel.muteThread(rootEventId) },
                 onAddToList = { eventId -> addToListEventId = eventId },
                 nip05Repo = feedViewModel.nip05Repo,
                 isZapAnimating = { it in notifZapAnimatingIds },

--- a/app/src/main/kotlin/com/wisp/app/repo/MuteRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/MuteRepository.kt
@@ -19,8 +19,12 @@ class MuteRepository(private val context: Context, pubkeyHex: String? = null) {
     private val _mutedWords = MutableStateFlow<Set<String>>(emptySet())
     val mutedWords: StateFlow<Set<String>> = _mutedWords
 
+    private val _mutedThreads = MutableStateFlow<Set<String>>(emptySet())
+    val mutedThreads: StateFlow<Set<String>> = _mutedThreads
+
     private var blockedSet = HashSet<String>()
     private var wordSet = HashSet<String>()
+    private var threadSet = HashSet<String>()
     private var lastUpdated: Long = 0
 
     init {
@@ -91,6 +95,20 @@ class MuteRepository(private val context: Context, pubkeyHex: String? = null) {
         return wordSet.any { lower.contains(it) }
     }
 
+    fun muteThread(rootEventId: String) {
+        threadSet.add(rootEventId)
+        _mutedThreads.value = threadSet.toSet()
+        saveToPrefs()
+    }
+
+    fun unmuteThread(rootEventId: String) {
+        threadSet.remove(rootEventId)
+        _mutedThreads.value = threadSet.toSet()
+        saveToPrefs()
+    }
+
+    fun isThreadMuted(rootEventId: String): Boolean = threadSet.contains(rootEventId)
+
     fun getBlockedPubkeys(): Set<String> = blockedSet.toSet()
 
     fun getMutedWords(): Set<String> = wordSet.toSet()
@@ -98,8 +116,10 @@ class MuteRepository(private val context: Context, pubkeyHex: String? = null) {
     fun clear() {
         _blockedPubkeys.value = emptySet()
         _mutedWords.value = emptySet()
+        _mutedThreads.value = emptySet()
         blockedSet = HashSet()
         wordSet = HashSet()
+        threadSet = HashSet()
         lastUpdated = 0
         prefs.edit().clear().apply()
     }
@@ -114,6 +134,7 @@ class MuteRepository(private val context: Context, pubkeyHex: String? = null) {
         prefs.edit()
             .putStringSet("blocked_pubkeys", blockedSet.toSet())
             .putStringSet("muted_words", wordSet.toSet())
+            .putStringSet("muted_threads", threadSet.toSet())
             .putLong("mute_updated", lastUpdated)
             .apply()
     }
@@ -129,6 +150,11 @@ class MuteRepository(private val context: Context, pubkeyHex: String? = null) {
         if (words != null) {
             wordSet = HashSet(words)
             _mutedWords.value = wordSet.toSet()
+        }
+        val threads = prefs.getStringSet("muted_threads", null)
+        if (threads != null) {
+            threadSet = HashSet(threads)
+            _mutedThreads.value = threadSet.toSet()
         }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -15,7 +15,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
-class NotificationRepository(context: Context, pubkeyHex: String?) {
+class NotificationRepository(
+    context: Context,
+    pubkeyHex: String?,
+    private val muteRepo: MuteRepository? = null,
+    private val eventRepo: EventRepository? = null
+) {
     private val prefs: SharedPreferences =
         context.getSharedPreferences("wisp_notif_${pubkeyHex ?: "anon"}", Context.MODE_PRIVATE)
 
@@ -62,6 +67,10 @@ class NotificationRepository(context: Context, pubkeyHex: String?) {
             // subscriptions bypass RelayPool dedup).
             if (seenEvents.get(event.id) != null) return
             seenEvents.put(event.id, true)
+
+            val threadRoot = resolveThreadRoot(event)
+            if (threadRoot != null && muteRepo?.isThreadMuted(threadRoot) == true) return
+
             val merged = when (event.kind) {
                 6 -> mergeRepost(event)
                 7 -> mergeReaction(event)
@@ -437,6 +446,55 @@ class NotificationRepository(context: Context, pubkeyHex: String?) {
                 is NotificationGroup.MentionNotification -> group.eventId
             }
         }.distinct()
+    }
+
+    fun purgeThread(rootEventId: String) = synchronized(lock) {
+        val toRemove = mutableListOf<String>()
+        for ((key, group) in groupMap) {
+            val root = when (group) {
+                is NotificationGroup.ReactionGroup -> {
+                    val referenced = eventRepo?.getEvent(group.referencedEventId)
+                    if (referenced != null) Nip10.getRootId(referenced) ?: referenced.id
+                    else group.referencedEventId
+                }
+                is NotificationGroup.ReplyNotification -> {
+                    val referenced = eventRepo?.getEvent(group.referencedEventId ?: group.replyEventId)
+                    if (referenced != null) Nip10.getRootId(referenced) ?: referenced.id
+                    else group.referencedEventId ?: group.replyEventId
+                }
+                is NotificationGroup.QuoteNotification -> null
+                is NotificationGroup.MentionNotification -> null
+            }
+            if (root == rootEventId) toRemove.add(key)
+        }
+        if (toRemove.isNotEmpty()) {
+            toRemove.forEach { groupMap.remove(it) }
+            rebuildSortedList()
+        }
+    }
+
+    private fun resolveThreadRoot(event: NostrEvent): String? {
+        return when (event.kind) {
+            1 -> Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
+            7 -> {
+                val refId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
+                    ?: return null
+                val refEvent = eventRepo?.getEvent(refId)
+                if (refEvent != null) Nip10.getRootId(refEvent) ?: refId else refId
+            }
+            6 -> {
+                val refId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
+                    ?: return null
+                val refEvent = eventRepo?.getEvent(refId)
+                if (refEvent != null) Nip10.getRootId(refEvent) ?: refId else refId
+            }
+            9735 -> {
+                val refId = Nip57.getZappedEventId(event) ?: return null
+                val refEvent = eventRepo?.getEvent(refId)
+                if (refEvent != null) Nip10.getRootId(refEvent) ?: refId else refId
+            }
+            else -> null
+        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -121,6 +121,7 @@ fun PostCard(
     resolvedEmojis: Map<String, String> = emptyMap(),
     unicodeEmojis: List<String> = emptyList(),
     onOpenEmojiLibrary: (() -> Unit)? = null,
+    onMuteThread: (() -> Unit)? = null,
     translationState: TranslationState = TranslationState(),
     onTranslate: () -> Unit = {},
     modifier: Modifier = Modifier,
@@ -321,6 +322,15 @@ fun PostCard(
                             onClick = {
                                 menuExpanded = false
                                 onBlockAuthor()
+                            }
+                        )
+                    }
+                    if (onMuteThread != null) {
+                        DropdownMenuItem(
+                            text = { Text("Mute Thread") },
+                            onClick = {
+                                menuExpanded = false
+                                onMuteThread()
                             }
                         )
                     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.BorderStroke
 import coil3.compose.AsyncImage
+import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.Nip30
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.NotificationGroup
@@ -99,6 +100,7 @@ fun NotificationsScreen(
     onZap: (NostrEvent) -> Unit = {},
     onFollowToggle: (String) -> Unit = {},
     onBlockUser: (String) -> Unit = {},
+    onMuteThread: (String) -> Unit = {},
     onAddToList: (String) -> Unit = {},
     nip05Repo: Nip05Repository? = null,
     isZapAnimating: (String) -> Boolean = { false },
@@ -285,6 +287,7 @@ fun NotificationsScreen(
                             onZap = onZap,
                             onFollowToggle = onFollowToggle,
                             onBlockUser = onBlockUser,
+                            onMuteThread = onMuteThread,
                             onAddToList = onAddToList,
                             nip05Repo = nip05Repo,
                             isZapAnimating = isZapAnimating,
@@ -323,6 +326,7 @@ fun NotificationsScreen(
                             onZap = onZap,
                             onFollowToggle = onFollowToggle,
                             onBlockUser = onBlockUser,
+                            onMuteThread = onMuteThread,
                             onAddToList = onAddToList,
                             nip05Repo = nip05Repo,
                             isZapAnimating = isZapAnimating,
@@ -438,6 +442,7 @@ private fun NotificationItem(
     onZap: (NostrEvent) -> Unit,
     onFollowToggle: (String) -> Unit,
     onBlockUser: (String) -> Unit,
+    onMuteThread: (String) -> Unit = {},
     onAddToList: (String) -> Unit = {},
     nip05Repo: Nip05Repository?,
     isZapAnimating: (String) -> Boolean,
@@ -471,6 +476,7 @@ private fun NotificationItem(
         onZap = onZap,
         onFollowToggle = onFollowToggle,
         onBlockUser = onBlockUser,
+        onMuteThread = onMuteThread,
         onAddToList = onAddToList,
         nip05Repo = nip05Repo,
         isZapAnimating = isZapAnimating,
@@ -887,6 +893,7 @@ private data class NotifPostCardParams(
     val onZap: (NostrEvent) -> Unit,
     val onFollowToggle: (String) -> Unit,
     val onBlockUser: (String) -> Unit,
+    val onMuteThread: (String) -> Unit = {},
     val onAddToList: (String) -> Unit,
     val nip05Repo: Nip05Repository?,
     val isZapAnimating: (String) -> Boolean,
@@ -997,6 +1004,10 @@ private fun ReferencedNotePostCard(
         onNavigateToProfileFromDetails = params.onProfileClick,
         onFollowAuthor = { params.onFollowToggle(event.pubkey) },
         onBlockAuthor = { params.onBlockUser(event.pubkey) },
+        onMuteThread = {
+            val rootId = Nip10.getRootId(event) ?: event.id
+            params.onMuteThread(rootId)
+        },
         isFollowingAuthor = followingAuthor,
         isOwnEvent = event.pubkey == params.userPubkey,
         nip05Repo = params.nip05Repo,

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -129,7 +129,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val contactRepo = ContactRepository(app, pubkeyHex)
     val listRepo = ListRepository(app, pubkeyHex)
     val dmRepo = DmRepository(app, pubkeyHex)
-    val notifRepo = NotificationRepository(app, pubkeyHex)
+    val notifRepo = NotificationRepository(app, pubkeyHex, muteRepo, eventRepo)
     val relayListRepo = RelayListRepository(app)
     val bookmarkRepo = BookmarkRepository(app, pubkeyHex)
     val bookmarkSetRepo = BookmarkSetRepository(app, pubkeyHex)
@@ -318,6 +318,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun togglePin(eventId: String) = socialActions.togglePin(eventId)
     fun deleteEvent(eventId: String, kind: Int) = socialActions.deleteEvent(eventId, kind)
     fun followAll(pubkeys: Set<String>) = socialActions.followAll(pubkeys)
+    fun muteThread(rootEventId: String) = socialActions.muteThread(rootEventId)
 
     // -- List CRUD delegates --
     fun createList(name: String, isPrivate: Boolean = false) = listCrud.createList(name, isPrivate)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
@@ -111,6 +111,11 @@ class SocialActionManager(
         publishMuteList()
     }
 
+    fun muteThread(rootEventId: String) {
+        muteRepo.muteThread(rootEventId)
+        notifRepo.purgeThread(rootEventId)
+    }
+
     fun updateMutedWords() {
         publishMuteList()
     }


### PR DESCRIPTION
## Summary
- Adds a "Mute Thread" option to the 3-dot menu on notification PostCards
- Muted thread root IDs stored locally in MuteRepository (SharedPreferences), persists across sessions
- Incoming notifications from muted threads are filtered in NotificationRepository.addEvent()
- Existing notification groups for the thread are purged immediately on mute
- Notes remain visible when browsing the thread directly via feed — only notifications are suppressed

## Test plan
- [x] Open notifications screen, tap 3-dot menu on any notification — "Mute Thread" appears
- [x] Tap "Mute Thread" — notification group disappears from list
- [x] New notifications from that thread do not appear
- [x] Navigate to the thread directly via feed — all notes still visible
- [x] Kill and restart app — muted thread persists