### PR TITLE
perf: remove tor debug logging, fix message queue buildup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 12
-        versionName = "0.3.4"
+        versionCode = 13
+        versionName = "0.3.5"
     }
 
     buildTypes {

--- a/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
@@ -1,6 +1,5 @@
 package com.wisp.app.relay
 
-import android.util.Log
 import okhttp3.Dispatcher
 import okhttp3.Dns
 import okhttp3.OkHttpClient
@@ -48,9 +47,7 @@ object HttpClientFactory {
             }
 
         if (isTor) {
-            val proxy = TorManager.proxy
-            Log.d("TorRelay", "[HttpClient] createRelayClient: Tor active, proxy=$proxy socksPort=${TorManager.socksPort.value}")
-            proxy?.let { builder.proxy(it) }
+            TorManager.proxy?.let { builder.proxy(it) }
             builder.dns(torSafeDns)
         }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -46,7 +46,6 @@ class RelayPool {
     private fun ensureClientCurrent() {
         val torNow = TorManager.isEnabled()
         if (torNow != clientBuiltWithTor) {
-            Log.d("TorRelay", "[Pool] ensureClientCurrent: rebuilding client (was tor=$clientBuiltWithTor, now tor=$torNow)")
             client = HttpClientFactory.createRelayClient()
             clientBuiltWithTor = torNow
         }
@@ -170,17 +169,6 @@ class RelayPool {
     fun updateRelays(configs: List<RelayConfig>) {
         ensureClientCurrent()
         val badRelays = healthTracker?.getBadRelays() ?: emptySet()
-        val onionConfigs = configs.filter { RelayConfig.isOnionUrl(it.url) }
-        if (onionConfigs.isNotEmpty()) {
-            Log.d("TorRelay", "[Pool] updateRelays: ${onionConfigs.size} .onion relays in config: ${onionConfigs.map { it.url }}")
-            Log.d("TorRelay", "[Pool] updateRelays: torEnabled=${TorManager.isEnabled()} socksPort=${TorManager.socksPort.value}")
-            for (cfg in onionConfigs) {
-                val blocked = cfg.url in blockedUrls
-                val bad = cfg.url in badRelays
-                val connectable = RelayConfig.isConnectableUrl(cfg.url)
-                Log.d("TorRelay", "[Pool] updateRelays: ${cfg.url} blocked=$blocked bad=$bad connectable=$connectable")
-            }
-        }
         val filtered = configs.filter {
             it.url !in blockedUrls && it.url !in badRelays && RelayConfig.isConnectableUrl(it.url)
         }.take(MAX_PERSISTENT)
@@ -622,12 +610,7 @@ class RelayPool {
         ensureClientCurrent()
         if (url in blockedUrls) return false
         if (!skipBadCheck && healthTracker?.isBad(url) == true) return false
-        if (!RelayConfig.isConnectableUrl(url)) {
-            if (RelayConfig.isOnionUrl(url)) {
-                Log.d("TorRelay", "[Pool] sendToRelayOrEphemeral: skipping .onion '$url' — torEnabled=${TorManager.isEnabled()}")
-            }
-            return false
-        }
+        if (!RelayConfig.isConnectableUrl(url)) return false
 
         // Check cooldown for failed relays
         val cooldownUntil = relayCooldowns[url]
@@ -684,11 +667,7 @@ class RelayPool {
         }
         ephemeralLastUsed[url] = System.currentTimeMillis()
         val sent = ephemeral.send(message)
-        // Return true if: message was sent immediately, OR relay is new (will drain
-        // queue on connect), OR relay exists but is still connecting (message was queued
-        // and will drain on connect — returning false here would incorrectly signal failure).
-        val isConnecting = !ephemeral.isConnected
-        return sent || isNew || isConnecting
+        return sent || isNew
     }
 
     private fun cooldownForFailure(httpCode: Int?): Long {
@@ -948,12 +927,7 @@ class RelayPool {
     ) {
         val configs = allConfigs ?: relays.map { it.config }.toList()
         val dmUrls = allDmUrls ?: dmRelays.map { it.config.url }.toList()
-        val onionConfigs = configs.filter { RelayConfig.isOnionUrl(it.url) }
-        val onionDm = dmUrls.filter { RelayConfig.isOnionUrl(it) }
         Log.d("RLC", "[Pool] swapClientAndReconnect — persistent=${configs.size} dm=${dmUrls.size}")
-        Log.d("TorRelay", "[Pool] swapClientAndReconnect: torEnabled=${TorManager.isEnabled()} onionPersistent=${onionConfigs.size} onionDm=${onionDm.size}")
-        if (onionConfigs.isNotEmpty()) Log.d("TorRelay", "[Pool] swapClientAndReconnect .onion relays: ${onionConfigs.map { it.url }}")
-        if (allConfigs != null) Log.d("TorRelay", "[Pool] swapClientAndReconnect: using saved configs (not pool snapshot)")
 
         disconnectAll()
         client = HttpClientFactory.createRelayClient()

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -285,17 +285,14 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     suspend fun probeRelay(input: String): String? {
-        Log.d("TorRelay", "probeRelay input='$input' torEnabled=${TorManager.isEnabled()} socksPort=${TorManager.socksPort.value} proxy=${TorManager.proxy}")
         // If the caller already provided a full URL, try only that
         if (input.startsWith("ws://") || input.startsWith("wss://")) {
-            Log.d("TorRelay", "probeRelay: full URL provided, trying directly")
             return if (tryConnect(input)) input else null
         }
         // Bare domain — try both protocols
         val isOnion = input.contains(".onion")
         // .onion relays typically use ws:// (TLS is redundant over Tor), try that first
         if (isOnion) {
-            Log.d("TorRelay", "probeRelay: .onion domain, trying ws:// first")
             val wsUrl = "ws://$input"
             if (tryConnect(wsUrl)) return wsUrl
             val wssUrl = "wss://$input"
@@ -306,26 +303,21 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
             val wsUrl = "ws://$input"
             if (tryConnect(wsUrl)) return wsUrl
         }
-        Log.d("TorRelay", "probeRelay: all attempts failed for '$input'")
         return null
     }
 
     private suspend fun tryConnect(url: String): Boolean {
         val isTor = TorManager.isEnabled()
         val timeoutMs = if (isTor) 15_000L else 4_000L
-        Log.d("TorRelay", "tryConnect url='$url' isTor=$isTor timeoutMs=$timeoutMs")
         val client = HttpClientFactory.createRelayClient()
-        Log.d("TorRelay", "tryConnect client proxy=${client.proxy} dns=${client.dns.javaClass.simpleName}")
         val relay = Relay(RelayConfig(url, read = true, write = false), client)
         relay.autoReconnect = false
         return try {
             relay.connect()
             val connected = relay.awaitConnected(timeoutMs = timeoutMs)
-            Log.d("TorRelay", "tryConnect result: url='$url' connected=$connected")
             relay.disconnect()
             connected
         } catch (e: Exception) {
-            Log.e("TorRelay", "tryConnect exception: url='$url' error=${e.message}", e)
             relay.disconnect()
             false
         }


### PR DESCRIPTION
## Summary
- Remove all `TorRelay` debug logging from hot paths (RelayPool, HttpClientFactory, FeedViewModel) to eliminate string interpolation overhead on every outbox message
- Revert `isConnecting` return value in `sendToRelayOrEphemeral()` that caused OutboxRouter to think messages were delivered to still-connecting relays, leading to message queue buildup
- Bump version to 0.3.5 (13)

## Test plan
- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Feed scrolling and navigation transitions feel smoother
- [ ] Tor relay connections still work (just without debug logging)
- [ ] Messages deliver correctly without queue buildup