### PR TITLE
perf: make extended network discovery user-triggered

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -40,6 +40,7 @@ import com.wisp.app.nostr.SignerIntentBridge
 import com.wisp.app.nostr.SignResult
 import com.wisp.app.repo.SigningMode
 import android.content.Context
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import com.wisp.app.ui.component.NotifBlipSound
 import com.wisp.app.ui.component.WispBottomBar
@@ -316,8 +317,15 @@ fun WispNavHost(
 
     val nonAppRoutes = setOf(Routes.AUTH, Routes.LOADING, Routes.ONBOARDING_PROFILE, Routes.ONBOARDING_SUGGESTIONS, Routes.EXISTING_USER_ONBOARDING)
     val hideBottomBarRoutes = nonAppRoutes
-    val showBottomBar by remember(currentRoute) {
-        derivedStateOf { currentRoute != null && currentRoute !in hideBottomBarRoutes }
+    val socialGraphDiscoveryState by feedViewModel.extendedNetworkRepo.discoveryState.collectAsState()
+    val socialGraphComputing = currentRoute == Routes.SOCIAL_GRAPH && (
+        socialGraphDiscoveryState is com.wisp.app.repo.DiscoveryState.FetchingFollowLists ||
+        socialGraphDiscoveryState is com.wisp.app.repo.DiscoveryState.BuildingGraph ||
+        socialGraphDiscoveryState is com.wisp.app.repo.DiscoveryState.ComputingNetwork ||
+        socialGraphDiscoveryState is com.wisp.app.repo.DiscoveryState.Filtering ||
+        socialGraphDiscoveryState is com.wisp.app.repo.DiscoveryState.FetchingRelayLists)
+    val showBottomBar by remember(currentRoute, socialGraphComputing) {
+        derivedStateOf { currentRoute != null && currentRoute !in hideBottomBarRoutes && !socialGraphComputing }
     }
 
     // After process death, Navigation restores the last screen but the ViewModel
@@ -1139,6 +1147,9 @@ fun WispNavHost(
                 onBack = { navController.popBackStack() },
                 onNavigateToProfile = { pubkey ->
                     navController.navigate("profile/$pubkey")
+                },
+                onNetworkDiscovered = {
+                    feedViewModel.integrateExtendedNetwork()
                 }
             )
         }
@@ -1330,6 +1341,7 @@ fun WispNavHost(
             val creators by onboardingViewModel.creators.collectAsState()
             val news by onboardingViewModel.news.collectAsState()
             val selectedPubkeys by onboardingViewModel.selectedPubkeys.collectAsState()
+            val scope = rememberCoroutineScope()
 
             OnboardingSuggestionsScreen(
                 activeNow = activeNow,
@@ -1340,21 +1352,23 @@ fun WispNavHost(
                 onTogglePubkey = { pubkey -> onboardingViewModel.togglePubkey(pubkey) },
                 totalSelected = selectedPubkeys.size,
                 onContinue = {
-                    onboardingViewModel.finishOnboarding(
-                        relayPool = feedViewModel.relayPool,
-                        contactRepo = feedViewModel.contactRepo,
-                        selectedPubkeys = selectedPubkeys,
-                        signer = activeSigner
-                    )
-                    feedViewModel.setFeedType(FeedType.EXTENDED_FOLLOWS)
-                    feedViewModel.reloadForNewAccount()
-                    relayViewModel.reload()
-                    blossomServersViewModel.reload()
-                    composeViewModel.reloadBlossomRepo()
-                    feedViewModel.initRelays()
-                    walletViewModel.refreshState()
-                    navController.navigate(Routes.LOADING) {
-                        popUpTo(0) { inclusive = true }
+                    scope.launch {
+                        onboardingViewModel.finishOnboarding(
+                            relayPool = feedViewModel.relayPool,
+                            contactRepo = feedViewModel.contactRepo,
+                            selectedPubkeys = selectedPubkeys,
+                            signer = activeSigner
+                        )
+                        feedViewModel.setFeedType(FeedType.EXTENDED_FOLLOWS)
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        blossomServersViewModel.reload()
+                        composeViewModel.reloadBlossomRepo()
+                        feedViewModel.initRelays()
+                        walletViewModel.refreshState()
+                        navController.navigate(Routes.LOADING) {
+                            popUpTo(0) { inclusive = true }
+                        }
                     }
                 }
             )

--- a/app/src/main/kotlin/com/wisp/app/repo/ExtendedNetworkRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/ExtendedNetworkRepository.kt
@@ -14,6 +14,7 @@ import com.wisp.app.relay.SubscriptionManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
@@ -46,6 +47,7 @@ data class NetworkStats(
 sealed class DiscoveryState {
     data object Idle : DiscoveryState()
     data class FetchingFollowLists(val fetched: Int, val total: Int) : DiscoveryState()
+    data class BuildingGraph(val processed: Int, val total: Int) : DiscoveryState()
     data class ComputingNetwork(val uniqueUsers: Int) : DiscoveryState()
     data class Filtering(val qualified: Int) : DiscoveryState()
     data class FetchingRelayLists(val fetched: Int, val total: Int) : DiscoveryState()
@@ -81,7 +83,7 @@ class ExtendedNetworkRepository(
     companion object {
         private const val TAG = "ExtendedNetworkRepo"
         private const val THRESHOLD = 10
-        private const val FOLLOW_LIST_TIMEOUT_MS = 8_000L
+        private const val FOLLOW_LIST_TIMEOUT_MS = 5_000L
         private const val RELAY_LIST_CHUNK_SIZE = 500
         private const val RELAY_LIST_TIMEOUT_MS = 8_000L
         private const val MAX_EXTENDED_RELAYS = 100
@@ -167,18 +169,38 @@ class ExtendedNetworkRepository(
             val allFilters = chunks.map { chunk -> Filter(kinds = listOf(3), authors = chunk) }
             val msg = if (allFilters.size == 1) ClientMessage.req(subId, allFilters[0])
             else ClientMessage.req(subId, allFilters)
-            val sentCount = relayPool.sendToTopRelays(msg, maxRelays = 15)
 
-            // Coverage-based waiting: poll until 70% of follow lists received,
-            // EOSE from all relays, or hard timeout (8s).
+            // Collect discovery events directly from the relay pool, bypassing the main
+            // event processing pipeline. The main pipeline processes events sequentially
+            // and gets congested with feed events (kind 1/6), causing discovery events
+            // to trickle through slowly. This dedicated collector runs in parallel.
             val coverageTarget = (firstDegree.size * 0.7).toInt()
-            val deadline = System.currentTimeMillis() + FOLLOW_LIST_TIMEOUT_MS
             coroutineScope {
+                val collectorJob = launch {
+                    relayPool.relayEvents.collect { relayEvent: com.wisp.app.relay.RelayEvent ->
+                        if (relayEvent.subscriptionId == subId && relayEvent.event.kind == 3) {
+                            pendingFollowLists[relayEvent.event.pubkey] = relayEvent.event
+                            _discoveryState.value = DiscoveryState.FetchingFollowLists(
+                                fetched = pendingFollowLists.size,
+                                total = firstDegree.size
+                            )
+                        }
+                    }
+                }
+
+                val sentCount = relayPool.sendToTopRelays(msg, maxRelays = 15)
                 val eoseDeferred = async {
                     subManager.awaitEoseCount(subId, sentCount, FOLLOW_LIST_TIMEOUT_MS)
                 }
+                var lastFetched = 0
+                var lastChangeTime = System.currentTimeMillis()
+                val deadline = System.currentTimeMillis() + FOLLOW_LIST_TIMEOUT_MS
                 while (System.currentTimeMillis() < deadline) {
                     val fetched = pendingFollowLists.size
+                    if (fetched != lastFetched) {
+                        lastFetched = fetched
+                        lastChangeTime = System.currentTimeMillis()
+                    }
                     if (fetched >= coverageTarget) {
                         Log.d(TAG, "Follow list coverage target met: $fetched/$coverageTarget")
                         break
@@ -187,11 +209,15 @@ class ExtendedNetworkRepository(
                         Log.d(TAG, "All EOSE received, $fetched follow lists collected")
                         break
                     }
+                    // Stall detection: no new events for 1.5s means relays are done
+                    if (fetched > 0 && System.currentTimeMillis() - lastChangeTime > 1_500) {
+                        Log.d(TAG, "Follow list fetch stalled at $fetched/${firstDegree.size}, proceeding")
+                        break
+                    }
                     kotlinx.coroutines.delay(200)
                 }
-                // Grace period for buffered events to flush through the processing pipeline
-                kotlinx.coroutines.delay(300)
                 eoseDeferred.cancel()
+                collectorJob.cancel()
             }
             subManager.closeSubscription(subId)
             discoveryTotal = 0
@@ -200,12 +226,15 @@ class ExtendedNetworkRepository(
 
             // Step 2: Parse follow lists, count 2nd-degree appearances, collect relay hints.
             // Write followedBy pairs to SQLite in batches to avoid OOM.
+            val followCount = firstDegree.size
+            _discoveryState.value = DiscoveryState.BuildingGraph(0, followCount)
             socialGraphDb.clearAll()
             val relayHints = mutableMapOf<String, MutableSet<String>>()
             var totalDbRows = 0
             val secondDegreeCount = withContext(Dispatchers.Default) {
                 val counts = mutableMapOf<String, Int>()
                 val batch = mutableListOf<Pair<String, String>>()
+                var processed = 0
                 for ((_, event) in pendingFollowLists) {
                     val entries = Nip02.parseFollowList(event)
                     for (entry in entries) {
@@ -222,10 +251,12 @@ class ExtendedNetworkRepository(
                             }
                         }
                     }
+                    processed++
                     if (batch.size >= 5000) {
                         totalDbRows += batch.size
                         socialGraphDb.insertBatch(batch)
                         batch.clear()
+                        _discoveryState.value = DiscoveryState.BuildingGraph(processed, followCount)
                     }
                 }
                 if (batch.isNotEmpty()) {
@@ -234,6 +265,7 @@ class ExtendedNetworkRepository(
                 }
                 counts
             }
+            _discoveryState.value = DiscoveryState.BuildingGraph(followCount, followCount)
 
             _discoveryState.value = DiscoveryState.ComputingNetwork(secondDegreeCount.size)
             Log.d(TAG, "Social graph: inserted $totalDbRows followedBy rows, ${secondDegreeCount.size} unique 2nd-degree follows")
@@ -264,31 +296,47 @@ class ExtendedNetworkRepository(
             // Split into chunks of 500, send all to all relays, 3s timeout.
             val missingRelayLists = relayListRepo.getMissingPubkeys(qualified.toList())
             if (missingRelayLists.isNotEmpty()) {
-                val chunks = missingRelayLists.chunked(RELAY_LIST_CHUNK_SIZE)
+                val rlChunks = missingRelayLists.chunked(RELAY_LIST_CHUNK_SIZE)
                 val rlSubIds = mutableListOf<String>()
                 _discoveryState.value = DiscoveryState.FetchingRelayLists(0, missingRelayLists.size)
 
-                val sentCounts = mutableListOf<Pair<String, Int>>()
-                for ((i, chunk) in chunks.withIndex()) {
-                    val rlSubId = "extnet-rl-$i"
-                    rlSubIds.add(rlSubId)
-                    val filter = Filter(kinds = listOf(10002), authors = chunk)
-                    val sent = relayPool.sendToTopRelays(ClientMessage.req(rlSubId, filter), maxRelays = 10)
-                    sentCounts.add(rlSubId to sent)
-                }
-
-                // Coverage-based waiting: poll until 70% of relay lists received,
-                // EOSE from all relays, or hard timeout.
                 val rlCoverageTarget = (missingRelayLists.size * 0.7).toInt()
-                val rlDeadline = System.currentTimeMillis() + RELAY_LIST_TIMEOUT_MS
                 coroutineScope {
+                    // Dedicated collector for relay list events — same bypass as follow lists
+                    val rlCollected = java.util.concurrent.atomic.AtomicInteger(0)
+                    val collectorJob = launch {
+                        relayPool.relayEvents.collect { relayEvent: com.wisp.app.relay.RelayEvent ->
+                            if (relayEvent.subscriptionId.startsWith("extnet-rl-") && relayEvent.event.kind == 10002) {
+                                relayListRepo.updateFromEvent(relayEvent.event)
+                                val count = rlCollected.incrementAndGet()
+                                _discoveryState.value = DiscoveryState.FetchingRelayLists(
+                                    count, missingRelayLists.size
+                                )
+                            }
+                        }
+                    }
+
+                    val sentCounts = mutableListOf<Pair<String, Int>>()
+                    for ((i, chunk) in rlChunks.withIndex()) {
+                        val rlSubId = "extnet-rl-$i"
+                        rlSubIds.add(rlSubId)
+                        val filter = Filter(kinds = listOf(10002), authors = chunk)
+                        val sent = relayPool.sendToTopRelays(ClientMessage.req(rlSubId, filter), maxRelays = 10)
+                        sentCounts.add(rlSubId to sent)
+                    }
+
                     val eoseDeferreds = sentCounts.map { (subId, count) ->
                         async { subManager.awaitEoseCount(subId, count, RELAY_LIST_TIMEOUT_MS) }
                     }
+                    var rlLastFetched = 0
+                    var rlLastChangeTime = System.currentTimeMillis()
+                    val rlDeadline = System.currentTimeMillis() + RELAY_LIST_TIMEOUT_MS
                     while (System.currentTimeMillis() < rlDeadline) {
-                        val stillMissing = relayListRepo.getMissingPubkeys(qualified.toList()).size
-                        val fetched = missingRelayLists.size - stillMissing
-                        _discoveryState.value = DiscoveryState.FetchingRelayLists(fetched, missingRelayLists.size)
+                        val fetched = rlCollected.get()
+                        if (fetched != rlLastFetched) {
+                            rlLastFetched = fetched
+                            rlLastChangeTime = System.currentTimeMillis()
+                        }
                         if (fetched >= rlCoverageTarget) {
                             Log.d(TAG, "Relay list coverage target met: $fetched/$rlCoverageTarget")
                             break
@@ -297,10 +345,14 @@ class ExtendedNetworkRepository(
                             Log.d(TAG, "All relay list EOSE received, $fetched relay lists collected")
                             break
                         }
+                        if (fetched > 0 && System.currentTimeMillis() - rlLastChangeTime > 1_500) {
+                            Log.d(TAG, "Relay list fetch stalled at $fetched/${missingRelayLists.size}, proceeding")
+                            break
+                        }
                         kotlinx.coroutines.delay(200)
                     }
-                    kotlinx.coroutines.delay(300)
                     eoseDeferreds.forEach { it.cancel() }
+                    collectorJob.cancel()
                 }
                 for (rlSubId in rlSubIds) subManager.closeSubscription(rlSubId)
             }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -73,6 +74,7 @@ import com.wisp.app.relay.ScoredRelay
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import com.wisp.app.nostr.RelaySet
 import com.wisp.app.relay.BroadcastState
 import com.wisp.app.viewmodel.FeedType
@@ -150,6 +152,7 @@ fun FeedScreen(
     var showListPicker by remember { mutableStateOf(false) }
     var showRelayDropdown by remember { mutableStateOf(false) }
     var showFeedTypeDropdown by remember { mutableStateOf(false) }
+    var showSocialGraphDialog by remember { mutableStateOf(false) }
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     val userProfile = profileVersion.let { userPubkey?.let { viewModel.eventRepo.getProfileData(it) } }
@@ -285,6 +288,29 @@ fun FeedScreen(
             text = { Text(zapErrorMessage ?: "") },
             confirmButton = {
                 TextButton(onClick = { zapErrorMessage = null }) { Text("OK") }
+            }
+        )
+    }
+
+    if (showSocialGraphDialog) {
+        AlertDialog(
+            onDismissRequest = { showSocialGraphDialog = false },
+            title = { Text("Social graph required") },
+            text = {
+                Text("The extended feed shows posts from friends-of-friends. You need to compute your social graph first.")
+            },
+            confirmButton = {
+                Button(onClick = {
+                    showSocialGraphDialog = false
+                    onSocialGraph()
+                }) {
+                    Text("Go to Social Graph")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSocialGraphDialog = false }) {
+                    Text("Cancel")
+                }
             }
         )
     }
@@ -431,7 +457,11 @@ fun FeedScreen(
                                         text = { Text("Extended") },
                                         onClick = {
                                             showFeedTypeDropdown = false
-                                            viewModel.setFeedType(FeedType.EXTENDED_FOLLOWS)
+                                            if (viewModel.extendedNetworkRepo.cachedNetwork.value == null) {
+                                                showSocialGraphDialog = true
+                                            } else {
+                                                viewModel.setFeedType(FeedType.EXTENDED_FOLLOWS)
+                                            }
                                         },
                                         trailingIcon = if (feedType == FeedType.EXTENDED_FOLLOWS) {{
                                             Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
@@ -597,7 +627,19 @@ fun FeedScreen(
                                 )
                             }
                             feedType == FeedType.EXTENDED_FOLLOWS && viewModel.extendedNetworkRepo.cachedNetwork.value == null -> {
-                                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                                // Shouldn't normally reach here since the dropdown intercepts,
+                                // but handle it as a fallback
+                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                    Text(
+                                        "Compute your social graph to see posts from friends-of-friends",
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        textAlign = TextAlign.Center
+                                    )
+                                    Spacer(Modifier.height(12.dp))
+                                    Button(onClick = { onSocialGraph() }) {
+                                        Text("Go to Social Graph")
+                                    }
+                                }
                             }
                             feedType == FeedType.LIST && selectedList == null -> {
                                 Text(

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/LoadingScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/LoadingScreen.kt
@@ -89,8 +89,6 @@ fun LoadingScreen(
     LaunchedEffect(minTimeElapsed, initLoadingState, timedOut, feed.size, initialLoadDone) {
         val initDone = initLoadingState == InitLoadingState.Done
         val feedReady = feed.isNotEmpty()
-        // Don't early-exit while discovery is still running
-        val discoveryBusy = initLoadingState is InitLoadingState.DiscoveringNetwork
         if (timedOut && feedReady) {
             viewModel.markLoadingComplete()
             onReady()
@@ -103,7 +101,7 @@ fun LoadingScreen(
             delay(300)
             viewModel.markLoadingComplete()
             onReady()
-        } else if (minTimeElapsed && feed.size >= 5 && !discoveryBusy) {
+        } else if (minTimeElapsed && feed.size >= 5) {
             // Early exit: enough notes to show a useful feed, don't wait for full EOSE
             viewModel.markLoadingComplete()
             onReady()

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SocialGraphScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SocialGraphScreen.kt
@@ -1,5 +1,6 @@
 package com.wisp.app.ui.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -61,6 +62,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -92,12 +94,33 @@ fun SocialGraphScreen(
     socialGraphDb: SocialGraphDb,
     userPubkey: String?,
     onBack: () -> Unit,
-    onNavigateToProfile: (String) -> Unit
+    onNavigateToProfile: (String) -> Unit,
+    onNetworkDiscovered: () -> Unit = {}
 ) {
     val discoveryState by extendedNetworkRepo.discoveryState.collectAsState()
     val cachedNetwork by extendedNetworkRepo.cachedNetwork.collectAsState()
     val scope = rememberCoroutineScope()
     val graphViewModel: SocialGraphViewModel = viewModel()
+
+    val isComputing = discoveryState is DiscoveryState.FetchingFollowLists ||
+        discoveryState is DiscoveryState.BuildingGraph ||
+        discoveryState is DiscoveryState.ComputingNetwork ||
+        discoveryState is DiscoveryState.Filtering ||
+        discoveryState is DiscoveryState.FetchingRelayLists
+
+    // Prevent leaving while computing
+    BackHandler(enabled = isComputing) { /* block back navigation */ }
+
+    // Notify once when discovery completes so the feed can resubscribe with new pubkeys
+    var notifiedComplete by remember { mutableStateOf(false) }
+    LaunchedEffect(discoveryState) {
+        if (discoveryState is DiscoveryState.Complete && !notifiedComplete) {
+            notifiedComplete = true
+            onNetworkDiscovered()
+        } else if (discoveryState !is DiscoveryState.Complete) {
+            notifiedComplete = false
+        }
+    }
 
     LaunchedEffect(Unit) {
         extendedNetworkRepo.resetDiscoveryState()
@@ -114,7 +137,7 @@ fun SocialGraphScreen(
             TopAppBar(
                 title = { Text("Social Graph") },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = onBack, enabled = !isComputing) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
@@ -165,6 +188,17 @@ fun SocialGraphScreen(
                         progress = if (state.total > 0) state.fetched.toFloat() / state.total else 0f,
                         detail = "${state.fetched} / ${state.total}"
                     )
+                    ComputingWarning()
+                }
+            }
+            is DiscoveryState.BuildingGraph -> {
+                ProgressColumn(padding) {
+                    ProgressContent(
+                        label = "Building graph...",
+                        progress = if (state.total > 0) state.processed.toFloat() / state.total else 0f,
+                        detail = "${state.processed} / ${state.total}"
+                    )
+                    ComputingWarning()
                 }
             }
             is DiscoveryState.ComputingNetwork -> {
@@ -173,6 +207,7 @@ fun SocialGraphScreen(
                         label = "Computing network...",
                         detail = "${state.uniqueUsers} unique users"
                     )
+                    ComputingWarning()
                 }
             }
             is DiscoveryState.Filtering -> {
@@ -181,6 +216,7 @@ fun SocialGraphScreen(
                         label = "Filtering...",
                         detail = "${state.qualified} qualified"
                     )
+                    ComputingWarning()
                 }
             }
             is DiscoveryState.FetchingRelayLists -> {
@@ -190,6 +226,7 @@ fun SocialGraphScreen(
                         progress = if (state.total > 0) state.fetched.toFloat() / state.total else 0f,
                         detail = "${state.fetched} / ${state.total}"
                     )
+                    ComputingWarning()
                 }
             }
             is DiscoveryState.Complete -> {
@@ -226,6 +263,18 @@ private fun ProgressColumn(
     ) {
         content()
     }
+}
+
+@Composable
+private fun ComputingWarning() {
+    Spacer(Modifier.height(24.dp))
+    Text(
+        text = "This may take 2\u20135 minutes. Please stay on this screen until it finishes.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = 16.dp)
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -258,6 +258,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun onAppResume(pausedMs: Long) = startup.onAppResume(pausedMs)
     fun refreshRelays() = startup.refreshRelays()
     fun refreshDmsAndNotifications() = startup.refreshDmsAndNotifications()
+    fun integrateExtendedNetwork() = startup.integrateExtendedNetwork()
     fun refreshNotifRepliesEtag() = startup.refreshNotifRepliesEtag()
 
     // -- Feed subscription delegates --

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/OnboardingViewModel.kt
@@ -155,7 +155,11 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
             viewModelScope.launch {
                 val relayTags = Nip65.buildRelayTags(relays)
                 val relayListEvent = s.signEvent(kind = 10002, content = "", tags = relayTags)
-                relayPool.sendToWriteRelays(ClientMessage.event(relayListEvent))
+                val relayListMsg = ClientMessage.event(relayListEvent)
+                relayPool.sendToWriteRelays(relayListMsg)
+                for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+                    relayPool.sendToRelayOrEphemeral(url, relayListMsg)
+                }
 
                 if (_name.value.isNotBlank() || _about.value.isNotBlank() || _picture.value.isNotBlank()) {
                     val content = buildJsonObject {
@@ -165,7 +169,11 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
                     }.toString()
 
                     val event = s.signEvent(kind = 0, content = content)
-                    relayPool.sendToWriteRelays(ClientMessage.event(event))
+                    val profileMsg = ClientMessage.event(event)
+                    relayPool.sendToWriteRelays(profileMsg)
+                    for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+                        relayPool.sendToRelayOrEphemeral(url, profileMsg)
+                    }
                 }
 
                 _publishing.value = false
@@ -258,7 +266,7 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
 
     private suspend fun loadCreators(relayPool: RelayPool) {
         try {
-            val profiles = fetchProfiles(relayPool, CREATOR_PUBKEYS, "onb-creators", null)
+            val profiles = fetchProfiles(relayPool, CREATOR_PUBKEYS, "onb-creators", ACTIVE_RELAYS)
             _creators.value = SuggestionSection(profiles = profiles, isLoading = false)
         } catch (e: Exception) {
             Log.e(TAG, "loadCreators failed: ${e.message}")
@@ -357,8 +365,9 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
 
     /**
      * Finish onboarding: publish kind 3 follow list (if any selected), mark complete.
+     * Suspend so contactRepo is updated before Navigation proceeds to feed.
      */
-    fun finishOnboarding(
+    suspend fun finishOnboarding(
         relayPool: RelayPool,
         contactRepo: ContactRepository,
         selectedPubkeys: Set<String>,
@@ -374,12 +383,17 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
             follows = Nip02.addFollow(follows, pubkey)
         }
         val tags = Nip02.buildFollowTags(follows)
-        viewModelScope.launch {
-            val event = s.signEvent(kind = 3, content = "", tags = tags)
-            relayPool.sendToWriteRelays(ClientMessage.event(event))
-            contactRepo.updateFromEvent(event)
-        }
-
+        val event = s.signEvent(kind = 3, content = "", tags = tags)
+        contactRepo.updateFromEvent(event)
         keyRepo.markOnboardingComplete()
+
+        // Fire-and-forget relay publishing
+        viewModelScope.launch {
+            val msg = ClientMessage.event(event)
+            relayPool.sendToWriteRelays(msg)
+            for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+                relayPool.sendToRelayOrEphemeral(url, msg)
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -373,55 +373,24 @@ class StartupCoordinator(
                 follows = cachedFollows.map { it.pubkey }
             }
 
-            // Subscribe feed FIRST, then run extended network discovery in the background.
-            // This gets notes on screen faster — extended network expands the feed later.
+            // Subscribe feed with current follow list and relay routing.
             Log.d("StartupCoord", "Subscribing feed, feedType=${feedSub.feedType.value}")
             feedSub.applyAuthorFilterForFeedType(feedSub.feedType.value)
             feedSub._initLoadingState.value = InitLoadingState.Subscribing
             feedSub.subscribeFeed()
-            Log.d("StartupCoord", "subscribeFeed called, launching extended network in background")
+            Log.d("StartupCoord", "subscribeFeed called")
 
-            // Extended network discovery runs in the background — expands pool + resubscribes
-            // feed when done, so new notes from 2nd-degree follows appear seamlessly.
-            val extNetCache = extendedNetworkRepo.cachedNetwork.value
-            val extNetCacheValid = extNetCache != null && !extendedNetworkRepo.isCacheStale(extNetCache)
-            Log.d("StartupCoord", "extNetCacheValid=$extNetCacheValid follows=${follows.size}")
-
-            if (!extNetCacheValid && follows.isNotEmpty()) {
+            // Safety retry: if the follow list arrived late (after the initial subscribeFeed
+            // call which early-returns on empty authors), wait and retry once.
+            if (follows.isEmpty()) {
                 launch {
-                    // Wait for recently-added relays to connect before discovery.
-                    // After recomputeAndMergeRelays the pool may have 30+ relays but
-                    // only a handful are connected yet — sendToTopRelays only reaches
-                    // connected relays, so we need to wait.
-                    val poolSize = relayPool.getRelayUrls().size
-                    val targetConnected = minOf(10, poolSize * 3 / 10)
-                    relayPool.awaitAnyConnected(minCount = targetConnected, timeoutMs = 5_000)
-                    Log.d("StartupCoord", "Discovery: awaited connections, connectedCount=${relayPool.connectedCount.value}")
-
-                    val progressJob = launch {
-                        extendedNetworkRepo.discoveryState.collect { ds ->
-                            if (ds is DiscoveryState.FetchingFollowLists && isColdStart) {
-                                feedSub._initLoadingState.value = InitLoadingState.DiscoveringNetwork(ds.fetched, ds.total)
-                            }
-                        }
+                    val arrived = withTimeoutOrNull(8_000) {
+                        contactRepo.followList.first { it.isNotEmpty() }
                     }
-                    try {
-                        extendedNetworkRepo.discoverNetwork()
-                    } catch (e: Exception) {
-                        Log.e("StartupCoord", "Extended network discovery failed during init", e)
-                    }
-                    progressJob.cancel()
-
-                    // Expand pool with extended relays and resubscribe feed
-                    val extConfigs = extendedNetworkRepo.getRelayConfigs()
-                    if (extConfigs.isNotEmpty()) {
-                        rebuildRelayPool()
-                        val poolSize = relayPool.getRelayUrls().size
-                        val targetConnected = poolSize * 3 / 10
-                        relayPool.awaitAnyConnected(minCount = targetConnected, timeoutMs = 3_000)
+                    if (arrived != null) {
+                        Log.d("StartupCoord", "Follow list arrived late (${arrived.size} follows), resubscribing feed")
                         feedSub.applyAuthorFilterForFeedType(feedSub.feedType.value)
                         feedSub.resubscribeFeed()
-                        Log.d("StartupCoord", "Extended network ready — resubscribed feed with ${extConfigs.size} extra relays")
                     }
                 }
             }
@@ -660,6 +629,23 @@ class StartupCoordinator(
             .filter { it.url !in baseUrls }
 
         relayPool.updateRelays(pinnedRelays + scoredConfigs + extendedConfigs)
+    }
+
+    /**
+     * Integrate an already-computed extended network into the relay pool and feed.
+     * Called after SocialGraphScreen finishes discovery.
+     */
+    fun integrateExtendedNetwork() {
+        scope.launch {
+            val extConfigs = extendedNetworkRepo.getRelayConfigs()
+            if (extConfigs.isNotEmpty()) {
+                rebuildRelayPool()
+                val poolSize = relayPool.getRelayUrls().size
+                relayPool.awaitAnyConnected(minCount = poolSize * 3 / 10, timeoutMs = 3_000)
+                feedSub.applyAuthorFilterForFeedType(feedSub.feedType.value)
+                feedSub.resubscribeFeed()
+            }
+        }
     }
 
     /** Called by Activity lifecycle — delegates to RelayLifecycleManager. */


### PR DESCRIPTION
## Summary
- Remove automatic extended network discovery from startup to prevent lag and OOM crashes for users with large follow lists (1000+)
- Discovery is now triggered explicitly from the Social Graph screen, with progress UI (fetching follow lists, building graph, computing network, fetching relay lists)
- Extended feed type selection shows an alert dialog directing users to compute their social graph first if no cache exists
- Back navigation and bottom bar hidden during computation to prevent users from leaving mid-process
- Startup safety retry for late-arriving follow lists to fix intermittent cold-start hangs
- Dedicated parallel collectors for discovery events to bypass congested main event pipeline

## Test plan
- [ ] Login with large follow list account — startup should be fast with no discovery loading phases
- [ ] Switch to "Extended" feed — should show alert dialog if no social graph computed
- [ ] Navigate to Social Graph, press "Compute Now" — discovery runs with progress feedback
- [ ] Verify back button and bottom nav are disabled during computation
- [ ] Restart app — cached network loads without re-discovery, extended feed works immediately
- [ ] Clear storage and re-login — verify no automatic discovery, onboarding completes smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)