### PR TITLE
fix: reduce memory pressure to prevent OOM crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:label="Wisp"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
+        android:largeHeap="true"
         android:theme="@style/Theme.Wisp.Splash">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/kotlin/com/wisp/app/WispApp.kt
+++ b/app/src/main/kotlin/com/wisp/app/WispApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.gif.AnimatedImageDecoder
+import coil3.memory.MemoryCache
 import coil3.video.VideoFrameDecoder
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.crossfade
@@ -28,6 +29,11 @@ class WispApp : Application(), SingletonImageLoader.Factory {
                 add(AnimatedImageDecoder.Factory())
                 add(VideoFrameDecoder.Factory())
                 add(OkHttpNetworkFetcherFactory(callFactory = { torAwareCallFactory }))
+            }
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(context, percent = 0.15)
+                    .build()
             }
             .crossfade(true)
             .build()


### PR DESCRIPTION
## Summary
- Enable `android:largeHeap="true"` to raise the heap ceiling
- Cap Coil image memory cache at 15% of heap (down from default ~25%)

Addresses an OOM crash reported on Pixel 7 / Android 36 where the app ran out of heap during SSL/WebSocket reads due to cumulative memory pressure from relay connections, event caches, and image loading.

## Test plan
- [x] Tested on device — app feels the same with no visible degradation