### PR TITLE
fix: make pull-to-refresh cosmetic only

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -198,13 +198,6 @@ class FeedSubscriptionManager(
 
     fun refreshFeed() {
         _isRefreshing.value = true
-        if (_feedType.value == FeedType.RELAY) {
-            eventRepo.clearRelayFeed()
-            subscribeRelayFeed()
-        } else {
-            eventRepo.resetFeedDisplay()
-            resubscribeFeed()
-        }
         scope.launch {
             delay(3000)
             _isRefreshing.value = false


### PR DESCRIPTION
## Summary
- Remove resubscription logic from `FeedSubscriptionManager.refreshFeed()` — the feed is already live via WebSocket, so pull-to-refresh was redundantly clearing state and resubscribing
- Keep the 3-second spinner animation so the gesture still feels responsive

## Test plan
- [ ] Pull to refresh on feed — spinner shows for 3s, feed stays intact
- [ ] Pull to refresh on notifications — same behavior (already cosmetic, unchanged)
- [ ] Verify feed still updates in real-time without pull gesture