### PR TITLE
feat: support tor .onion relay storage and connections

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="Wisp"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.Wisp.Splash">
         <activity

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -227,7 +227,10 @@ fun WispNavHost(
         if (torStatus == com.wisp.app.relay.TorStatus.CONNECTED ||
             torStatus == com.wisp.app.relay.TorStatus.DISABLED) {
             if (authViewModel.isLoggedIn) {
-                feedViewModel.lifecycleManager.onTorSwitch()
+                feedViewModel.lifecycleManager.onTorSwitch(
+                    savedConfigs = feedViewModel.keyRepo.getRelays(),
+                    savedDmUrls = feedViewModel.keyRepo.getDmRelays()
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip51.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip51.kt
@@ -62,7 +62,7 @@ object Nip51 {
         return event.tags.mapNotNull { tag ->
             if (tag.size >= 2 && (tag[0] == "relay" || tag[0] == "r")) {
                 val url = tag[1].trim().trimEnd('/')
-                if (RelayConfig.isAcceptableUrl(url)) url else null
+                if (RelayConfig.isValidUrl(url)) url else null
             } else null
         }
     }
@@ -81,7 +81,7 @@ object Nip51 {
             when (tag[0]) {
                 "relay", "r" -> {
                     val url = tag[1].trim().trimEnd('/')
-                    if (RelayConfig.isAcceptableUrl(url)) relays.add(url)
+                    if (RelayConfig.isValidUrl(url)) relays.add(url)
                 }
                 "title" -> title = tag[1]
             }

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip65.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip65.kt
@@ -1,14 +1,15 @@
 package com.wisp.app.nostr
 
+import android.util.Log
 import com.wisp.app.relay.RelayConfig
 
 object Nip65 {
     fun parseRelayList(event: NostrEvent): List<RelayConfig> {
         if (event.kind != 10002) return emptyList()
-        return event.tags.mapNotNull { tag ->
+        val result = event.tags.mapNotNull { tag ->
             if (tag.size < 2 || tag[0] != "r") return@mapNotNull null
             val url = tag[1].trim().trimEnd('/')
-            if (!RelayConfig.isAcceptableUrl(url)) return@mapNotNull null
+            if (!RelayConfig.isValidUrl(url)) return@mapNotNull null
             val marker = tag.getOrNull(2)
             RelayConfig(
                 url = url,
@@ -16,6 +17,11 @@ object Nip65 {
                 write = marker == null || marker == "write"
             )
         }
+        val onionRelays = result.filter { RelayConfig.isOnionUrl(it.url) }
+        if (onionRelays.isNotEmpty()) {
+            Log.d("TorRelay", "[Nip65] parseRelayList: pubkey=${event.pubkey.take(8)}… has ${onionRelays.size} .onion relay(s): ${onionRelays.map { it.url }}")
+        }
+        return result
     }
 
     fun buildRelayTags(relays: List<RelayConfig>): List<List<String>> {

--- a/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
@@ -1,5 +1,6 @@
 package com.wisp.app.relay
 
+import android.util.Log
 import okhttp3.Dispatcher
 import okhttp3.Dns
 import okhttp3.OkHttpClient
@@ -47,7 +48,9 @@ object HttpClientFactory {
             }
 
         if (isTor) {
-            TorManager.proxy?.let { builder.proxy(it) }
+            val proxy = TorManager.proxy
+            Log.d("TorRelay", "[HttpClient] createRelayClient: Tor active, proxy=$proxy socksPort=${TorManager.socksPort.value}")
+            proxy?.let { builder.proxy(it) }
             builder.dns(torSafeDns)
         }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -116,9 +116,15 @@ class Relay(
             }
             val socketId = System.nanoTime() // unique ID for this WebSocket instance
             Log.d("RLC", "[Relay] connect() creating ws#$socketId for ${config.url}")
+            if (config.url.contains(".onion")) {
+                Log.d("TorRelay", "[Relay] connect() .onion relay: ${config.url} proxy=${client.proxy} connectTimeout=${client.connectTimeoutMillis}ms")
+            }
             webSocket = client.newWebSocket(request, object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
                     Log.d("RLC", "[Relay] ws#$socketId onOpen ${config.url} | isConnected was=$isConnected")
+                    if (config.url.contains(".onion")) {
+                        Log.d("TorRelay", "[Relay] .onion connection SUCCESS: ${config.url}")
+                    }
                     isConnected = true
                     // Successful connection — reset attempt tracking
                     synchronized(attemptLock) { connectAttempts.clear() }
@@ -140,6 +146,9 @@ class Relay(
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                     val isCurrent = synchronized(connectLock) { this@Relay.webSocket === webSocket }
                     Log.e("RLC", "[Relay] ws#$socketId onFailure ${config.url}: ${t.message} | isCurrent=$isCurrent isConnected=$isConnected")
+                    if (config.url.contains(".onion")) {
+                        Log.e("TorRelay", "[Relay] .onion connection FAILED: ${config.url} | error=${t.javaClass.simpleName}: ${t.message}", t)
+                    }
                     synchronized(connectLock) {
                         // Only null the reference if this callback is for the current WebSocket
                         if (this@Relay.webSocket === webSocket) {

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayConfig.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayConfig.kt
@@ -33,16 +33,15 @@ data class RelayConfig(
 
         private val IP_HOST_REGEX = Regex("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")
 
-        /**
-         * Returns true if the relay URL is safe to use.
-         * Rejects: localhost, IP addresses, URLs with ports (unless .onion with Tor active).
-         * When Tor is enabled, .onion addresses are allowed with ws:// or wss:// and any port.
-         */
-        fun isAcceptableUrl(url: String): Boolean {
-            val isOnion = url.contains(".onion")
+        fun isOnionUrl(url: String): Boolean = url.contains(".onion")
 
-            if (isOnion) {
-                if (!TorManager.isEnabled()) return false
+        /**
+         * Structural URL validation — can this URL be stored in a relay list?
+         * Always allows .onion addresses (with ws:// or wss://) regardless of Tor state.
+         * Rejects: localhost, IP addresses, URLs with ports (unless .onion).
+         */
+        fun isValidUrl(url: String): Boolean {
+            if (isOnionUrl(url)) {
                 // .onion relays can use ws:// (TLS redundant over Tor) or wss://
                 if (!url.startsWith("wss://") && !url.startsWith("ws://")) return false
                 return true
@@ -55,6 +54,16 @@ data class RelayConfig(
             val host = hostPort.lowercase()
             if (host == "localhost" || host.endsWith(".localhost")) return false
             if (IP_HOST_REGEX.matches(host)) return false
+            return true
+        }
+
+        /**
+         * Returns true if the relay URL can be connected to right now.
+         * .onion addresses require Tor to be active.
+         */
+        fun isConnectableUrl(url: String): Boolean {
+            if (!isValidUrl(url)) return false
+            if (isOnionUrl(url) && !TorManager.isEnabled()) return false
             return true
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
@@ -142,12 +142,15 @@ class RelayLifecycleManager(
     /**
      * Handle Tor on/off switch. Swaps the OkHttpClient, reconnects all relays,
      * and re-establishes subscriptions via [onReconnected].
-     * Uses a longer timeout since Tor connections are slower.
+     * Pass the full saved relay list so .onion relays are included when Tor turns on.
      */
-    fun onTorSwitch() {
+    fun onTorSwitch(
+        savedConfigs: List<RelayConfig>? = null,
+        savedDmUrls: List<String>? = null
+    ) {
         reconnectJob?.cancel()
         reconnectJob = scope.launch {
-            relayPool.swapClientAndReconnect()
+            relayPool.swapClientAndReconnect(savedConfigs, savedDmUrls)
             relayPool.awaitAnyConnected(minCount = 3, timeoutMs = 10_000)
             relayPool.appIsActive = true
             onReconnected(true)

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -29,6 +29,7 @@ data class BroadcastState(val accepted: Int, val sent: Int)
 
 class RelayPool {
     private var client: OkHttpClient = Relay.createClient()
+    private var clientBuiltWithTor: Boolean = TorManager.isEnabled()
     private val relays = CopyOnWriteArrayList<Relay>()
     private val dmRelays = CopyOnWriteArrayList<Relay>()
     private val ephemeralRelays = java.util.concurrent.ConcurrentHashMap<String, Relay>()
@@ -37,6 +38,19 @@ class RelayPool {
     @Volatile private var pinnedRelayUrls = emptySet<String>()
     private var blockedUrls = emptySet<String>()
     fun getBlockedUrls(): Set<String> = blockedUrls
+
+    /**
+     * Ensure the OkHttpClient matches the current Tor state.
+     * If Tor was enabled/disabled since the client was built, rebuild it.
+     */
+    private fun ensureClientCurrent() {
+        val torNow = TorManager.isEnabled()
+        if (torNow != clientBuiltWithTor) {
+            Log.d("TorRelay", "[Pool] ensureClientCurrent: rebuilding client (was tor=$clientBuiltWithTor, now tor=$torNow)")
+            client = HttpClientFactory.createRelayClient()
+            clientBuiltWithTor = torNow
+        }
+    }
 
     @Volatile var appIsActive = false
         set(value) {
@@ -154,8 +168,22 @@ class RelayPool {
     }
 
     fun updateRelays(configs: List<RelayConfig>) {
+        ensureClientCurrent()
         val badRelays = healthTracker?.getBadRelays() ?: emptySet()
-        val filtered = configs.filter { it.url !in blockedUrls && it.url !in badRelays }.take(MAX_PERSISTENT)
+        val onionConfigs = configs.filter { RelayConfig.isOnionUrl(it.url) }
+        if (onionConfigs.isNotEmpty()) {
+            Log.d("TorRelay", "[Pool] updateRelays: ${onionConfigs.size} .onion relays in config: ${onionConfigs.map { it.url }}")
+            Log.d("TorRelay", "[Pool] updateRelays: torEnabled=${TorManager.isEnabled()} socksPort=${TorManager.socksPort.value}")
+            for (cfg in onionConfigs) {
+                val blocked = cfg.url in blockedUrls
+                val bad = cfg.url in badRelays
+                val connectable = RelayConfig.isConnectableUrl(cfg.url)
+                Log.d("TorRelay", "[Pool] updateRelays: ${cfg.url} blocked=$blocked bad=$bad connectable=$connectable")
+            }
+        }
+        val filtered = configs.filter {
+            it.url !in blockedUrls && it.url !in badRelays && RelayConfig.isConnectableUrl(it.url)
+        }.take(MAX_PERSISTENT)
 
         // Disconnect removed relays
         val currentUrls = filtered.map { it.url }.toSet()
@@ -183,7 +211,8 @@ class RelayPool {
     }
 
     fun updateDmRelays(urls: List<String>) {
-        val filtered = urls.filter { it !in blockedUrls }.take(MAX_DM_RELAYS)
+        ensureClientCurrent()
+        val filtered = urls.filter { it !in blockedUrls && RelayConfig.isConnectableUrl(it) }.take(MAX_DM_RELAYS)
         val currentUrls = filtered.toSet()
         dmRelays.filter { it.config.url !in currentUrls }.forEach {
             it.disconnect()
@@ -590,9 +619,15 @@ class RelayPool {
     }
 
     fun sendToRelayOrEphemeral(url: String, message: String, skipBadCheck: Boolean = false): Boolean {
+        ensureClientCurrent()
         if (url in blockedUrls) return false
         if (!skipBadCheck && healthTracker?.isBad(url) == true) return false
-        if (!RelayConfig.isAcceptableUrl(url)) return false
+        if (!RelayConfig.isConnectableUrl(url)) {
+            if (RelayConfig.isOnionUrl(url)) {
+                Log.d("TorRelay", "[Pool] sendToRelayOrEphemeral: skipping .onion '$url' — torEnabled=${TorManager.isEnabled()}")
+            }
+            return false
+        }
 
         // Check cooldown for failed relays
         val cooldownUntil = relayCooldowns[url]
@@ -903,16 +938,28 @@ class RelayPool {
 
     /**
      * Rebuild the OkHttpClient (e.g. after Tor toggle) and reconnect all relays.
+     * When [allConfigs] / [allDmUrls] are provided (e.g. from saved prefs), they
+     * are used instead of the currently-connected set so that .onion relays are
+     * picked up when Tor turns on.
      */
-    fun swapClientAndReconnect() {
-        val savedConfigs = relays.map { it.config }.toList()
-        val savedDmUrls = dmRelays.map { it.config.url }.toList()
-        Log.d("RLC", "[Pool] swapClientAndReconnect — persistent=${savedConfigs.size} dm=${savedDmUrls.size}")
+    fun swapClientAndReconnect(
+        allConfigs: List<RelayConfig>? = null,
+        allDmUrls: List<String>? = null
+    ) {
+        val configs = allConfigs ?: relays.map { it.config }.toList()
+        val dmUrls = allDmUrls ?: dmRelays.map { it.config.url }.toList()
+        val onionConfigs = configs.filter { RelayConfig.isOnionUrl(it.url) }
+        val onionDm = dmUrls.filter { RelayConfig.isOnionUrl(it) }
+        Log.d("RLC", "[Pool] swapClientAndReconnect — persistent=${configs.size} dm=${dmUrls.size}")
+        Log.d("TorRelay", "[Pool] swapClientAndReconnect: torEnabled=${TorManager.isEnabled()} onionPersistent=${onionConfigs.size} onionDm=${onionDm.size}")
+        if (onionConfigs.isNotEmpty()) Log.d("TorRelay", "[Pool] swapClientAndReconnect .onion relays: ${onionConfigs.map { it.url }}")
+        if (allConfigs != null) Log.d("TorRelay", "[Pool] swapClientAndReconnect: using saved configs (not pool snapshot)")
 
         disconnectAll()
         client = HttpClientFactory.createRelayClient()
-        updateRelays(savedConfigs)
-        updateDmRelays(savedDmUrls)
+        clientBuiltWithTor = TorManager.isEnabled()
+        updateRelays(configs)
+        updateDmRelays(dmUrls)
     }
 
     fun disconnectAll() {

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayProber.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayProber.kt
@@ -172,7 +172,7 @@ object RelayProber {
             val relays = Nip65.parseRelayList(event)
             for (relay in relays) {
                 val url = relay.url.trimEnd('/')
-                if (RelayConfig.isAcceptableUrl(url)) {
+                if (RelayConfig.isValidUrl(url)) {
                     tally[url] = (tally[url] ?: 0) + 1
                 }
             }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayScoreBoard.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayScoreBoard.kt
@@ -83,9 +83,19 @@ class RelayScoreBoard(
             }
         }
 
+        val onionRelays = newRelayAuthors.keys.filter { RelayConfig.isOnionUrl(it) }
         Log.d(TAG, "recompute(): ${follows.size} follows, $knownCount have relay lists, " +
                 "${follows.size - knownCount} missing, ${newRelayAuthors.size} unique relays" +
                 if (excludeRelays.isNotEmpty()) ", ${excludeRelays.size} excluded" else "")
+        if (onionRelays.isNotEmpty()) {
+            Log.d("TorRelay", "[ScoreBoard] recompute: ${onionRelays.size} .onion relays found: $onionRelays")
+            for (url in onionRelays) {
+                val authors = newRelayAuthors[url]?.size ?: 0
+                Log.d("TorRelay", "[ScoreBoard]   $url — $authors author(s)")
+            }
+        } else {
+            Log.d("TorRelay", "[ScoreBoard] recompute: no .onion relays found among ${newRelayAuthors.size} unique relays")
+        }
 
         if (newRelayAuthors.isEmpty()) {
             scoredRelays = emptyList()
@@ -182,7 +192,7 @@ class RelayScoreBoard(
     @Synchronized fun addHintRelays(pubkey: String, urls: List<String>) {
         if (pubkey !in cachedFollowSet) return  // only for followed authors
         if (pubkey in authorToRelays) return     // already has confirmed relay list
-        val validUrls = urls.map { it.trimEnd('/') }.filter { RelayConfig.isAcceptableUrl(it) }
+        val validUrls = urls.map { it.trimEnd('/') }.filter { RelayConfig.isValidUrl(it) }
         if (validUrls.isEmpty()) return
 
         val hints = hintAuthorRelays.getOrPut(pubkey) { mutableSetOf() }

--- a/app/src/main/kotlin/com/wisp/app/repo/RelayHintStore.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/RelayHintStore.kt
@@ -33,7 +33,7 @@ class RelayHintStore(context: Context) {
 
     /** Add a single relay hint for a pubkey. */
     fun addHint(pubkey: String, relayUrl: String) {
-        if (relayUrl.isBlank() || !RelayConfig.isAcceptableUrl(relayUrl)) return
+        if (relayUrl.isBlank() || !RelayConfig.isValidUrl(relayUrl)) return
         @Suppress("NAME_SHADOWING")
         val relayUrl = relayUrl.trimEnd('/')
         val hints = cache.get(pubkey)
@@ -50,7 +50,7 @@ class RelayHintStore(context: Context) {
         for (tag in event.tags) {
             if (tag.size >= 3 && tag[0] == "p") {
                 val url = tag[2]
-                if (RelayConfig.isAcceptableUrl(url)) {
+                if (RelayConfig.isValidUrl(url)) {
                     addHint(tag[1], url)
                 }
             }

--- a/app/src/main/kotlin/com/wisp/app/repo/RelaySetRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/RelaySetRepository.kt
@@ -106,7 +106,7 @@ class RelaySetRepository(private val context: Context, pubkeyHex: String? = null
             pubkey = owner,
             dTag = tag,
             name = name,
-            relays = relays.map { it.trim().trimEnd('/') }.filter { RelayConfig.isAcceptableUrl(it) }.toSet(),
+            relays = relays.map { it.trim().trimEnd('/') }.filter { RelayConfig.isValidUrl(it) }.toSet(),
             createdAt = System.currentTimeMillis() / 1000
         )
         relaySets["$owner:$tag"] = set

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -899,15 +899,20 @@ private fun RelayPickerDialog(
                         } else {
                             IconButton(
                                 onClick = {
-                                    val domain = urlInput.trim()
+                                    val input = urlInput.trim().removeSuffix("/")
+                                    val domain = input
                                         .removePrefix("wss://")
                                         .removePrefix("ws://")
-                                        .removeSuffix("/")
                                     if (domain.isNotBlank()) {
                                         isProbing = true
                                         probeError = null
                                         scope.launch {
-                                            val result = onProbe(domain)
+                                            // If the user specified a protocol, try only that
+                                            val result = when {
+                                                input.startsWith("ws://") || input.startsWith("wss://") ->
+                                                    onProbe(input)
+                                                else -> onProbe(domain)
+                                            }
                                             isProbing = false
                                             if (result != null) {
                                                 onSelect(result)

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/RelayScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/RelayScreen.kt
@@ -28,11 +28,13 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.wisp.app.relay.RelayConfig
 import com.wisp.app.relay.RelayPool
@@ -47,6 +49,7 @@ fun RelayScreen(
     onBack: () -> Unit,
     signer: com.wisp.app.nostr.NostrSigner? = null
 ) {
+    val context = LocalContext.current
     val selectedTab by viewModel.selectedTab.collectAsState()
     val relays by viewModel.relays.collectAsState()
     val dmRelays by viewModel.dmRelays.collectAsState()
@@ -94,7 +97,7 @@ fun RelayScreen(
                     OutlinedTextField(
                         value = newRelayUrl,
                         onValueChange = { viewModel.updateNewRelayUrl(it) },
-                        label = { Text("wss://...") },
+                        label = { Text("wss:// or ws://.onion") },
                         singleLine = true,
                         modifier = Modifier.weight(1f)
                     )
@@ -114,7 +117,11 @@ fun RelayScreen(
                         RelaySetType.BLOCKED -> "Broadcast Blocked Relays"
                     }
                     Button(
-                        onClick = { viewModel.publishRelayList(relayPool, signer = signer) },
+                        onClick = {
+                            val ok = viewModel.publishRelayList(relayPool, signer = signer)
+                            val msg = if (ok) "Relay list broadcast" else "Failed to broadcast"
+                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        },
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Text(buttonLabel)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -300,7 +300,7 @@ class EventRouter(
             for (tag in event.tags) {
                 if (tag.size >= 3 && tag[0] == "p") {
                     val url = tag[2].trimEnd('/')
-                    if (RelayConfig.isAcceptableUrl(url) && !relayListRepo.hasRelayList(tag[1])) {
+                    if (RelayConfig.isValidUrl(url) && !relayListRepo.hasRelayList(tag[1])) {
                         relayScoreBoard.addHintRelays(tag[1], listOf(url))
                     }
                 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.NostrSigner
 import com.wisp.app.relay.HttpClientFactory
+import com.wisp.app.relay.TorManager
 import com.wisp.app.relay.Relay
 import com.wisp.app.relay.RelayLifecycleManager
 import com.wisp.app.relay.OutboxRouter
@@ -283,24 +284,48 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         return counts
     }
 
-    suspend fun probeRelay(domain: String): String? {
-        val wssUrl = "wss://$domain"
-        if (tryConnect(wssUrl)) return wssUrl
-        val wsUrl = "ws://$domain"
-        if (tryConnect(wsUrl)) return wsUrl
+    suspend fun probeRelay(input: String): String? {
+        Log.d("TorRelay", "probeRelay input='$input' torEnabled=${TorManager.isEnabled()} socksPort=${TorManager.socksPort.value} proxy=${TorManager.proxy}")
+        // If the caller already provided a full URL, try only that
+        if (input.startsWith("ws://") || input.startsWith("wss://")) {
+            Log.d("TorRelay", "probeRelay: full URL provided, trying directly")
+            return if (tryConnect(input)) input else null
+        }
+        // Bare domain — try both protocols
+        val isOnion = input.contains(".onion")
+        // .onion relays typically use ws:// (TLS is redundant over Tor), try that first
+        if (isOnion) {
+            Log.d("TorRelay", "probeRelay: .onion domain, trying ws:// first")
+            val wsUrl = "ws://$input"
+            if (tryConnect(wsUrl)) return wsUrl
+            val wssUrl = "wss://$input"
+            if (tryConnect(wssUrl)) return wssUrl
+        } else {
+            val wssUrl = "wss://$input"
+            if (tryConnect(wssUrl)) return wssUrl
+            val wsUrl = "ws://$input"
+            if (tryConnect(wsUrl)) return wsUrl
+        }
+        Log.d("TorRelay", "probeRelay: all attempts failed for '$input'")
         return null
     }
 
     private suspend fun tryConnect(url: String): Boolean {
+        val isTor = TorManager.isEnabled()
+        val timeoutMs = if (isTor) 15_000L else 4_000L
+        Log.d("TorRelay", "tryConnect url='$url' isTor=$isTor timeoutMs=$timeoutMs")
         val client = HttpClientFactory.createRelayClient()
+        Log.d("TorRelay", "tryConnect client proxy=${client.proxy} dns=${client.dns.javaClass.simpleName}")
         val relay = Relay(RelayConfig(url, read = true, write = false), client)
         relay.autoReconnect = false
         return try {
             relay.connect()
-            val connected = relay.awaitConnected(timeoutMs = 4000)
+            val connected = relay.awaitConnected(timeoutMs = timeoutMs)
+            Log.d("TorRelay", "tryConnect result: url='$url' connected=$connected")
             relay.disconnect()
             connected
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.e("TorRelay", "tryConnect exception: url='$url' error=${e.message}", e)
             relay.disconnect()
             false
         }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/RelayViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/RelayViewModel.kt
@@ -48,7 +48,7 @@ class RelayViewModel(app: Application) : AndroidViewModel(app) {
 
     fun addRelay(): Boolean {
         val url = _newRelayUrl.value.trim().trimEnd('/')
-        if (url.isBlank() || !RelayConfig.isAcceptableUrl(url)) return false
+        if (url.isBlank() || !RelayConfig.isValidUrl(url)) return false
 
         when (_selectedTab.value) {
             RelaySetType.GENERAL -> {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
@@ -90,7 +90,7 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
 
     fun addSearchRelay(url: String): Boolean {
         val trimmed = url.trim().trimEnd('/')
-        if (!RelayConfig.isAcceptableUrl(trimmed)) return false
+        if (!RelayConfig.isValidUrl(trimmed)) return false
         if (trimmed in _searchRelays.value) return false
         val updated = _searchRelays.value + trimmed
         keyRepo.saveSearchRelays(updated)

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext ws:// for .onion domains (TLS is redundant over Tor) -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">onion</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- Users can now add `.onion` relays to any relay list at any time, regardless of Tor state
- `.onion` relays are only connected when Tor is active — silently skipped otherwise
- Fixed cleartext `ws://` blocked by Android network security policy for `.onion` domains
- Fixed OkHttpClient not having Tor proxy when Tor is enabled before login/startup
- Fixed relay probe timeout too short for Tor (4s → 15s) and wrong protocol order for `.onion`
- Fixed relay picker ignoring user-specified `ws://`/`wss://` protocol
- Added broadcast feedback toast to relay screen

## Test plan
- [ ] Add a `.onion` relay with Tor **off** — should be accepted and saved
- [ ] The `.onion` relay appears in relay list but is not connected
- [ ] Enable Tor — `.onion` relay auto-connects
- [ ] Disable Tor — `.onion` relay disconnects but stays in the saved list
- [ ] Enable Tor before login, login — `.onion` relays in saved list connect
- [ ] Use relay feed picker to connect to a `.onion` relay while Tor is active
- [ ] Broadcast relay list shows toast confirmation
- [ ] Clearnet relays still work normally with Tor on and off