### PR TITLE
fix: preserve scroll position when navigating back to feed

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
@@ -135,8 +136,12 @@ fun FeedScreen(
     val translationVersion by viewModel.translationRepo.version.collectAsState()
     val connectedCount by viewModel.relayPool.connectedCount.collectAsState()
     val listState = rememberLazyListState()
+    var handledScrollTrigger by rememberSaveable { mutableStateOf(scrollToTopTrigger) }
     LaunchedEffect(scrollToTopTrigger) {
-        if (scrollToTopTrigger > 0) listState.scrollToItem(0)
+        if (scrollToTopTrigger != handledScrollTrigger) {
+            handledScrollTrigger = scrollToTopTrigger
+            listState.scrollToItem(0)
+        }
     }
     val userPubkey = viewModel.getUserPubkey()
     val selectedList by viewModel.selectedList.collectAsState()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -139,8 +140,12 @@ fun NotificationsScreen(
         )
     }
 
+    var handledScrollTrigger by rememberSaveable { mutableStateOf(scrollToTopTrigger) }
     LaunchedEffect(scrollToTopTrigger) {
-        if (scrollToTopTrigger > 0) listState.scrollToItem(0)
+        if (scrollToTopTrigger != handledScrollTrigger) {
+            handledScrollTrigger = scrollToTopTrigger
+            listState.scrollToItem(0)
+        }
     }
 
     // Version flows for cache invalidation on reply PostCards


### PR DESCRIPTION
## Summary
- Fix feed and notifications scrolling to the top when navigating back from compose or other screens
- The `scrollToTopTrigger` LaunchedEffect re-fired on every navigation return because Compose restarts all effects when a composable re-enters composition. If the trigger had ever been incremented (user tapped active tab to scroll to top), the stale value would scroll the list to position 0
- Track the last-handled trigger value in `rememberSaveable` so the effect only fires on genuine new increments

## Test plan
- [ ] Scroll down in the feed, tap compose, publish or go back — feed should stay at the same position
- [ ] Tap the feed tab to scroll to top, then scroll down, navigate away and back — should preserve position
- [ ] Tapping the feed tab while on feed should still scroll to top as before
- [ ] Same behavior verified on notifications screen