### PR TITLE
fix: scoreboard fallback routing + reduce false bad-relay marks

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -8,7 +8,8 @@ import com.wisp.app.repo.RelayListRepository
 class OutboxRouter(
     private val relayPool: RelayPool,
     private val relayListRepo: RelayListRepository,
-    private val relayHintStore: com.wisp.app.repo.RelayHintStore? = null
+    private val relayHintStore: com.wisp.app.repo.RelayHintStore? = null,
+    private val relayScoreBoard: RelayScoreBoard? = null
 ) {
     companion object {
         /**
@@ -114,6 +115,7 @@ class OutboxRouter(
         Log.d("RLC", "[OutboxRouter] poolUrls=${poolUrls.size}, connectedCount=${relayPool.connectedCount.value}")
         val relayToAuthors = mutableMapOf<String, MutableSet<String>>()
         val fallbackAuthors = mutableListOf<String>()
+        val trulyUnknown = mutableListOf<String>()
 
         for (author in authors) {
             val writeRelays = relayListRepo.getWriteRelays(author)
@@ -131,19 +133,37 @@ class OutboxRouter(
             }
         }
 
-        // Merge fallback authors into PINNED relays only (not all pool relays).
-        // Broadcasting to the full pool (30+ relays) for authors without relay lists
-        // causes massive duplication. Pinned relays + indexers provide sufficient coverage.
+        // Route fallback authors via scoreboard data (known author→relay mappings from
+        // kind 10002) before dumping to pinned relays. This avoids sending 80+ author queries
+        // to personal relays when the pool shrinks and write relays leave the pool.
         if (fallbackAuthors.isNotEmpty()) {
-            val pinnedUrls = relayPool.getPinnedRelayUrls()
-            val fallbackTargets = if (pinnedUrls.isNotEmpty()) {
-                poolUrls.filter { it in pinnedUrls }
+            val scoreboardRouted = relayScoreBoard?.getRelaysForAuthors(fallbackAuthors)
+
+            if (scoreboardRouted != null && scoreboardRouted.isNotEmpty()) {
+                for ((relayUrl, authors) in scoreboardRouted) {
+                    if (relayUrl.isEmpty()) {
+                        trulyUnknown.addAll(authors)
+                    } else if (relayUrl !in blockedUrls) {
+                        relayToAuthors.getOrPut(relayUrl) { mutableSetOf() }.addAll(authors)
+                    }
+                }
             } else {
-                // No pinned relays known — use first 5 pool relays as fallback
-                poolUrls.take(5)
+                trulyUnknown.addAll(fallbackAuthors)
             }
-            for (url in fallbackTargets) {
-                relayToAuthors.getOrPut(url) { mutableSetOf() }.addAll(fallbackAuthors)
+
+            // Truly unknown authors → high-coverage pinned relays only (not personal relays)
+            if (trulyUnknown.isNotEmpty()) {
+                val coverageCounts = relayScoreBoard?.getCoverageCounts() ?: emptyMap()
+                val pinnedUrls = relayPool.getPinnedRelayUrls()
+                val fallbackTargets = if (pinnedUrls.isNotEmpty()) {
+                    poolUrls.filter { it in pinnedUrls && (coverageCounts[it] ?: 0) >= 10 }
+                        .ifEmpty { poolUrls.filter { it in pinnedUrls }.take(2) }
+                } else {
+                    poolUrls.take(5)
+                }
+                for (url in fallbackTargets) {
+                    relayToAuthors.getOrPut(url) { mutableSetOf() }.addAll(trulyUnknown)
+                }
             }
         }
 
@@ -181,8 +201,10 @@ class OutboxRouter(
             }
         }
 
+        val scoreboardRouted = fallbackAuthors.size - trulyUnknown.size
         Log.d("RLC", "[OutboxRouter] subscribeByAuthors($subId): ${authors.size} authors → " +
-                "${relayToAuthors.size} pool relays targeted, ${fallbackAuthors.size} fallback authors, " +
+                "${relayToAuthors.size} pool relays targeted, ${fallbackAuthors.size} fallback authors " +
+                "($scoreboardRouted scoreboard-routed, ${trulyUnknown.size} truly-unknown), " +
                 "${indexerRelays.size} indexers")
 
         return targetedRelays

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayHealthTracker.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayHealthTracker.kt
@@ -20,8 +20,8 @@ class RelayHealthTracker(
         private const val MAX_SESSION_HISTORY = 10
         private const val MIN_SESSIONS_FOR_EVAL = 3
         private const val MIN_SESSION_DURATION_MS = 30_000L
-        private const val BAD_ZERO_EVENT_SESSIONS = 5
-        private const val BAD_DISCONNECT_SESSIONS = 6
+        private const val BAD_ZERO_EVENT_SESSIONS = 8
+        private const val BAD_DISCONNECT_SESSIONS = 8
         private const val BAD_RATE_LIMIT_SESSIONS = 3
         private const val BAD_RELAY_EXPIRY_MS = 24 * 60 * 60 * 1000L // 24 hours
 
@@ -150,6 +150,12 @@ class RelayHealthTracker(
         val session = activeSessions.remove(url) ?: return
         val duration = System.currentTimeMillis() - session.startedAt
         getOrCreateStats(url).totalConnectedMs += duration
+        // Short-lived disconnects are almost certainly app lifecycle transitions
+        // (minimize/close), not actual relay failures — skip failure tracking.
+        if (duration < MIN_SESSION_DURATION_MS) {
+            Log.d(TAG, "Session too short for failure tracking: $url (${duration / 1000}s)")
+            return
+        }
         getOrCreateStats(url).totalFailures++
         recordSession(url, session, duration, isMidSessionFailure = true)
         evaluateRelay(url)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -145,7 +145,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val blossomRepo = BlossomRepository(app, pubkeyHex)
     val relayInfoRepo = RelayInfoRepository()
     val relayScoreBoard = RelayScoreBoard(app, relayListRepo, contactRepo, pubkeyHex)
-    val outboxRouter = OutboxRouter(relayPool, relayListRepo, relayHintStore)
+    val outboxRouter = OutboxRouter(relayPool, relayListRepo, relayHintStore, relayScoreBoard)
     val subManager = SubscriptionManager(relayPool)
     val lifecycleManager = RelayLifecycleManager(
         context = app,


### PR DESCRIPTION
## Summary
- **Fallback author routing**: When pool shrinks and authors' write relays leave the pool, `subscribeByAuthors()` now consults `RelayScoreBoard` for correct author→relay mappings instead of dumping all fallback authors to every pinned relay. Only truly-unknown authors (no relay list at all) go to high-coverage pinned relays, excluding low-coverage personal relays.
- **Health tracker false positives**: Short-lived disconnects (<30s) during app minimize/close no longer count as mid-session failures. Bad-relay thresholds raised from 5/6 to 8/8 (out of 10 session history) to require more consistent bad behavior before marking.

## Test plan
- [ ] `./gradlew assembleDebug` compiles
- [ ] Check logcat for `[OutboxRouter] subscribeByAuthors` — verify `scoreboard-routed` count shows authors correctly routed
- [ ] Verify personal relay no longer receives 80+ author queries after pool shrinks
- [ ] Cycle app minimize/resume several times — verify `news.utxo.com` (or similar specialty relays) no longer get falsely marked bad