### PR TITLE
fix: rebuild feed from cache on feed type switch

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -697,6 +697,34 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         newNotesCutoff = Long.MAX_VALUE
     }
 
+    /**
+     * Rebuild the feed display from eventCache. Used when switching feed types
+     * (e.g. LIST → FOLLOWS) where resetFeedDisplay() cleared feedList/feedIds
+     * but seenEventIds still contains all previously seen events — causing
+     * relay-resent events to be silently deduped by addEvent().
+     *
+     * Scans eventCache for kind 1 root notes, re-inserts them via binaryInsert,
+     * then emits the filtered feed. The optional [sinceTimestamp] limits which
+     * events are re-inserted (defaults to 24h).
+     */
+    fun rebuildFeedFromCache(sinceTimestamp: Long = System.currentTimeMillis() / 1000 - 60 * 60 * 24) {
+        val snapshot = eventCache.snapshot()
+        var inserted = 0
+        for ((_, event) in snapshot) {
+            if (event.kind != 1) continue
+            if (event.created_at < sinceTimestamp) continue
+            if (muteRepo?.isBlocked(event.pubkey) == true) continue
+            if (deletedEventsRepo?.isDeleted(event.id) == true) continue
+            val isReply = event.tags.any { it.size >= 2 && it[0] == "e" }
+            if (isReply) continue
+            val sortTime = feedSortTime.get(event.id) ?: event.created_at
+            binaryInsert(event, sortTime = sortTime)
+            inserted++
+        }
+        rebuildFilteredFeed()
+        android.util.Log.d("RLC", "[EventRepo] rebuildFeedFromCache: $inserted events re-inserted from cache (since=$sinceTimestamp)")
+    }
+
     // -- Isolated relay feed methods --
 
     fun addRelayFeedEvent(event: NostrEvent) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -147,6 +147,10 @@ fun FeedScreen(
     }
     val userPubkey = viewModel.getUserPubkey()
     val selectedList by viewModel.selectedList.collectAsState()
+    // Instantly jump to top whenever feed type, selected list, or selected relay changes
+    LaunchedEffect(feedType, selectedList, selectedRelay, selectedRelaySet) {
+        listState.scrollToItem(0)
+    }
     val ownLists by viewModel.listRepo.ownLists.collectAsState()
     var showRelayPicker by remember { mutableStateOf(false) }
     var showListPicker by remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -135,8 +135,9 @@ class FeedSubscriptionManager(
         when (type) {
             FeedType.FOLLOWS, FeedType.EXTENDED_FOLLOWS -> {
                 if (prev == FeedType.LIST) {
-                    Log.d("RLC", "[FeedSub] switching from $prev to $type — clearing feed and resubscribing")
+                    Log.d("RLC", "[FeedSub] switching from $prev to $type — rebuilding feed from cache and resubscribing")
                     eventRepo.resetFeedDisplay()
+                    eventRepo.rebuildFeedFromCache()
                     resubscribeFeed()
                 } else {
                     // Switching from RELAY or between FOLLOWS/EXTENDED — main feed still running
@@ -156,6 +157,9 @@ class FeedSubscriptionManager(
             }
             FeedType.LIST -> {
                 eventRepo.resetFeedDisplay()
+                // Lists use a 7-day window, so rebuild cache with matching range
+                val listSince = System.currentTimeMillis() / 1000 - 60 * 60 * 24 * 7
+                eventRepo.rebuildFeedFromCache(sinceTimestamp = listSince)
                 resubscribeFeed()
             }
         }


### PR DESCRIPTION
## Summary
- **Feed switch dedup bug**: switching between feed types (LIST → FOLLOWS, LIST → LIST) caused empty/stale feeds because `seenEventIds` blocked re-entry of cached events after `resetFeedDisplay()` cleared the feed list
- **Fix**: add `rebuildFeedFromCache()` that re-inserts kind 1 root notes from `eventCache` into the feed display, bypassing `seenEventIds` dedup
- **UX**: snap scroll to top on any feed type, list, or relay change for snappy switching