### PR TITLE
fix: deduplicate relay URLs in NIP-65 to prevent LazyColumn crash

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip65.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip65.kt
@@ -17,11 +17,18 @@ object Nip65 {
                 write = marker == null || marker == "write"
             )
         }
-        val onionRelays = result.filter { RelayConfig.isOnionUrl(it.url) }
+        val deduped = result.groupBy { it.url }.map { (url, configs) ->
+            RelayConfig(
+                url = url,
+                read = configs.any { it.read },
+                write = configs.any { it.write }
+            )
+        }
+        val onionRelays = deduped.filter { RelayConfig.isOnionUrl(it.url) }
         if (onionRelays.isNotEmpty()) {
             Log.d("TorRelay", "[Nip65] parseRelayList: pubkey=${event.pubkey.take(8)}… has ${onionRelays.size} .onion relay(s): ${onionRelays.map { it.url }}")
         }
-        return result
+        return deduped
     }
 
     fun buildRelayTags(relays: List<RelayConfig>): List<List<String>> {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -639,7 +639,7 @@ fun UserProfileScreen(
                             item {
                                 SectionLabel("Relay List (NIP-65)")
                             }
-                            items(items = relayList, key = { it.url }) { relay ->
+                            items(items = relayList.distinctBy { it.url }, key = { it.url }) { relay ->
                                 RelayRow(relay)
                             }
                         }


### PR DESCRIPTION
## Summary
- Crash on Samsung SM-S721B (Android 36) when viewing a user profile whose NIP-65 relay list contains the same relay URL with different markers (e.g. `wss://nostr.mom` listed as both read and write)
- `Nip65.parseRelayList` now groups duplicate URLs and merges their read/write flags
- Added `distinctBy` safety net in `UserProfileScreen` relay list, matching the pattern already used in `RelayScreen`

## Test plan
- [ ] View a user profile whose kind 10002 event has duplicate relay entries
- [ ] Verify the relay tab renders without crash and shows merged read/write flags
- [ ] Verify own relay list screen still works correctly