### PR TITLE
fix: respect notification sound toggle for zap and reply sounds

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -419,6 +419,7 @@ fun WispNavHost(
                     hasUnreadNotifications = hasUnreadNotifications,
                     isZapAnimating = isZapAnimating,
                     isReplyAnimating = isReplyAnimating,
+                    notifSoundEnabled = notifSoundEnabled,
                     onTabSelected = { tab ->
                         if (currentRoute == tab.route) {
                             scrollToTopTrigger++

--- a/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
@@ -51,6 +51,7 @@ fun WispBottomBar(
     hasUnreadNotifications: Boolean,
     isZapAnimating: Boolean = false,
     isReplyAnimating: Boolean = false,
+    notifSoundEnabled: Boolean = true,
     onTabSelected: (BottomTab) -> Unit
 ) {
     NavigationBar {
@@ -111,11 +112,13 @@ fun WispBottomBar(
                                 }
                             ZapBurstEffect(
                                 isActive = isZapAnimating,
-                                modifier = zeroFootprintModifier
+                                modifier = zeroFootprintModifier,
+                                soundEnabled = notifSoundEnabled
                             )
                             IcqFlowerBurstEffect(
                                 isActive = isReplyAnimating,
-                                modifier = zeroFootprintModifier
+                                modifier = zeroFootprintModifier,
+                                soundEnabled = notifSoundEnabled
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/IcqFlowerOverlay.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/IcqFlowerOverlay.kt
@@ -34,7 +34,8 @@ import kotlin.math.sin
 @Composable
 fun IcqFlowerBurstEffect(
     isActive: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    soundEnabled: Boolean = true
 ) {
     val context = LocalContext.current
     val replySound = remember { ReplySound(context) }
@@ -53,7 +54,7 @@ fun IcqFlowerBurstEffect(
         if (!isActive) return@LaunchedEffect
 
         petalCount = (6..8).random()
-        replySound.play()
+        if (soundEnabled) replySound.play()
 
         progress.snapTo(0f)
         rotation.snapTo(0f)

--- a/app/src/main/kotlin/com/wisp/app/ui/component/LightningOverlay.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/LightningOverlay.kt
@@ -34,7 +34,8 @@ import kotlin.random.Random
 @Composable
 fun ZapBurstEffect(
     isActive: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    soundEnabled: Boolean = true
 ) {
     val context = LocalContext.current
     val zapSound = remember { ZapSound(context) }
@@ -52,7 +53,7 @@ fun ZapBurstEffect(
         if (!isActive) return@LaunchedEffect
 
         bolts = generateMiniBolts()
-        zapSound.play()
+        if (soundEnabled) zapSound.play()
 
         progress.snapTo(0f)
         progress.animateTo(1f, animationSpec = tween(800, easing = LinearEasing))


### PR DESCRIPTION
## Summary
- The mute notifications toggle only silenced the generic blip sound — zap (lightning) and reply (ICQ flower) sounds still played unconditionally
- Added a `soundEnabled` parameter to `ZapBurstEffect` and `IcqFlowerBurstEffect`, wired through `WispBottomBar` from the existing `notifSoundEnabled` preference

## Test plan
- [ ] Toggle notification sounds off via the mute button on the notifications screen
- [ ] Receive a zap — verify no lightning sound plays (visual animation still shows)
- [ ] Receive a reply — verify no ICQ flower sound plays (visual animation still shows)
- [ ] Toggle sounds back on and verify all three sound types play again