### PR TITLE
feat: add option to hide new notes button

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -36,6 +36,8 @@ import androidx.compose.material.icons.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Hub
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material3.IconButton
@@ -84,6 +86,8 @@ fun WispDrawerContent(
     onCustomEmojis: () -> Unit = {},
     onConsole: () -> Unit = {},
     onRelaySettings: () -> Unit,
+    newNotesButtonHidden: Boolean = false,
+    onToggleNewNotesButton: () -> Unit = {},
     onLogout: () -> Unit
 ) {
     ModalDrawerSheet(
@@ -317,6 +321,21 @@ fun WispDrawerContent(
                     label = { Text("Console") },
                     selected = false,
                     onClick = onConsole,
+                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                )
+                NavigationDrawerItem(
+                    icon = {
+                        Icon(
+                            if (newNotesButtonHidden) Icons.Outlined.NotificationsOff
+                            else Icons.Outlined.Notifications,
+                            contentDescription = null
+                        )
+                    },
+                    label = {
+                        Text(if (newNotesButtonHidden) "Show New Notes Button" else "Hide New Notes Button")
+                    },
+                    selected = false,
+                    onClick = onToggleNewNotesButton,
                     modifier = Modifier.padding(start = 36.dp, end = 12.dp)
                 )
             }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -162,6 +164,7 @@ fun FeedScreen(
     val userProfile = profileVersion.let { userPubkey?.let { viewModel.eventRepo.getProfileData(it) } }
 
     val newNoteCount by viewModel.newNoteCount.collectAsState()
+    val newNotesButtonHidden by viewModel.newNotesButtonHidden.collectAsState()
     val initLoadingState by viewModel.initLoadingState.collectAsState()
     val relayFeedStatus by viewModel.relayFeedStatus.collectAsState()
     val zapInProgress by viewModel.zapInProgress.collectAsState()
@@ -390,6 +393,11 @@ fun FeedScreen(
                 onRelaySettings = {
                     scope.launch { drawerState.close() }
                     onRelays()
+                },
+                newNotesButtonHidden = newNotesButtonHidden,
+                onToggleNewNotesButton = {
+                    if (newNotesButtonHidden) viewModel.showNewNotesButton()
+                    else viewModel.hideNewNotesButton(permanent = true)
                 },
                 onLogout = {
                     scope.launch { drawerState.close() }
@@ -739,7 +747,7 @@ fun FeedScreen(
                         }
 
                         NewNotesButton(
-                            visible = newNoteCount > 0 && !isAtTop,
+                            visible = newNoteCount > 0 && !isAtTop && !newNotesButtonHidden,
                             count = newNoteCount,
                             onClick = {
                                 scope.launch {
@@ -747,6 +755,7 @@ fun FeedScreen(
                                     viewModel.resetNewNoteCount()
                                 }
                             },
+                            onHide = { permanent -> viewModel.hideNewNotesButton(permanent) },
                             modifier = Modifier
                                 .align(Alignment.TopCenter)
                                 .padding(top = 8.dp)
@@ -1312,39 +1321,68 @@ private fun ListPickerDialog(
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun NewNotesButton(
     visible: Boolean,
     count: Int,
     onClick: () -> Unit,
+    onHide: (permanent: Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var showMenu by remember { mutableStateOf(false) }
+
     androidx.compose.animation.AnimatedVisibility(
         visible = visible,
         enter = slideInVertically { -it },
         exit = slideOutVertically { -it },
         modifier = modifier
     ) {
-        Surface(
-            onClick = onClick,
-            shape = RoundedCornerShape(20.dp),
-            color = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary,
-            shadowElevation = 4.dp
-        ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    Icons.Default.KeyboardArrowUp,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
+        Box {
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                shadowElevation = 4.dp,
+                modifier = Modifier.combinedClickable(
+                    onClick = onClick,
+                    onLongClick = { showMenu = true }
                 )
-                Spacer(Modifier.width(4.dp))
-                Text(
-                    "$count new notes",
-                    style = MaterialTheme.typography.labelMedium
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Default.KeyboardArrowUp,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        "$count new notes",
+                        style = MaterialTheme.typography.labelMedium
+                    )
+                }
+            }
+
+            DropdownMenu(
+                expanded = showMenu,
+                onDismissRequest = { showMenu = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text("Hide until app restart") },
+                    onClick = {
+                        showMenu = false
+                        onHide(false)
+                    }
+                )
+                DropdownMenuItem(
+                    text = { Text("Hide forever") },
+                    onClick = {
+                        showMenu = false
+                        onHide(true)
+                    }
                 )
             }
         }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -50,6 +50,8 @@ import kotlinx.coroutines.Dispatchers
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.RelaySet
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -236,6 +238,26 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         if (type == FeedType.RELAY) relay else main
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
     val newNoteCount: StateFlow<Int> = eventRepo.newNoteCount
+
+    // -- New notes button visibility --
+    private val settingsPrefs = app.getSharedPreferences("wisp_settings", Context.MODE_PRIVATE)
+    private val _newNotesButtonHidden = MutableStateFlow(
+        settingsPrefs.getBoolean("new_notes_button_hidden", false)
+    )
+    val newNotesButtonHidden: StateFlow<Boolean> = _newNotesButtonHidden
+
+    fun hideNewNotesButton(permanent: Boolean) {
+        _newNotesButtonHidden.value = true
+        if (permanent) {
+            settingsPrefs.edit().putBoolean("new_notes_button_hidden", true).apply()
+        }
+    }
+
+    fun showNewNotesButton() {
+        _newNotesButtonHidden.value = false
+        settingsPrefs.edit().putBoolean("new_notes_button_hidden", false).apply()
+    }
+
     val initialLoadDone: StateFlow<Boolean> = feedSub.initialLoadDone
     val initLoadingState: StateFlow<InitLoadingState> = feedSub.initLoadingState
     val feedType: StateFlow<FeedType> = feedSub.feedType


### PR DESCRIPTION
## Summary
- Long-pressing the "new notes" feed button opens a dropdown with two options: **Hide until app restart** (session-only) and **Hide forever** (persisted via SharedPreferences)
- Added a toggle in the navigation drawer under Settings to re-enable/disable the button
- State managed via `MutableStateFlow` in `FeedViewModel`, with permanent preference stored in `wisp_settings`

## Test plan
- [ ] Tap "new notes" button — should scroll to top as before
- [ ] Long-press "new notes" button — dropdown appears with two hide options
- [ ] Select "Hide until app restart" — button disappears, reappears after app restart
- [ ] Select "Hide forever" — button disappears, stays hidden after app restart
- [ ] Open drawer > Settings > "Show New Notes Button" — re-enables the button