### PR TITLE
Add bookmarks to Lists Hub and Add to List dialog

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -63,6 +63,7 @@ import com.wisp.app.ui.screen.CustomEmojiScreen
 import com.wisp.app.ui.screen.SearchScreen
 import com.wisp.app.ui.screen.SocialGraphScreen
 import com.wisp.app.ui.screen.BookmarkSetScreen
+import com.wisp.app.ui.screen.BookmarksScreen
 import com.wisp.app.ui.screen.HashtagFeedScreen
 import com.wisp.app.ui.screen.KeysScreen
 import com.wisp.app.ui.screen.ListScreen
@@ -116,6 +117,7 @@ object Routes {
     const val KEYS = "keys"
     const val LIST_DETAIL = "list/{pubkey}/{dTag}"
     const val LISTS_HUB = "lists"
+    const val BOOKMARKS = "bookmarks"
     const val BOOKMARK_SET_DETAIL = "bookmark_set/{pubkey}/{dTag}"
     const val LOADING = "loading"
     const val ONBOARDING_PROFILE = "onboarding/profile"
@@ -389,9 +391,12 @@ fun WispNavHost(
     // Add Note to List dialog — shared across all screens
     if (addToListEventId != null) {
         val ownSets by feedViewModel.bookmarkSetRepo.ownSets.collectAsState()
+        val bookmarkedIds by feedViewModel.bookmarkRepo.bookmarkedIds.collectAsState()
         AddNoteToListDialog(
             eventId = addToListEventId!!,
             bookmarkSets = ownSets,
+            isBookmarked = addToListEventId!! in bookmarkedIds,
+            onToggleBookmark = { eventId -> feedViewModel.toggleBookmark(eventId) },
             onAddToSet = { dTag, eventId -> feedViewModel.addNoteToBookmarkSet(dTag, eventId) },
             onRemoveFromSet = { dTag, eventId -> feedViewModel.removeNoteFromBookmarkSet(dTag, eventId) },
             onCreateSet = { name -> feedViewModel.createBookmarkSet(name) },
@@ -727,7 +732,9 @@ fun WispNavHost(
                 )
             }
             val isBlockedState by feedViewModel.muteRepo.blockedPubkeys.collectAsState()
-            val profileListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val profileSetListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val profileBookmarkedIds by feedViewModel.bookmarkRepo.bookmarkedIds.collectAsState()
+            val profileListedIds = remember(profileSetListedIds, profileBookmarkedIds) { profileSetListedIds + profileBookmarkedIds }
             val profilePinnedIds by if (isOwnProfile) feedViewModel.pinRepo.pinnedIds.collectAsState() else userProfileViewModel.pinnedNoteIds.collectAsState()
             val profileZapInProgress by feedViewModel.zapInProgress.collectAsState()
             UserProfileScreen(
@@ -793,7 +800,9 @@ fun WispNavHost(
         }
 
         composable(Routes.SEARCH) {
-            val searchListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val searchSetListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val searchBookmarkedIds by feedViewModel.bookmarkRepo.bookmarkedIds.collectAsState()
+            val searchListedIds = remember(searchSetListedIds, searchBookmarkedIds) { searchSetListedIds + searchBookmarkedIds }
             val extNetCache by feedViewModel.extendedNetworkRepo.cachedNetwork.collectAsState()
             SearchScreen(
                 viewModel = searchViewModel,
@@ -938,7 +947,9 @@ fun WispNavHost(
                     onGoToWallet = { navController.navigate(Routes.WALLET) }
                 )
             }
-            val threadListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val threadSetListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val threadBookmarkedIds by feedViewModel.bookmarkRepo.bookmarkedIds.collectAsState()
+            val threadListedIds = remember(threadSetListedIds, threadBookmarkedIds) { threadSetListedIds + threadBookmarkedIds }
             val threadPinnedIds by feedViewModel.pinRepo.pinnedIds.collectAsState()
             val threadResolvedEmojis by feedViewModel.customEmojiRepo.resolvedEmojis.collectAsState()
             val threadUnicodeEmojis by feedViewModel.customEmojiRepo.unicodeEmojis.collectAsState()
@@ -1248,6 +1259,7 @@ fun WispNavHost(
             ListsHubScreen(
                 listRepo = feedViewModel.listRepo,
                 bookmarkSetRepo = feedViewModel.bookmarkSetRepo,
+                bookmarkRepo = feedViewModel.bookmarkRepo,
                 eventRepo = feedViewModel.eventRepo,
                 onBack = { navController.popBackStack() },
                 onListDetail = { list ->
@@ -1256,10 +1268,40 @@ fun WispNavHost(
                 onBookmarkSetDetail = { set ->
                     navController.navigate("bookmark_set/${set.pubkey}/${set.dTag}")
                 },
+                onBookmarksClick = { navController.navigate(Routes.BOOKMARKS) },
                 onCreateList = { name, isPrivate -> feedViewModel.createList(name, isPrivate) },
                 onCreateBookmarkSet = { name, isPrivate -> feedViewModel.createBookmarkSet(name, isPrivate) },
                 onDeleteList = { dTag -> feedViewModel.deleteList(dTag) },
                 onDeleteBookmarkSet = { dTag -> feedViewModel.deleteBookmarkSet(dTag) }
+            )
+        }
+
+        composable(Routes.BOOKMARKS) {
+            val bookmarkedIds by feedViewModel.bookmarkRepo.bookmarkedIds.collectAsState()
+
+            LaunchedEffect(Unit) {
+                feedViewModel.fetchBookmarkEvents()
+            }
+
+            BookmarksScreen(
+                bookmarkedIds = bookmarkedIds,
+                eventRepo = feedViewModel.eventRepo,
+                userPubkey = feedViewModel.getUserPubkey(),
+                onBack = { navController.popBackStack() },
+                onNoteClick = { event -> navController.navigate("thread/${event.id}") },
+                onQuotedNoteClick = { eventId -> navController.navigate("thread/$eventId") },
+                onReply = { event ->
+                    replyTarget = event
+                    quoteTarget = null
+                    composeViewModel.clear()
+                    navController.navigate(Routes.COMPOSE)
+                },
+                onReact = { event, emoji -> feedViewModel.toggleReaction(event, emoji) },
+                onProfileClick = { pubkey -> navController.navigate("profile/$pubkey") },
+                onRemoveBookmark = { eventId -> feedViewModel.removeBookmark(eventId) },
+                onToggleFollow = { pubkey -> feedViewModel.toggleFollow(pubkey) },
+                onBlockUser = { pubkey -> feedViewModel.blockUser(pubkey) },
+                translationRepo = feedViewModel.translationRepo
             )
         }
 
@@ -1379,7 +1421,9 @@ fun WispNavHost(
             var notifZapTarget by remember { mutableStateOf<NostrEvent?>(null) }
             val notifZapInProgress by feedViewModel.zapInProgress.collectAsState()
             var notifZapAnimatingIds by remember { mutableStateOf(emptySet<String>()) }
-            val notifListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val notifSetListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val notifBookmarkedIds by feedViewModel.bookmarkRepo.bookmarkedIds.collectAsState()
+            val notifListedIds = remember(notifSetListedIds, notifBookmarkedIds) { notifSetListedIds + notifBookmarkedIds }
             val isNwcConnected = feedViewModel.nwcRepo.hasConnection()
             var showNotifEmojiLibrary by remember { mutableStateOf(false) }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/component/AddToListDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/AddToListDialog.kt
@@ -28,6 +28,8 @@ import com.wisp.app.nostr.BookmarkSet
 fun AddNoteToListDialog(
     eventId: String,
     bookmarkSets: List<BookmarkSet>,
+    isBookmarked: Boolean = false,
+    onToggleBookmark: ((String) -> Unit)? = null,
     onAddToSet: (dTag: String, eventId: String) -> Unit,
     onRemoveFromSet: (dTag: String, eventId: String) -> Unit,
     onCreateSet: (name: String) -> Unit,
@@ -40,44 +42,58 @@ fun AddNoteToListDialog(
         title = { Text("Add to List") },
         text = {
             Column {
-                if (bookmarkSets.isEmpty()) {
-                    Text(
-                        "No note lists yet. Create one below.",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(bottom = 8.dp)
-                    )
-                } else {
-                    bookmarkSets.forEach { set ->
-                        val isInSet = eventId in set.eventIds
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    if (isInSet) onRemoveFromSet(set.dTag, eventId)
-                                    else onAddToSet(set.dTag, eventId)
-                                }
-                                .padding(vertical = 8.dp)
-                        ) {
-                            Checkbox(
-                                checked = isInSet,
-                                onCheckedChange = {
-                                    if (isInSet) onRemoveFromSet(set.dTag, eventId)
-                                    else onAddToSet(set.dTag, eventId)
-                                }
-                            )
-                            Spacer(Modifier.width(8.dp))
-                            Text(
-                                set.name,
-                                style = MaterialTheme.typography.bodyLarge,
-                                modifier = Modifier.weight(1f)
-                            )
-                            Text(
-                                "${set.eventIds.size}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
+                // Global Bookmarks row
+                if (onToggleBookmark != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onToggleBookmark(eventId) }
+                            .padding(vertical = 8.dp)
+                    ) {
+                        Checkbox(
+                            checked = isBookmarked,
+                            onCheckedChange = { onToggleBookmark(eventId) }
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            "Bookmarks",
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+
+                bookmarkSets.forEach { set ->
+                    val isInSet = eventId in set.eventIds
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                if (isInSet) onRemoveFromSet(set.dTag, eventId)
+                                else onAddToSet(set.dTag, eventId)
+                            }
+                            .padding(vertical = 8.dp)
+                    ) {
+                        Checkbox(
+                            checked = isInSet,
+                            onCheckedChange = {
+                                if (isInSet) onRemoveFromSet(set.dTag, eventId)
+                                else onAddToSet(set.dTag, eventId)
+                            }
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            set.name,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Text(
+                            "${set.eventIds.size}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                 }
                 Spacer(Modifier.height(12.dp))

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/BookmarksScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/BookmarksScreen.kt
@@ -1,0 +1,126 @@
+package com.wisp.app.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.repo.EventRepository
+import com.wisp.app.repo.TranslationRepository
+import com.wisp.app.ui.component.PostCard
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BookmarksScreen(
+    bookmarkedIds: Set<String>,
+    eventRepo: EventRepository,
+    userPubkey: String?,
+    onBack: () -> Unit,
+    onNoteClick: (NostrEvent) -> Unit = {},
+    onQuotedNoteClick: ((String) -> Unit)? = null,
+    onReply: (NostrEvent) -> Unit = {},
+    onReact: (NostrEvent, String) -> Unit = { _, _ -> },
+    onProfileClick: (String) -> Unit = {},
+    onRemoveBookmark: ((String) -> Unit)? = null,
+    onToggleFollow: (String) -> Unit = {},
+    onBlockUser: (String) -> Unit = {},
+    translationRepo: TranslationRepository? = null
+) {
+    val profileVersion by eventRepo.profileVersion.collectAsState()
+    val reactionVersion by eventRepo.reactionVersion.collectAsState()
+    val translationVersion by translationRepo?.version?.collectAsState() ?: remember { mutableStateOf(0) }
+
+    val events = remember(bookmarkedIds, profileVersion) {
+        bookmarkedIds.mapNotNull { id -> eventRepo.getEvent(id) }
+            .sortedByDescending { it.created_at }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Bookmarks") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { padding ->
+        if (bookmarkedIds.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    "No bookmarked notes",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else if (events.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    "Notes not loaded yet",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(padding)
+            ) {
+                items(items = events, key = { it.id }) { event ->
+                    val profile = eventRepo.getProfileData(event.pubkey)
+                    val likeCount = reactionVersion.let { eventRepo.getReactionCount(event.id) }
+                    val userEmojis = reactionVersion.let {
+                        userPubkey?.let { eventRepo.getUserReactionEmojis(event.id, it) } ?: emptySet()
+                    }
+                    val translationState = remember(translationVersion, event.id) {
+                        translationRepo?.getState(event.id) ?: com.wisp.app.repo.TranslationState()
+                    }
+                    PostCard(
+                        event = event,
+                        profile = profile,
+                        onReply = { onReply(event) },
+                        onProfileClick = { onProfileClick(event.pubkey) },
+                        onNavigateToProfile = onProfileClick,
+                        onNoteClick = { onNoteClick(event) },
+                        onQuotedNoteClick = onQuotedNoteClick,
+                        onReact = { emoji -> onReact(event, emoji) },
+                        userReactionEmojis = userEmojis,
+                        likeCount = likeCount,
+                        eventRepo = eventRepo,
+                        onFollowAuthor = { onToggleFollow(event.pubkey) },
+                        onBlockAuthor = { onBlockUser(event.pubkey) },
+                        isOwnEvent = event.pubkey == userPubkey,
+                        translationState = translationState,
+                        onTranslate = { translationRepo?.translate(event.id, event.content) }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -165,7 +165,9 @@ fun FeedScreen(
     val initLoadingState by viewModel.initLoadingState.collectAsState()
     val relayFeedStatus by viewModel.relayFeedStatus.collectAsState()
     val zapInProgress by viewModel.zapInProgress.collectAsState()
-    val listedIds by viewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+    val setListedIds by viewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+    val bookmarkedIds by viewModel.bookmarkRepo.bookmarkedIds.collectAsState()
+    val listedIds = remember(setListedIds, bookmarkedIds) { setListedIds + bookmarkedIds }
     val pinnedIds by viewModel.pinRepo.pinnedIds.collectAsState()
 
     var zapTargetEvent by remember { mutableStateOf<NostrEvent?>(null) }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ListsHubScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ListsHubScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wisp.app.nostr.BookmarkSet
 import com.wisp.app.nostr.FollowSet
+import com.wisp.app.repo.BookmarkRepository
 import com.wisp.app.repo.BookmarkSetRepository
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.ListRepository
@@ -58,10 +59,12 @@ import com.wisp.app.ui.component.ProfilePicture
 fun ListsHubScreen(
     listRepo: ListRepository,
     bookmarkSetRepo: BookmarkSetRepository,
+    bookmarkRepo: BookmarkRepository,
     eventRepo: EventRepository,
     onBack: () -> Unit,
     onListDetail: (FollowSet) -> Unit,
     onBookmarkSetDetail: (BookmarkSet) -> Unit,
+    onBookmarksClick: () -> Unit,
     onCreateList: (String, Boolean) -> Unit,
     onCreateBookmarkSet: (String, Boolean) -> Unit,
     onDeleteList: (String) -> Unit,
@@ -69,6 +72,7 @@ fun ListsHubScreen(
 ) {
     val ownLists by listRepo.ownLists.collectAsState()
     val ownSets by bookmarkSetRepo.ownSets.collectAsState()
+    val bookmarkedIds by bookmarkRepo.bookmarkedIds.collectAsState()
     val profileVersion by eventRepo.profileVersion.collectAsState()
 
     var showCreateDialog by remember { mutableStateOf(false) }
@@ -185,6 +189,36 @@ fun ListsHubScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp)
                 )
+            }
+
+            // Global bookmarks row
+            item(key = "global-bookmarks") {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onBookmarksClick)
+                        .padding(horizontal = 16.dp, vertical = 10.dp)
+                ) {
+                    Icon(
+                        Icons.Outlined.BookmarkBorder,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(Modifier.width(16.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Bookmarks",
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Text(
+                            "${bookmarkedIds.size} notes",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
             }
 
             if (notesLists.isEmpty()) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -355,6 +355,55 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun removeNoteFromBookmarkSet(dTag: String, eventId: String) = listCrud.removeNoteFromBookmarkSet(dTag, eventId)
     fun deleteBookmarkSet(dTag: String) = listCrud.deleteBookmarkSet(dTag)
     fun fetchBookmarkSetEvents(dTag: String) = listCrud.fetchBookmarkSetEvents(dTag)
+
+    fun fetchBookmarkEvents() {
+        val ids = bookmarkRepo.getBookmarkedIds().toList()
+        if (ids.isEmpty()) return
+        val missing = ids.filter { eventRepo.getEvent(it) == null }
+        if (missing.isEmpty()) return
+        val subId = "fetch-bookmarks"
+        val filter = com.wisp.app.nostr.Filter(ids = missing)
+        relayPool.sendToReadRelays(com.wisp.app.nostr.ClientMessage.req(subId, filter))
+        viewModelScope.launch {
+            subManager.awaitEoseWithTimeout(subId)
+            subManager.closeSubscription(subId)
+            kotlinx.coroutines.withContext(processingDispatcher) {
+                metadataFetcher.sweepMissingProfiles()
+            }
+        }
+    }
+
+    fun toggleBookmark(eventId: String) {
+        val s = signer ?: return
+        if (bookmarkRepo.isBookmarked(eventId)) {
+            bookmarkRepo.removeBookmark(eventId)
+        } else {
+            bookmarkRepo.addBookmark(eventId)
+        }
+        publishBookmarkList(s)
+    }
+
+    fun removeBookmark(eventId: String) {
+        val s = signer ?: return
+        bookmarkRepo.removeBookmark(eventId)
+        publishBookmarkList(s)
+    }
+
+    private fun publishBookmarkList(s: com.wisp.app.nostr.NostrSigner) {
+        val tags = com.wisp.app.nostr.Nip51.buildBookmarkListTags(
+            bookmarkRepo.getBookmarkedIds(),
+            bookmarkRepo.getCoordinates(),
+            bookmarkRepo.getHashtags()
+        )
+        viewModelScope.launch {
+            val event = s.signEvent(
+                kind = com.wisp.app.nostr.Nip51.KIND_BOOKMARK_LIST,
+                content = "",
+                tags = tags
+            )
+            relayPool.sendToWriteRelays(com.wisp.app.nostr.ClientMessage.event(event))
+        }
+    }
     fun createEmojiSet(name: String, emojis: List<com.wisp.app.nostr.CustomEmoji>) = listCrud.createEmojiSet(name, emojis)
     fun updateEmojiSet(dTag: String, title: String, emojis: List<com.wisp.app.nostr.CustomEmoji>) = listCrud.updateEmojiSet(dTag, title, emojis)
     fun deleteEmojiSet(dTag: String) = listCrud.deleteEmojiSet(dTag)


### PR DESCRIPTION
## Summary
- Bookmarks (kind 10003) now appear as a first-class "Bookmarks" row at the top of the Notes Lists section in the Lists Hub, with a dedicated screen showing all bookmarked notes
- The Add to List dialog (triggered from the bookmark icon on notes) now shows a "Bookmarks" checkbox at the top, so users can bookmark directly alongside adding to custom lists
- The bookmark icon on notes now highlights when a note is bookmarked (not just when in a bookmark set)

## Test plan
- [ ] Open Lists Hub — "Bookmarks" row appears at top of Notes Lists with correct count
- [ ] Tap Bookmarks row — opens BookmarksScreen showing all bookmarked notes as PostCards
- [ ] Tap bookmark icon on a note in the feed — "Bookmarks" appears as first entry in the dialog
- [ ] Check the Bookmarks checkbox — note gets bookmarked, icon highlights on the action bar
- [ ] Uncheck — bookmark removed, icon unhighlights
- [ ] Verify highlight works across Feed, Thread, Search, Profile, and Notifications screens