### PR TITLE
fix: stop adding e-mention tags for quoted notes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -345,21 +345,13 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             tags.addAll(Nip10.buildReplyTags(replyTo, hint))
         }
 
-        val (mentionedPubkeys, mentionedEventIds) = extractNostrRefs(content)
+        val (mentionedPubkeys, _) = extractNostrRefs(content)
         val existingPubkeys = tags.filter { it.firstOrNull() == "p" }.map { it[1] }.toSet()
         for (pubkey in mentionedPubkeys) {
             if (pubkey !in existingPubkeys) {
                 tags.add(listOf("p", pubkey))
             }
         }
-        val existingEventIds = tags.filter { it.firstOrNull() == "e" }.map { it[1] }.toSet()
-        val quoteEventId = quoteTo?.id
-        for (eventId in mentionedEventIds) {
-            if (eventId !in existingEventIds && eventId != quoteEventId) {
-                tags.add(listOf("e", eventId, "", "mention"))
-            }
-        }
-
         val finalContent = if (quoteTo != null) {
             val quoteHint = outboxRouter?.getRelayHint(quoteTo.pubkey) ?: ""
             tags.addAll(Nip18.buildQuoteTags(quoteTo, quoteHint))


### PR DESCRIPTION
## Summary
- Removed incorrect `["e", eventId, "", "mention"]` tags being added for inline `nostr:` event references
- `e` tags are for reply threading (NIP-10), not for quotes — the `q` tag from `Nip18.buildQuoteTags` already handles this correctly

## Test plan
- [ ] Quote a note and verify the published event has a `q` tag but no `e` mention tag
- [ ] Reply to a note and verify `e` reply tags are still added correctly
- [ ] Post a note with an inline `nostr:nevent1...` reference and verify no `e` tag is added