### PR TITLE
fix: reuse a single OkHttpClient for image loading

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/WispApp.kt
+++ b/app/src/main/kotlin/com/wisp/app/WispApp.kt
@@ -19,10 +19,7 @@ class WispApp : Application(), SingletonImageLoader.Factory {
 
     override fun newImageLoader(context: android.content.Context): ImageLoader {
         val torAwareCallFactory = Call.Factory { request ->
-            HttpClientFactory.createHttpClient(
-                connectTimeoutSeconds = 10,
-                readTimeoutSeconds = 30
-            ).newCall(request)
+            HttpClientFactory.getImageClient().newCall(request)
         }
         return ImageLoader.Builder(context)
             .components {

--- a/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
@@ -54,6 +54,22 @@ object HttpClientFactory {
         return builder.build()
     }
 
+    private var imageClient: OkHttpClient? = null
+    private var imageClientBuiltWithTor: Boolean = false
+
+    fun getImageClient(): OkHttpClient {
+        val torNow = TorManager.isEnabled()
+        val client = imageClient
+        if (client != null && imageClientBuiltWithTor == torNow) return client
+        return createHttpClient(
+            connectTimeoutSeconds = 10,
+            readTimeoutSeconds = 30
+        ).also {
+            imageClient = it
+            imageClientBuiltWithTor = torNow
+        }
+    }
+
     fun createHttpClient(
         connectTimeoutSeconds: Long = 10,
         readTimeoutSeconds: Long = 10,


### PR DESCRIPTION
## Summary
- The Coil `Call.Factory` was creating a new `OkHttpClient` per image request, each with its own connection pool and dispatcher — hundreds of independent connections in feeds with many authors
- Added a cached singleton `getImageClient()` in `HttpClientFactory` that reuses the same client (with connection pooling) and auto-rebuilds when Tor state changes

## Test plan
- [ ] Install on device, open a feed with many unique authors
- [ ] Verify images load normally and phone network stays responsive
- [ ] Toggle Tor on/off, verify images still load correctly