### PR TITLE
perf: restrict APK to arm64-v8a only

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,10 @@ android {
         targetSdk = 35
         versionCode = 15
         versionName = "0.4.0"
+
+        ndk {
+            abiFilters += "arm64-v8a"
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- Restrict NDK ABI filters to `arm64-v8a` only, dropping x86, x86_64, and armeabi-v7a native libraries
- Reduces APK size by removing unused native `.so` files (secp256k1, Tor, media3) for architectures that cover <1% of modern phones
- arm64-v8a covers ~99% of Android phones shipped since 2015

## Test plan
- [ ] Build release APK and compare size to previous universal build
- [ ] Install and run on arm64 device
- [ ] Verify secp256k1 signing, Tor, and media playback still work