### PR TITLE
feat: add crash reporting via DM

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/CrashHandler.kt
+++ b/app/src/main/kotlin/com/wisp/app/CrashHandler.kt
@@ -1,0 +1,90 @@
+package com.wisp.app
+
+import android.content.Context
+import android.os.Build
+import com.wisp.app.nostr.ClientMessage
+import com.wisp.app.nostr.Nip17
+import com.wisp.app.relay.RelayPool
+import com.wisp.app.repo.KeyRepository
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object CrashHandler {
+
+    const val DEVELOPER_PUBKEY = "e2ccf7cf20403f3f2a4a55b328f0de3be38558a7d5f33632fdaaefc726c1c8eb"
+    private const val CRASH_LOG_FILE = "crash_log.txt"
+
+    private var defaultHandler: Thread.UncaughtExceptionHandler? = null
+
+    fun install(context: Context) {
+        defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            writeCrashLog(context, throwable)
+            defaultHandler?.uncaughtException(thread, throwable)
+        }
+    }
+
+    private fun writeCrashLog(context: Context, throwable: Throwable) {
+        try {
+            val timestamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
+            val version = try {
+                val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                "${pInfo.versionName} (${pInfo.longVersionCode})"
+            } catch (_: Exception) {
+                "unknown"
+            }
+
+            val log = buildString {
+                appendLine("Wisp Crash Report")
+                appendLine("=================")
+                appendLine("Time: $timestamp")
+                appendLine("Version: $version")
+                appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
+                appendLine("Android: ${Build.VERSION.SDK_INT}")
+                appendLine()
+                appendLine("Stack trace:")
+                appendLine(throwable.stackTraceToString())
+            }
+
+            File(context.filesDir, CRASH_LOG_FILE).writeText(log)
+        } catch (_: Exception) {
+            // Best-effort — don't crash the crash handler
+        }
+    }
+
+    fun hasCrashLog(context: Context): Boolean =
+        File(context.filesDir, CRASH_LOG_FILE).exists()
+
+    fun getCrashLog(context: Context): String =
+        File(context.filesDir, CRASH_LOG_FILE).readText()
+
+    fun clearCrashLog(context: Context) {
+        File(context.filesDir, CRASH_LOG_FILE).delete()
+    }
+
+    private val DEVELOPER_DM_RELAYS = listOf(
+        "wss://relay.0xchat.com",
+        "wss://relay.utxo.one/chat",
+        "wss://relay.damus.io"
+    )
+
+    fun sendCrashDm(keyRepo: KeyRepository, relayPool: RelayPool, crashLog: String) {
+        val keypair = keyRepo.getKeypair() ?: return
+
+        val recipientPubkey = DEVELOPER_PUBKEY.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+        val wrap = Nip17.createGiftWrap(
+            senderPrivkey = keypair.privkey,
+            senderPubkey = keypair.pubkey,
+            recipientPubkey = recipientPubkey,
+            message = crashLog
+        )
+        val msg = ClientMessage.event(wrap)
+
+        for (url in DEVELOPER_DM_RELAYS) {
+            relayPool.sendToRelayOrEphemeral(url, msg)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -71,6 +71,7 @@ import com.wisp.app.ui.screen.ListsHubScreen
 import com.wisp.app.ui.screen.PowSettingsScreen
 import com.wisp.app.ui.screen.OnboardingScreen
 import com.wisp.app.ui.component.AddNoteToListDialog
+import com.wisp.app.ui.component.CrashReportDialog
 import com.wisp.app.ui.screen.OnboardingSuggestionsScreen
 import com.wisp.app.ui.screen.RelayDetailScreen
 import com.wisp.app.ui.screen.WalletScreen
@@ -364,6 +365,26 @@ fun WispNavHost(
         notificationsViewModel.notifReceived.collect {
             if (currentNotifSoundEnabled) notifBlipSound.play()
         }
+    }
+
+    // Crash report dialog — check on launch if a crash log exists
+    var showCrashDialog by remember { mutableStateOf(CrashHandler.hasCrashLog(context)) }
+    if (showCrashDialog) {
+        val crashLog = remember { CrashHandler.getCrashLog(context) }
+        CrashReportDialog(
+            crashLog = crashLog,
+            onSend = {
+                showCrashDialog = false
+                CrashHandler.clearCrashLog(context)
+                kotlinx.coroutines.MainScope().launch(kotlinx.coroutines.Dispatchers.Default) {
+                    CrashHandler.sendCrashDm(authViewModel.keyRepo, feedViewModel.relayPool, crashLog)
+                }
+            },
+            onDismiss = {
+                showCrashDialog = false
+                CrashHandler.clearCrashLog(context)
+            }
+        )
     }
 
     // Add Note to List dialog — shared across all screens

--- a/app/src/main/kotlin/com/wisp/app/WispApp.kt
+++ b/app/src/main/kotlin/com/wisp/app/WispApp.kt
@@ -15,6 +15,7 @@ class WispApp : Application(), SingletonImageLoader.Factory {
 
     override fun onCreate() {
         super.onCreate()
+        CrashHandler.install(this)
         TorManager.initialize(this)
     }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/component/CrashReportDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/CrashReportDialog.kt
@@ -1,0 +1,51 @@
+package com.wisp.app.ui.component
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun CrashReportDialog(
+    crashLog: String,
+    onSend: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Wisp crashed") },
+        text = {
+            Text(
+                text = crashLog,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 10.sp,
+                    lineHeight = 14.sp
+                ),
+                modifier = Modifier
+                    .heightIn(max = 300.dp)
+                    .verticalScroll(rememberScrollState())
+                    .horizontalScroll(rememberScrollState())
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onSend) {
+                Text("Send Report")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Dismiss")
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -45,10 +45,14 @@ import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Text
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -95,7 +99,21 @@ fun WispDrawerContent(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                ProfilePicture(url = profile?.picture, size = 64)
+                var crashTapCount by remember { mutableIntStateOf(0) }
+                LaunchedEffect(crashTapCount) {
+                    if (crashTapCount > 0) {
+                        delay(2000)
+                        crashTapCount = 0
+                    }
+                }
+                Box(modifier = Modifier.clickable {
+                    crashTapCount++
+                    if (crashTapCount >= 7) {
+                        throw RuntimeException("Test crash")
+                    }
+                }) {
+                    ProfilePicture(url = profile?.picture, size = 64)
+                }
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = { onToggleTor(!isTorEnabled) }) {
                     Box(contentAlignment = Alignment.Center) {


### PR DESCRIPTION
## Summary
- Installs an uncaught exception handler that writes crash logs to disk
- On next launch, shows a dialog with the stack trace and option to send it as a NIP-17 DM to the developer
- Adds a hidden 7-tap trigger on the drawer profile picture for test crashes

## Test plan
- [x] Trigger test crash via 7-tap on profile picture in drawer
- [x] Relaunch app, verify crash dialog appears with stack trace
- [x] Tap "Send Report" and confirm DM is received
- [x] Tap "Dismiss" and confirm crash log is cleared