### PR TITLE
Add relay hints to e-tags and improve profile fetching

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip51.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip51.kt
@@ -260,12 +260,16 @@ object Nip51 {
         eventIds: Set<String>,
         coordinates: Set<String> = emptySet(),
         hashtags: Set<String> = emptySet(),
-        title: String? = null
+        title: String? = null,
+        relayHints: Map<String, String> = emptyMap()
     ): List<List<String>> {
         val tags = mutableListOf<List<String>>()
         tags.add(listOf("d", dTag))
         if (title != null) tags.add(listOf("title", title))
-        for (id in eventIds) tags.add(listOf("e", id))
+        for (id in eventIds) {
+            val hint = relayHints[id]
+            if (hint != null) tags.add(listOf("e", id, hint)) else tags.add(listOf("e", id))
+        }
         for (coord in coordinates) tags.add(listOf("a", coord))
         for (tag in hashtags) tags.add(listOf("t", tag))
         return tags
@@ -276,12 +280,16 @@ object Nip51 {
         eventIds: Set<String>,
         coordinates: Set<String> = emptySet(),
         hashtags: Set<String> = emptySet(),
-        title: String? = null
+        title: String? = null,
+        relayHints: Map<String, String> = emptyMap()
     ): Pair<List<List<String>>, String> {
         val tags = listOf(listOf("d", dTag))
         val privateTags = mutableListOf<List<String>>()
         if (title != null) privateTags.add(listOf("title", title))
-        for (id in eventIds) privateTags.add(listOf("e", id))
+        for (id in eventIds) {
+            val hint = relayHints[id]
+            if (hint != null) privateTags.add(listOf("e", id, hint)) else privateTags.add(listOf("e", id))
+        }
         for (coord in coordinates) privateTags.add(listOf("a", coord))
         for (tag in hashtags) privateTags.add(listOf("t", tag))
         return Pair(tags, buildPrivateContent(privateTags))
@@ -302,9 +310,12 @@ object Nip51 {
         return BookmarkList(eventIds, coordinates, hashtags, event.created_at)
     }
 
-    fun buildBookmarkListTags(eventIds: Set<String>, coordinates: Set<String> = emptySet(), hashtags: Set<String> = emptySet()): List<List<String>> {
+    fun buildBookmarkListTags(eventIds: Set<String>, coordinates: Set<String> = emptySet(), hashtags: Set<String> = emptySet(), relayHints: Map<String, String> = emptyMap()): List<List<String>> {
         val tags = mutableListOf<List<String>>()
-        for (id in eventIds) tags.add(listOf("e", id))
+        for (id in eventIds) {
+            val hint = relayHints[id]
+            if (hint != null) tags.add(listOf("e", id, hint)) else tags.add(listOf("e", id))
+        }
         for (coord in coordinates) tags.add(listOf("a", coord))
         for (tag in hashtags) tags.add(listOf("t", tag))
         return tags
@@ -316,7 +327,10 @@ object Nip51 {
         }.toSet()
     }
 
-    fun buildPinListTags(eventIds: Set<String>): List<List<String>> {
-        return eventIds.map { listOf("e", it) }
+    fun buildPinListTags(eventIds: Set<String>, relayHints: Map<String, String> = emptyMap()): List<List<String>> {
+        return eventIds.map { id ->
+            val hint = relayHints[id]
+            if (hint != null) listOf("e", id, hint) else listOf("e", id)
+        }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -233,13 +233,23 @@ class OutboxRouter(
             }
         }
 
-        // Fallback: send unknown pubkeys to top relays (not all — avoids 150-relay broadcast)
+        // Fallback: send unknown pubkeys to top relays + profile indexers
         if (unknownPubkeys.isNotEmpty()) {
             sendChunkedToTopRelays(subId, unknownPubkeys, listOf(
                 Filter(kinds = listOf(0))
             ), limitPerAuthor = true)
+            // Also query profile-specialized relays via ephemeral connections
+            val chunks = unknownPubkeys.chunked(MAX_AUTHORS_PER_FILTER)
+            for (chunk in chunks) {
+                val f = Filter(kinds = listOf(0), authors = chunk, limit = chunk.size)
+                val msg = ClientMessage.req(subId, f)
+                for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+                    relayPool.sendToRelayOrEphemeral(url, msg)
+                }
+            }
         }
     }
+
 
     /**
      * Subscribe to a specific user's content via their write relays.

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayConfig.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayConfig.kt
@@ -25,6 +25,7 @@ data class RelayConfig(
 
         /** Fallback indexer relays used when the user hasn't configured search relays (kind 10007). */
         val DEFAULT_INDEXER_RELAYS = listOf(
+            "wss://purplepag.es",
             "wss://indexer.coracle.social",
             "wss://relay.nos.social",
             "wss://relay.damus.io",

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -426,6 +426,10 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     fun getProfileData(pubkey: String): ProfileData? = profileRepo?.get(pubkey)
 
+    fun requestProfileIfMissing(pubkey: String, relayHints: List<String> = emptyList()) {
+        metadataFetcher?.addToPendingProfiles(pubkey, relayHints)
+    }
+
     fun getReactionCount(eventId: String): Int {
         return reactionCounts.get(eventId)?.values?.sum() ?: 0
     }
@@ -556,6 +560,22 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     }
 
     fun getEventRelays(eventId: String): Set<String> = eventRelays.get(eventId) ?: emptySet()
+
+    fun getRelayHintsForEvents(eventIds: Set<String>): Map<String, String> {
+        val result = mutableMapOf<String, String>()
+        for (id in eventIds) {
+            val relay = getEventRelays(id).firstOrNull()
+            if (relay != null) {
+                result[id] = relay
+            } else {
+                // Fall back to author's known relays from RelayHintStore
+                val event = eventCache.get(id) ?: continue
+                val authorHint = relayHintStore?.getHints(event.pubkey)?.firstOrNull()
+                if (authorHint != null) result[id] = authorHint
+            }
+        }
+        return result
+    }
 
     fun getRepostAuthor(eventId: String): String? = repostAuthors.get(eventId)?.firstOrNull()
 

--- a/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
@@ -28,6 +28,7 @@ class MetadataFetcher(
 ) {
     // Batched profile fetching
     private val pendingProfilePubkeys = mutableSetOf<String>()
+    private val pendingProfileRelayHints = mutableMapOf<String, List<String>>()
     private val inFlightProfiles = mutableSetOf<String>() // currently being fetched, prevents re-queueing
     private var profileBatchJob: Job? = null
     private var metaBatchCounter = 0
@@ -79,6 +80,7 @@ class MetadataFetcher(
         onDemandQuoteBatchJob?.cancel()
         synchronized(pendingProfilePubkeys) {
             pendingProfilePubkeys.clear()
+            pendingProfileRelayHints.clear()
             inFlightProfiles.clear()
         }
         synchronized(pendingReplyCountIds) { pendingReplyCountIds.clear() }
@@ -113,7 +115,7 @@ class MetadataFetcher(
         addToPendingProfiles(pubkey)
     }
 
-    fun addToPendingProfiles(pubkey: String) {
+    fun addToPendingProfiles(pubkey: String, relayHints: List<String> = emptyList()) {
         synchronized(pendingProfilePubkeys) {
             if (profileRepo.has(pubkey)) return
             if (pubkey in exhaustedProfiles) return
@@ -125,6 +127,7 @@ class MetadataFetcher(
             }
             if (pubkey in pendingProfilePubkeys) return
             pendingProfilePubkeys.add(pubkey)
+            if (relayHints.isNotEmpty()) pendingProfileRelayHints[pubkey] = relayHints
             val shouldFlushNow = pendingProfilePubkeys.size >= 200
             if (shouldFlushNow) {
                 profileBatchJob?.cancel()
@@ -284,7 +287,9 @@ class MetadataFetcher(
         if (pendingProfilePubkeys.isEmpty()) return
         val subId = "meta-batch-${metaBatchCounter++}"
         val pubkeys = pendingProfilePubkeys.toList()
+        val relayHints = pendingProfileRelayHints.toMap()
         pendingProfilePubkeys.clear()
+        pendingProfileRelayHints.clear()
         inFlightProfiles.addAll(pubkeys)
 
         pubkeys.forEach { profileAttempts[it] = (profileAttempts[it] ?: 0) + 1 }
@@ -296,6 +301,17 @@ class MetadataFetcher(
             // Retry: send to top 10 relays instead of all — most profiles are on major relays
             val filter = Filter(kinds = listOf(0), authors = pubkeys, limit = pubkeys.size)
             relayPool.sendToTopRelays(ClientMessage.req(subId, filter), maxRelays = 10)
+        }
+
+        // Also send to any relay hints from nprofile references
+        val hintUrls = relayHints.values.flatten().distinct()
+        if (hintUrls.isNotEmpty()) {
+            val hintPubkeys = relayHints.keys.toList()
+            val filter = Filter(kinds = listOf(0), authors = hintPubkeys, limit = hintPubkeys.size)
+            val msg = ClientMessage.req(subId, filter)
+            for (url in hintUrls) {
+                relayPool.sendToRelayOrEphemeral(url, msg)
+            }
         }
 
         scope.launch(processingContext) {

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -111,7 +111,7 @@ internal sealed interface ContentSegment {
     data class LinkSegment(val url: String) : ContentSegment
     data class InlineLinkSegment(val url: String) : ContentSegment
     data class NostrNoteSegment(val eventId: String, val relayHints: List<String> = emptyList()) : ContentSegment
-    data class NostrProfileSegment(val pubkey: String) : ContentSegment
+    data class NostrProfileSegment(val pubkey: String, val relayHints: List<String> = emptyList()) : ContentSegment
     data class NostrAddressableSegment(val dTag: String, val relays: List<String>, val author: String?, val kind: Int?) : ContentSegment
     data class CustomEmojiSegment(val shortcode: String, val url: String) : ContentSegment
     data class HashtagSegment(val tag: String) : ContentSegment
@@ -164,7 +164,7 @@ internal fun parseContent(content: String, emojiMap: Map<String, String> = empty
         } else if (token.startsWith("nostr:")) {
             when (val decoded = Nip19.decodeNostrUri(token)) {
                 is NostrUriData.NoteRef -> segments.add(ContentSegment.NostrNoteSegment(decoded.eventId, decoded.relays))
-                is NostrUriData.ProfileRef -> segments.add(ContentSegment.NostrProfileSegment(decoded.pubkey))
+                is NostrUriData.ProfileRef -> segments.add(ContentSegment.NostrProfileSegment(decoded.pubkey, decoded.relays))
                 is NostrUriData.AddressRef -> segments.add(ContentSegment.NostrAddressableSegment(decoded.dTag, decoded.relays, decoded.author, decoded.kind))
                 null -> segments.add(ContentSegment.TextSegment(token))
             }
@@ -243,6 +243,7 @@ fun RichContent(
     modifier: Modifier = Modifier
 ) {
     val segments = remember(content, emojiMap) { parseContent(content.trimEnd('\n', '\r'), emojiMap) }
+    val profileVer = eventRepo?.profileVersion?.collectAsState()?.value ?: 0
     var fullScreenImageUrl by remember { mutableStateOf<String?>(null) }
     var fullScreenVideoUrl by remember { mutableStateOf<String?>(null) }
     var fullScreenVideoPositionMs by remember { mutableLongStateOf(0L) }
@@ -300,12 +301,24 @@ fun RichContent(
                 val inlineSegments = group as List<ContentSegment>
 
                 // Build profile display names for this run
-                val profileNames = mutableMapOf<String, String>()
-                for (seg in inlineSegments) {
-                    if (seg is ContentSegment.NostrProfileSegment) {
-                        val profile = eventRepo?.getProfileData(seg.pubkey)
-                        profileNames[seg.pubkey] = profile?.displayString
-                            ?: "${seg.pubkey.take(8)}...${seg.pubkey.takeLast(4)}"
+                val profilePubkeys = inlineSegments
+                    .filterIsInstance<ContentSegment.NostrProfileSegment>()
+                    .map { it.pubkey }
+                val profileNames = remember(profilePubkeys, profileVer) {
+                    val names = mutableMapOf<String, String>()
+                    for (pubkey in profilePubkeys) {
+                        val profile = eventRepo?.getProfileData(pubkey)
+                        names[pubkey] = profile?.displayString
+                            ?: "${pubkey.take(8)}...${pubkey.takeLast(4)}"
+                    }
+                    names
+                }
+                // Queue fetches for any missing profiles
+                LaunchedEffect(profilePubkeys) {
+                    for (seg in inlineSegments) {
+                        if (seg is ContentSegment.NostrProfileSegment) {
+                            eventRepo?.requestProfileIfMissing(seg.pubkey, seg.relayHints)
+                        }
                     }
                 }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ListScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ListScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wisp.app.nostr.FollowSet
 import com.wisp.app.nostr.Nip19
+import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.toHex
 import com.wisp.app.repo.ContactRepository
 import com.wisp.app.repo.EventRepository
@@ -68,6 +69,7 @@ fun ListScreen(
     contactRepo: ContactRepository? = null
 ) {
     val profileVersion by eventRepo.profileVersion.collectAsState()
+    val clipboardManager = androidx.compose.ui.platform.LocalClipboardManager.current
     var showPickerDialog by remember { mutableStateOf(false) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
     var showFollowAllConfirm by remember { mutableStateOf(false) }
@@ -140,33 +142,44 @@ fun ListScreen(
                             Icon(Icons.Default.Add, "Add Members")
                         }
                     }
-                    if (isOwnList || (!isOwnList && onFollowAll != null)) {
-                        Box {
-                            IconButton(onClick = { menuExpanded = true }) {
-                                Icon(Icons.Default.MoreVert, "More options")
+                    Box {
+                        IconButton(onClick = { menuExpanded = true }) {
+                            Icon(Icons.Default.MoreVert, "More options")
+                        }
+                        DropdownMenu(
+                            expanded = menuExpanded,
+                            onDismissRequest = { menuExpanded = false }
+                        ) {
+                            if (!isOwnList && onFollowAll != null) {
+                                DropdownMenuItem(
+                                    text = { Text("Follow All Members") },
+                                    onClick = {
+                                        menuExpanded = false
+                                        showFollowAllConfirm = true
+                                    }
+                                )
                             }
-                            DropdownMenu(
-                                expanded = menuExpanded,
-                                onDismissRequest = { menuExpanded = false }
-                            ) {
-                                if (!isOwnList && onFollowAll != null) {
-                                    DropdownMenuItem(
-                                        text = { Text("Follow All Members") },
-                                        onClick = {
-                                            menuExpanded = false
-                                            showFollowAllConfirm = true
+                            if (followSet != null) {
+                                DropdownMenuItem(
+                                    text = { Text("Copy List JSON") },
+                                    onClick = {
+                                        menuExpanded = false
+                                        val event = eventRepo.findAddressableEvent(Nip51.KIND_FOLLOW_SET, followSet.pubkey, followSet.dTag)
+                                        val json = event?.toJson() ?: ""
+                                        if (json.isNotEmpty()) {
+                                            clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(json))
                                         }
-                                    )
-                                }
-                                if (isOwnList && onDeleteList != null) {
-                                    DropdownMenuItem(
-                                        text = { Text("Delete List", color = MaterialTheme.colorScheme.error) },
-                                        onClick = {
-                                            menuExpanded = false
-                                            showDeleteConfirm = true
-                                        }
-                                    )
-                                }
+                                    }
+                                )
+                            }
+                            if (isOwnList && onDeleteList != null) {
+                                DropdownMenuItem(
+                                    text = { Text("Delete List", color = MaterialTheme.colorScheme.error) },
+                                    onClick = {
+                                        menuExpanded = false
+                                        showDeleteConfirm = true
+                                    }
+                                )
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ListsHubScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ListsHubScreen.kt
@@ -234,6 +234,7 @@ fun ListsHubScreen(
                 items(notesLists, key = { "n:${it.pubkey}:${it.dTag}" }) { bookmarkSet ->
                     BookmarkSetRow(
                         bookmarkSet = bookmarkSet,
+                        eventRepo = eventRepo,
                         onClick = { onBookmarkSetDetail(bookmarkSet) },
                         onDelete = {
                             deleteConfirmation = DeleteTarget.Notes(bookmarkSet.dTag, bookmarkSet.name)
@@ -271,21 +272,10 @@ private fun FollowSetRow(
 
     if (showJsonDialog) {
         val jsonText = remember(followSet) {
-            buildString {
-                appendLine("{")
-                appendLine("  \"kind\": 30000,")
-                appendLine("  \"pubkey\": \"${followSet.pubkey}\",")
-                appendLine("  \"d_tag\": \"${followSet.dTag}\",")
-                appendLine("  \"name\": \"${followSet.name}\",")
-                appendLine("  \"members\": [")
-                followSet.members.forEachIndexed { i, pk ->
-                    val comma = if (i < followSet.members.size - 1) "," else ""
-                    appendLine("    \"$pk\"$comma")
-                }
-                appendLine("  ],")
-                appendLine("  \"created_at\": ${followSet.createdAt}")
-                append("}")
-            }
+            val event = eventRepo.findAddressableEvent(
+                com.wisp.app.nostr.Nip51.KIND_FOLLOW_SET, followSet.pubkey, followSet.dTag
+            )
+            event?.toJson() ?: "Event not found in cache"
         }
         JsonViewDialog(json = jsonText, onDismiss = { showJsonDialog = false })
     }
@@ -369,6 +359,7 @@ private fun FollowSetRow(
 @Composable
 private fun BookmarkSetRow(
     bookmarkSet: BookmarkSet,
+    eventRepo: EventRepository,
     onClick: () -> Unit,
     onDelete: () -> Unit,
     onViewJson: () -> Unit
@@ -378,37 +369,10 @@ private fun BookmarkSetRow(
 
     if (showJsonDialog) {
         val jsonText = remember(bookmarkSet) {
-            buildString {
-                appendLine("{")
-                appendLine("  \"kind\": 30003,")
-                appendLine("  \"pubkey\": \"${bookmarkSet.pubkey}\",")
-                appendLine("  \"d_tag\": \"${bookmarkSet.dTag}\",")
-                appendLine("  \"name\": \"${bookmarkSet.name}\",")
-                appendLine("  \"event_ids\": [")
-                bookmarkSet.eventIds.forEachIndexed { i, id ->
-                    val comma = if (i < bookmarkSet.eventIds.size - 1) "," else ""
-                    appendLine("    \"$id\"$comma")
-                }
-                appendLine("  ],")
-                if (bookmarkSet.coordinates.isNotEmpty()) {
-                    appendLine("  \"coordinates\": [")
-                    bookmarkSet.coordinates.forEachIndexed { i, c ->
-                        val comma = if (i < bookmarkSet.coordinates.size - 1) "," else ""
-                        appendLine("    \"$c\"$comma")
-                    }
-                    appendLine("  ],")
-                }
-                if (bookmarkSet.hashtags.isNotEmpty()) {
-                    appendLine("  \"hashtags\": [")
-                    bookmarkSet.hashtags.forEachIndexed { i, t ->
-                        val comma = if (i < bookmarkSet.hashtags.size - 1) "," else ""
-                        appendLine("    \"$t\"$comma")
-                    }
-                    appendLine("  ],")
-                }
-                appendLine("  \"created_at\": ${bookmarkSet.createdAt}")
-                append("}")
-            }
+            val event = eventRepo.findAddressableEvent(
+                com.wisp.app.nostr.Nip51.KIND_BOOKMARK_SET, bookmarkSet.pubkey, bookmarkSet.dTag
+            )
+            event?.toJson() ?: "Event not found in cache"
         }
         JsonViewDialog(json = jsonText, onDismiss = { showJsonDialog = false })
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -333,7 +333,7 @@ class EventRouter(
                 eventRepo.cacheEvent(event)
                 eventRepo.addRelayFeedEvent(event)
                 onRelayFeedEventReceived()
-                if (event.kind == 1) eventRepo.addEventRelay(event.id, relayUrl)
+                eventRepo.addEventRelay(event.id, relayUrl)
                 if (event.kind == 1) {
                     metadataFetcher.fetchQuotedEvents(event)
                     if (eventRepo.getProfileData(event.pubkey) == null) {
@@ -351,7 +351,7 @@ class EventRouter(
                 }
             } else if (isFeedSub) {
                 eventRepo.addEvent(event)
-                if (event.kind == 1) eventRepo.addEventRelay(event.id, relayUrl)
+                eventRepo.addEventRelay(event.id, relayUrl)
                 if (event.kind == 1) {
                     metadataFetcher.fetchQuotedEvents(event)
                     if (eventRepo.getProfileData(event.pubkey) == null) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -413,10 +413,13 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     private fun publishBookmarkList(s: com.wisp.app.nostr.NostrSigner) {
+        val ids = bookmarkRepo.getBookmarkedIds()
+        val hints = eventRepo.getRelayHintsForEvents(ids)
         val tags = com.wisp.app.nostr.Nip51.buildBookmarkListTags(
-            bookmarkRepo.getBookmarkedIds(),
+            ids,
             bookmarkRepo.getCoordinates(),
-            bookmarkRepo.getHashtags()
+            bookmarkRepo.getHashtags(),
+            relayHints = hints
         )
         viewModelScope.launch {
             val event = s.signEvent(
@@ -424,6 +427,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
                 content = "",
                 tags = tags
             )
+            eventRepo.cacheEvent(event)
             relayPool.sendToWriteRelays(com.wisp.app.nostr.ClientMessage.event(event))
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ListCrudManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ListCrudManager.kt
@@ -47,6 +47,7 @@ class ListCrudManager(
             scope.launch {
                 val encrypted = s.nip44Encrypt(plaintext, s.pubkeyHex)
                 val event = s.signEvent(kind = Nip51.KIND_FOLLOW_SET, content = encrypted, tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 listRepo.updateFromEvent(event, plaintext)
             }
@@ -54,6 +55,7 @@ class ListCrudManager(
             val tags = Nip51.buildFollowSetTags(dTag, emptySet(), title = title)
             scope.launch {
                 val event = s.signEvent(kind = Nip51.KIND_FOLLOW_SET, content = "", tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 listRepo.updateFromEvent(event)
             }
@@ -71,6 +73,7 @@ class ListCrudManager(
             scope.launch {
                 val encrypted = s.nip44Encrypt(plaintext, myPubkey)
                 val event = s.signEvent(kind = Nip51.KIND_FOLLOW_SET, content = encrypted, tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 listRepo.updateFromEvent(event, plaintext)
             }
@@ -78,6 +81,7 @@ class ListCrudManager(
             val tags = Nip51.buildFollowSetTags(dTag, newMembers, title = title)
             scope.launch {
                 val event = s.signEvent(kind = Nip51.KIND_FOLLOW_SET, content = "", tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 listRepo.updateFromEvent(event)
             }
@@ -96,6 +100,7 @@ class ListCrudManager(
                 val hasContent = newMembers.isNotEmpty() || title != null
                 val encrypted = if (hasContent) s.nip44Encrypt(plaintext, myPubkey) else ""
                 val event = s.signEvent(kind = Nip51.KIND_FOLLOW_SET, content = encrypted, tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 listRepo.updateFromEvent(event, if (hasContent) plaintext else "[]")
             }
@@ -103,6 +108,7 @@ class ListCrudManager(
             val tags = Nip51.buildFollowSetTags(dTag, newMembers, title = title)
             scope.launch {
                 val event = s.signEvent(kind = Nip51.KIND_FOLLOW_SET, content = "", tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 listRepo.updateFromEvent(event)
             }
@@ -141,6 +147,7 @@ class ListCrudManager(
             scope.launch {
                 val encrypted = s.nip44Encrypt(plaintext, s.pubkeyHex)
                 val event = s.signEvent(kind = Nip51.KIND_BOOKMARK_SET, content = encrypted, tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 bookmarkSetRepo.updateFromEvent(event, plaintext)
             }
@@ -148,6 +155,7 @@ class ListCrudManager(
             val tags = Nip51.buildBookmarkSetTags(dTag, emptySet(), title = title)
             scope.launch {
                 val event = s.signEvent(kind = Nip51.KIND_BOOKMARK_SET, content = "", tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 bookmarkSetRepo.updateFromEvent(event)
             }
@@ -160,18 +168,21 @@ class ListCrudManager(
         val existing = bookmarkSetRepo.getSet(myPubkey, dTag) ?: return
         val newIds = existing.eventIds + eventId
         val title = existing.name.takeIf { it != existing.dTag }
+        val hints = eventRepo.getRelayHintsForEvents(newIds)
         if (existing.isPrivate) {
-            val (tags, plaintext) = Nip51.buildBookmarkSetPrivate(dTag, newIds, existing.coordinates, existing.hashtags, title = title)
+            val (tags, plaintext) = Nip51.buildBookmarkSetPrivate(dTag, newIds, existing.coordinates, existing.hashtags, title = title, relayHints = hints)
             scope.launch {
                 val encrypted = s.nip44Encrypt(plaintext, myPubkey)
                 val event = s.signEvent(kind = Nip51.KIND_BOOKMARK_SET, content = encrypted, tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 bookmarkSetRepo.updateFromEvent(event, plaintext)
             }
         } else {
-            val tags = Nip51.buildBookmarkSetTags(dTag, newIds, existing.coordinates, existing.hashtags, title = title)
+            val tags = Nip51.buildBookmarkSetTags(dTag, newIds, existing.coordinates, existing.hashtags, title = title, relayHints = hints)
             scope.launch {
                 val event = s.signEvent(kind = Nip51.KIND_BOOKMARK_SET, content = "", tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 bookmarkSetRepo.updateFromEvent(event)
             }
@@ -184,19 +195,22 @@ class ListCrudManager(
         val existing = bookmarkSetRepo.getSet(myPubkey, dTag) ?: return
         val newIds = existing.eventIds - eventId
         val title = existing.name.takeIf { it != existing.dTag }
+        val hints = eventRepo.getRelayHintsForEvents(newIds)
         if (existing.isPrivate) {
-            val (tags, plaintext) = Nip51.buildBookmarkSetPrivate(dTag, newIds, existing.coordinates, existing.hashtags, title = title)
+            val (tags, plaintext) = Nip51.buildBookmarkSetPrivate(dTag, newIds, existing.coordinates, existing.hashtags, title = title, relayHints = hints)
             scope.launch {
                 val hasContent = newIds.isNotEmpty() || existing.coordinates.isNotEmpty() || existing.hashtags.isNotEmpty() || title != null
                 val encrypted = if (hasContent) s.nip44Encrypt(plaintext, myPubkey) else ""
                 val event = s.signEvent(kind = Nip51.KIND_BOOKMARK_SET, content = encrypted, tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 bookmarkSetRepo.updateFromEvent(event, if (hasContent) plaintext else "[]")
             }
         } else {
-            val tags = Nip51.buildBookmarkSetTags(dTag, newIds, existing.coordinates, existing.hashtags, title = title)
+            val tags = Nip51.buildBookmarkSetTags(dTag, newIds, existing.coordinates, existing.hashtags, title = title, relayHints = hints)
             scope.launch {
                 val event = s.signEvent(kind = Nip51.KIND_BOOKMARK_SET, content = "", tags = tags)
+                eventRepo.cacheEvent(event)
                 relayPool.sendToWriteRelays(ClientMessage.event(event))
                 bookmarkSetRepo.updateFromEvent(event)
             }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
@@ -216,7 +216,9 @@ class SocialActionManager(
 
     private fun publishPinList() {
         val s = getSigner() ?: return
-        val tags = Nip51.buildPinListTags(pinRepo.getPinnedIds())
+        val ids = pinRepo.getPinnedIds()
+        val hints = eventRepo.getRelayHintsForEvents(ids)
+        val tags = Nip51.buildPinListTags(ids, relayHints = hints)
         scope.launch {
             val event = s.signEvent(kind = Nip51.KIND_PIN_LIST, content = "", tags = tags)
             relayPool.sendToWriteRelays(ClientMessage.event(event))


### PR DESCRIPTION
## Summary
- Add relay hints as third element in e-tags when publishing bookmark lists (10003), bookmark sets (30003), and pin lists (10001) using event relay provenance with RelayHintStore author fallback
- Improve profile resolution for `nostr:nprofile` references in rich content by passing relay hints through to MetadataFetcher and querying profile indexer relays (purplepag.es) as fallback
- View JSON dialogs now show the actual signed Nostr event instead of synthetic JSON
- Cache list/set events in eventRepo after signing so they're immediately available for View JSON
- Track relay provenance for all event kinds in EventRouter, not just kind 1
- Add "Copy List JSON" option to follow set detail screen menu

## Test plan
- [ ] Add a note to a bookmark set, verify e-tags include relay hints in View JSON
- [ ] Toggle a bookmark, verify relay hints in the published kind 10003
- [ ] Pin a note, verify relay hints in the published kind 10001
- [ ] View JSON on a follow set and bookmark set, verify it shows the actual signed event
- [ ] Open a note with an nprofile mention for a user not yet cached, verify their name resolves