### PR TITLE
feat: add relay health browser screen

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -59,6 +59,7 @@ import com.wisp.app.ui.screen.NotificationsScreen
 import com.wisp.app.ui.screen.SafetyScreen
 import com.wisp.app.ui.screen.UserProfileScreen
 import com.wisp.app.ui.screen.ConsoleScreen
+import com.wisp.app.ui.screen.RelayHealthScreen
 import com.wisp.app.ui.screen.CustomEmojiScreen
 import com.wisp.app.ui.screen.SearchScreen
 import com.wisp.app.ui.screen.SocialGraphScreen
@@ -91,6 +92,7 @@ import com.wisp.app.viewmodel.ThreadViewModel
 import com.wisp.app.viewmodel.UserProfileViewModel
 import com.wisp.app.viewmodel.NotificationsViewModel
 import com.wisp.app.viewmodel.ConsoleViewModel
+import com.wisp.app.viewmodel.RelayHealthViewModel
 import com.wisp.app.viewmodel.DraftsViewModel
 import com.wisp.app.viewmodel.SearchViewModel
 import com.wisp.app.viewmodel.HashtagFeedViewModel
@@ -131,6 +133,7 @@ object Routes {
     const val SOCIAL_GRAPH = "social_graph"
     const val POW_SETTINGS = "pow_settings"
     const val INTERFACE_SETTINGS = "interface_settings"
+    const val RELAY_HEALTH = "relay_health"
 }
 
 @Composable
@@ -161,6 +164,7 @@ fun WispNavHost(
     val draftsViewModel: DraftsViewModel = viewModel()
     val searchViewModel: SearchViewModel = viewModel()
     val consoleViewModel: ConsoleViewModel = viewModel()
+    val relayHealthViewModel: RelayHealthViewModel = viewModel()
     val onboardingViewModel: OnboardingViewModel = viewModel()
 
     relayViewModel.relayPool = feedViewModel.relayPool
@@ -587,6 +591,9 @@ fun WispNavHost(
                 },
                 onConsole = {
                     navController.navigate(Routes.CONSOLE)
+                },
+                onRelayHealth = {
+                    navController.navigate(Routes.RELAY_HEALTH)
                 },
                 onKeys = {
                     navController.navigate(Routes.KEYS)
@@ -1157,6 +1164,23 @@ fun WispNavHost(
             ConsoleScreen(
                 viewModel = consoleViewModel,
                 onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(Routes.RELAY_HEALTH) {
+            relayHealthViewModel.init(
+                feedViewModel.relayPool,
+                feedViewModel.healthTracker,
+                feedViewModel.relayInfoRepo,
+                feedViewModel.eventRepo,
+                feedViewModel.relayScoreBoard
+            )
+            RelayHealthScreen(
+                viewModel = relayHealthViewModel,
+                onBack = { navController.popBackStack() },
+                onRelayDetail = { url ->
+                    navController.navigate("relay_detail/${java.net.URLEncoder.encode(url, "UTF-8")}")
+                }
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayHealthTracker.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayHealthTracker.kt
@@ -68,6 +68,8 @@ class RelayHealthTracker(
     private val lifetimeStats = mutableMapOf<String, RelayStats>()
     /** URL → timestamp when marked bad. Entries expire after [BAD_RELAY_EXPIRY_MS]. */
     private val _badRelays = mutableMapOf<String, Long>()
+    /** URL → human-readable reason why the relay was marked bad. */
+    private val _badRelayReasons = mutableMapOf<String, String>()
 
     var onBadRelaysChanged: (() -> Unit)? = null
 
@@ -178,6 +180,7 @@ class RelayHealthTracker(
         val markedAt = _badRelays[url] ?: return false
         if (System.currentTimeMillis() - markedAt > BAD_RELAY_EXPIRY_MS) {
             _badRelays.remove(url)
+            _badRelayReasons.remove(url)
             sessionHistory.remove(url)
             Log.d(TAG, "Bad relay expired, giving second chance: $url")
             return false
@@ -190,6 +193,7 @@ class RelayHealthTracker(
         val expired = _badRelays.filter { now - it.value > BAD_RELAY_EXPIRY_MS }.keys
         for (url in expired) {
             _badRelays.remove(url)
+            _badRelayReasons.remove(url)
             sessionHistory.remove(url)
             Log.d(TAG, "Bad relay expired: $url")
         }
@@ -198,6 +202,7 @@ class RelayHealthTracker(
 
     fun clearBadRelay(url: String) {
         if (_badRelays.remove(url) != null) {
+            _badRelayReasons.remove(url)
             sessionHistory.remove(url)
             saveToPrefs()
             onBadRelaysChanged?.invoke()
@@ -209,6 +214,7 @@ class RelayHealthTracker(
         if (_badRelays.isNotEmpty()) {
             val count = _badRelays.size
             _badRelays.clear()
+            _badRelayReasons.clear()
             sessionHistory.clear()
             saveToPrefs()
             onBadRelaysChanged?.invoke()
@@ -220,13 +226,48 @@ class RelayHealthTracker(
 
     fun getAllStats(): Map<String, RelayStats> = lifetimeStats.toMap()
 
+    fun getBadRelayReason(url: String): String? = _badRelayReasons[url]
+
+    // -- Session history exposure --
+
+    data class SessionSummary(
+        val eventsReceived: Int,
+        val hadMidSessionFailure: Boolean,
+        val hadRateLimit: Boolean,
+        val durationMs: Long
+    )
+
+    data class ActiveSessionInfo(
+        val eventsReceived: Int,
+        val durationMs: Long
+    )
+
+    @Synchronized
+    fun getSessionHistory(url: String): List<SessionSummary> {
+        return sessionHistory[url]?.map {
+            SessionSummary(it.eventsReceived, it.hadMidSessionFailure, it.hadRateLimit, it.durationMs)
+        } ?: emptyList()
+    }
+
+    @Synchronized
+    fun getActiveSession(url: String): ActiveSessionInfo? {
+        val session = activeSessions[url] ?: return null
+        return ActiveSessionInfo(
+            eventsReceived = session.eventsReceived,
+            durationMs = System.currentTimeMillis() - session.startedAt
+        )
+    }
+
+    fun getAllTrackedUrls(): Set<String> = lifetimeStats.keys.toSet()
+
     // -- Account management --
 
     fun clear() {
         activeSessions.clear()
         sessionHistory.clear()
         lifetimeStats.clear()
-        _badRelays.clear()  // Map.clear()
+        _badRelays.clear()
+        _badRelayReasons.clear()
         prefs.edit().clear().apply()
     }
 
@@ -290,6 +331,11 @@ class RelayHealthTracker(
 
         if (isBadNow && !wasBad) {
             _badRelays[url] = System.currentTimeMillis()
+            val reasons = mutableListOf<String>()
+            if (zeroEventSessions >= BAD_ZERO_EVENT_SESSIONS) reasons.add("$zeroEventSessions/${history.size} sessions received 0 events")
+            if (disconnectSessions >= BAD_DISCONNECT_SESSIONS) reasons.add("$disconnectSessions/${history.size} sessions disconnected mid-session")
+            if (rateLimitSessions >= BAD_RATE_LIMIT_SESSIONS) reasons.add("$rateLimitSessions/${history.size} sessions hit rate limits")
+            _badRelayReasons[url] = reasons.joinToString("; ")
             Log.w(TAG, "Relay marked BAD: $url (zero=$zeroEventSessions, disconnects=$disconnectSessions, rateLimit=$rateLimitSessions)")
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -895,6 +895,16 @@ class RelayPool {
 
     fun getEphemeralCount(): Int = ephemeralRelays.size
 
+    fun getEphemeralRelayUrls(): List<String> = ephemeralRelays.keys.toList()
+
+    fun getAllRelayUrls(): List<String> {
+        val urls = mutableListOf<String>()
+        urls.addAll(relays.map { it.config.url })
+        urls.addAll(dmRelays.map { it.config.url })
+        urls.addAll(ephemeralRelays.keys)
+        return urls
+    }
+
     fun isRelayConnected(url: String): Boolean = relayIndex[url]?.isConnected == true
 
     /** Clear cooldown for a specific relay so it can be retried immediately. */

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Key
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Hub
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Settings
@@ -84,6 +85,7 @@ fun WispDrawerContent(
     onPowSettings: () -> Unit = {},
     onCustomEmojis: () -> Unit = {},
     onConsole: () -> Unit = {},
+    onRelayHealth: () -> Unit = {},
     onRelaySettings: () -> Unit,
     onInterfaceSettings: () -> Unit = {},
     onLogout: () -> Unit
@@ -319,6 +321,13 @@ fun WispDrawerContent(
                     label = { Text("Custom Emojis") },
                     selected = false,
                     onClick = onCustomEmojis,
+                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                )
+                NavigationDrawerItem(
+                    icon = { Icon(Icons.Outlined.FavoriteBorder, contentDescription = null) },
+                    label = { Text("Relay Health") },
+                    selected = false,
+                    onClick = onRelayHealth,
                     modifier = Modifier.padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -118,6 +118,7 @@ fun FeedScreen(
     onSafety: () -> Unit = {},
     onCustomEmojis: () -> Unit = {},
     onConsole: () -> Unit = {},
+    onRelayHealth: () -> Unit = {},
     onKeys: () -> Unit = {},
     onPowSettings: () -> Unit = {},
     onInterfaceSettings: () -> Unit = {},
@@ -407,6 +408,10 @@ fun FeedScreen(
                 onConsole = {
                     scope.launch { drawerState.close() }
                     onConsole()
+                },
+                onRelayHealth = {
+                    scope.launch { drawerState.close() }
+                    onRelayHealth()
                 },
                 onRelaySettings = {
                     scope.launch { drawerState.close() }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/RelayDetailScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/RelayDetailScreen.kt
@@ -748,20 +748,20 @@ private fun ConsoleEntryItem(entry: ConsoleLogEntry) {
 
 // -- Formatting Helpers --
 
-private fun formatNumber(n: Long): String = when {
+internal fun formatNumber(n: Long): String = when {
     n >= 1_000_000 -> String.format("%.1fM", n / 1_000_000.0)
     n >= 1_000 -> String.format("%.1fK", n / 1_000.0)
     else -> n.toString()
 }
 
-private fun formatBytes(bytes: Long): String = when {
+internal fun formatBytes(bytes: Long): String = when {
     bytes >= 1_073_741_824 -> String.format("%.1f GB", bytes / 1_073_741_824.0)
     bytes >= 1_048_576 -> String.format("%.1f MB", bytes / 1_048_576.0)
     bytes >= 1024 -> String.format("%.1f KB", bytes / 1024.0)
     else -> "$bytes B"
 }
 
-private fun formatDuration(ms: Long): String {
+internal fun formatDuration(ms: Long): String {
     val totalSeconds = ms / 1000
     val hours = totalSeconds / 3600
     val minutes = (totalSeconds % 3600) / 60

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/RelayHealthScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/RelayHealthScreen.kt
@@ -1,0 +1,454 @@
+package com.wisp.app.ui.screen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.wisp.app.ui.component.ProfilePicture
+import com.wisp.app.ui.component.RelayIcon
+import com.wisp.app.viewmodel.HealthFilter
+import com.wisp.app.viewmodel.HealthSortMode
+import com.wisp.app.viewmodel.RelayHealthSummary
+import com.wisp.app.viewmodel.RelayHealthViewModel
+import com.wisp.app.viewmodel.RelayType
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RelayHealthScreen(
+    viewModel: RelayHealthViewModel,
+    onBack: () -> Unit,
+    onRelayDetail: (String) -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Relay Health") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            // Summary row
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    SummaryCard(
+                        label = "Connected",
+                        value = "${state.totalConnected}/${state.totalRelays}",
+                        modifier = Modifier.weight(1f)
+                    )
+                    SummaryCard(
+                        label = "Bad",
+                        value = state.totalBad.toString(),
+                        modifier = Modifier.weight(1f),
+                        valueColor = if (state.totalBad > 0) Color(0xFFFF5252) else null
+                    )
+                }
+            }
+
+            // Sort/filter chips
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    FilterChip(
+                        selected = state.sortMode == HealthSortMode.STATUS,
+                        onClick = { viewModel.setSortMode(HealthSortMode.STATUS) },
+                        label = { Text("Status", style = MaterialTheme.typography.labelSmall) }
+                    )
+                    FilterChip(
+                        selected = state.sortMode == HealthSortMode.FAILURES,
+                        onClick = { viewModel.setSortMode(HealthSortMode.FAILURES) },
+                        label = { Text("Failures", style = MaterialTheme.typography.labelSmall) }
+                    )
+                    FilterChip(
+                        selected = state.sortMode == HealthSortMode.EVENTS,
+                        onClick = { viewModel.setSortMode(HealthSortMode.EVENTS) },
+                        label = { Text("Events", style = MaterialTheme.typography.labelSmall) }
+                    )
+                    FilterChip(
+                        selected = state.sortMode == HealthSortMode.NAME,
+                        onClick = { viewModel.setSortMode(HealthSortMode.NAME) },
+                        label = { Text("Name", style = MaterialTheme.typography.labelSmall) }
+                    )
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 2.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    FilterChip(
+                        selected = state.filter == HealthFilter.ALL,
+                        onClick = { viewModel.setFilter(HealthFilter.ALL) },
+                        label = { Text("All", style = MaterialTheme.typography.labelSmall) }
+                    )
+                    FilterChip(
+                        selected = state.filter == HealthFilter.BAD_ONLY,
+                        onClick = { viewModel.setFilter(HealthFilter.BAD_ONLY) },
+                        label = { Text("Bad Only", style = MaterialTheme.typography.labelSmall) }
+                    )
+                    FilterChip(
+                        selected = state.filter == HealthFilter.ERRORS_ONLY,
+                        onClick = { viewModel.setFilter(HealthFilter.ERRORS_ONLY) },
+                        label = { Text("Errors", style = MaterialTheme.typography.labelSmall) }
+                    )
+                }
+            }
+
+            // Relay list
+            items(state.relays, key = { it.url }) { relay ->
+                RelayHealthItem(
+                    relay = relay,
+                    onClick = { onRelayDetail(relay.url) },
+                    onClearBad = { viewModel.clearBadRelay(relay.url) }
+                )
+            }
+
+            // Empty state
+            if (state.relays.isEmpty()) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            if (state.filter != HealthFilter.ALL) "No relays match this filter"
+                            else "No relay data yet",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            item { Spacer(Modifier.height(32.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun SummaryCard(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    valueColor: Color? = null
+) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = modifier
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = valueColor ?: MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun RelayHealthItem(
+    relay: RelayHealthSummary,
+    onClick: () -> Unit,
+    onClearBad: () -> Unit
+) {
+    val domain = remember(relay.url) {
+        relay.url.removePrefix("wss://").removePrefix("ws://").removeSuffix("/")
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            // Relay icon with connection status overlay
+            Box {
+                RelayIcon(
+                    iconUrl = relay.iconUrl,
+                    relayUrl = relay.url,
+                    size = 40.dp
+                )
+                // Connection dot overlaid on bottom-right of icon
+                Surface(
+                    shape = CircleShape,
+                    color = when {
+                        relay.isBad -> Color(0xFFFF5252)
+                        relay.cooldownRemaining > 0 -> Color(0xFFFFD54F)
+                        relay.isConnected -> Color(0xFF81C784)
+                        else -> MaterialTheme.colorScheme.outline
+                    },
+                    modifier = Modifier
+                        .size(12.dp)
+                        .align(Alignment.BottomEnd)
+                ) {}
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            // Info column
+            Column(modifier = Modifier.weight(1f)) {
+                // Relay name + domain
+                Text(
+                    text = relay.relayName ?: domain,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (relay.relayName != null) {
+                    Text(
+                        text = domain,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                Spacer(Modifier.height(4.dp))
+
+                // Badges row: type + bad/cooldown
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (relay.relayType != RelayType.PERSISTENT) {
+                        Surface(
+                            shape = RoundedCornerShape(4.dp),
+                            color = when (relay.relayType) {
+                                RelayType.DM -> Color(0xFF90CAF9).copy(alpha = 0.2f)
+                                RelayType.EPHEMERAL -> MaterialTheme.colorScheme.outline.copy(alpha = 0.15f)
+                                else -> Color.Transparent
+                            }
+                        ) {
+                            Text(
+                                text = if (relay.relayType == RelayType.DM) "DM" else "Ephemeral",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                            )
+                        }
+                    }
+                    if (relay.isBad) {
+                        Surface(
+                            onClick = onClearBad,
+                            shape = RoundedCornerShape(4.dp),
+                            color = MaterialTheme.colorScheme.error.copy(alpha = 0.15f)
+                        ) {
+                            Column(modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)) {
+                                Text(
+                                    "BAD — Tap to clear",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                                if (relay.badReason != null) {
+                                    Text(
+                                        relay.badReason,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Cooldown with reason
+                if (!relay.isBad && relay.cooldownRemaining > 0) {
+                    Spacer(Modifier.height(2.dp))
+                    Surface(
+                        shape = RoundedCornerShape(4.dp),
+                        color = Color(0xFFFFD54F).copy(alpha = 0.15f)
+                    ) {
+                        Column(modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)) {
+                            Text(
+                                "Cooldown ${relay.cooldownRemaining}s",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color(0xFFFFD54F)
+                            )
+                            if (relay.cooldownReason != null) {
+                                Text(
+                                    text = relay.cooldownReason,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(4.dp))
+
+                // Stats row
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (relay.stats != null) {
+                        Text(
+                            text = "${formatNumber(relay.stats.totalEventsReceived)} events",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        if (relay.stats.totalFailures > 0) {
+                            Text(
+                                text = "${relay.stats.totalFailures} failures",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color(0xFFFF5252)
+                            )
+                        }
+                        if (relay.stats.totalRateLimits > 0) {
+                            Text(
+                                text = "${relay.stats.totalRateLimits} rate limits",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color(0xFFFFD54F)
+                            )
+                        }
+                    }
+                }
+
+                // Session health
+                if (relay.sessionHistory.isNotEmpty()) {
+                    val okSessions = relay.sessionHistory.count { !it.hadMidSessionFailure }
+                    val total = relay.sessionHistory.size
+                    val healthColor = when {
+                        okSessions.toFloat() / total < 0.5f -> Color(0xFFFF5252)
+                        okSessions.toFloat() / total < 0.8f -> Color(0xFFFFD54F)
+                        else -> MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                    Text(
+                        text = "$okSessions/$total sessions OK",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = healthColor
+                    )
+                }
+
+                // Inbox authors — overlapping profile pictures
+                if (relay.inboxAuthorCount > 0) {
+                    Spacer(Modifier.height(6.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box {
+                            relay.inboxAuthors.forEachIndexed { index, author ->
+                                Box(
+                                    modifier = Modifier
+                                        .offset(x = (index * 16).dp)
+                                        .zIndex((relay.inboxAuthors.size - index).toFloat())
+                                ) {
+                                    ProfilePicture(url = author.picture, size = 22)
+                                }
+                            }
+                        }
+                        // Offset text past the stacked avatars
+                        Spacer(Modifier.width((relay.inboxAuthors.size * 16 + 8).dp))
+                        Text(
+                            text = if (relay.inboxAuthorCount > relay.inboxAuthors.size)
+                                "covers ${relay.inboxAuthorCount} (${relay.inboxAuthorCount - relay.inboxAuthors.size} more)"
+                            else
+                                "covers ${relay.inboxAuthorCount}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                // Operator row
+                if (relay.operatorName != null || relay.operatorPubkey != null) {
+                    Spacer(Modifier.height(4.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        ProfilePicture(url = relay.operatorPicture, size = 18)
+                        Text(
+                            text = "Op: ${relay.operatorName
+                                ?: relay.operatorPubkey?.take(12)?.plus("...")}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/RelayHealthViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/RelayHealthViewModel.kt
@@ -1,0 +1,229 @@
+package com.wisp.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wisp.app.relay.ConsoleLogEntry
+import com.wisp.app.relay.ConsoleLogType
+import com.wisp.app.relay.RelayHealthTracker
+import com.wisp.app.relay.RelayPool
+import com.wisp.app.relay.RelayScoreBoard
+import com.wisp.app.repo.EventRepository
+import com.wisp.app.repo.RelayInfoRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+enum class RelayType { PERSISTENT, DM, EPHEMERAL }
+enum class HealthSortMode { STATUS, FAILURES, EVENTS, NAME }
+enum class HealthFilter { ALL, BAD_ONLY, ERRORS_ONLY }
+
+data class AuthorSummary(
+    val pubkey: String,
+    val displayName: String?,
+    val picture: String?
+)
+
+data class RelayHealthSummary(
+    val url: String,
+    val isConnected: Boolean,
+    val isBad: Boolean,
+    val badReason: String?,
+    val cooldownRemaining: Int,
+    val cooldownReason: String?,
+    val stats: RelayHealthTracker.RelayStats?,
+    val recentErrors: Int,
+    val sessionHistory: List<RelayHealthTracker.SessionSummary>,
+    val activeSession: RelayHealthTracker.ActiveSessionInfo?,
+    val relayType: RelayType,
+    val iconUrl: String? = null,
+    val relayName: String? = null,
+    val operatorPubkey: String? = null,
+    val operatorName: String? = null,
+    val operatorPicture: String? = null,
+    val inboxAuthors: List<AuthorSummary> = emptyList(),
+    val inboxAuthorCount: Int = 0
+)
+
+data class RelayHealthState(
+    val relays: List<RelayHealthSummary> = emptyList(),
+    val sortMode: HealthSortMode = HealthSortMode.STATUS,
+    val filter: HealthFilter = HealthFilter.ALL,
+    val totalConnected: Int = 0,
+    val totalRelays: Int = 0,
+    val totalBad: Int = 0
+)
+
+class RelayHealthViewModel : ViewModel() {
+    private var relayPool: RelayPool? = null
+    private var healthTracker: RelayHealthTracker? = null
+    private var relayInfoRepo: RelayInfoRepository? = null
+    private var eventRepo: EventRepository? = null
+    private var scoreBoard: RelayScoreBoard? = null
+
+    private val _state = MutableStateFlow(RelayHealthState())
+    val state: StateFlow<RelayHealthState> = _state
+
+    fun init(
+        relayPool: RelayPool,
+        healthTracker: RelayHealthTracker,
+        relayInfoRepo: RelayInfoRepository,
+        eventRepo: EventRepository,
+        scoreBoard: RelayScoreBoard
+    ) {
+        if (this.relayPool != null) return
+        this.relayPool = relayPool
+        this.healthTracker = healthTracker
+        this.relayInfoRepo = relayInfoRepo
+        this.eventRepo = eventRepo
+        this.scoreBoard = scoreBoard
+
+        // Prefetch NIP-11 info for all relays so icons load
+        viewModelScope.launch(Dispatchers.IO) {
+            relayInfoRepo.prefetchAll(relayPool.getAllRelayUrls())
+        }
+
+        viewModelScope.launch {
+            while (true) {
+                refresh()
+                delay(2000)
+            }
+        }
+    }
+
+    fun setSortMode(mode: HealthSortMode) {
+        _state.value = _state.value.copy(sortMode = mode)
+        refresh()
+    }
+
+    fun setFilter(filter: HealthFilter) {
+        _state.value = _state.value.copy(filter = filter)
+        refresh()
+    }
+
+    fun clearBadRelay(url: String) {
+        healthTracker?.clearBadRelay(url)
+        refresh()
+    }
+
+    private fun refresh() {
+        val pool = relayPool ?: return
+        val tracker = healthTracker ?: return
+        val infoRepo = relayInfoRepo
+        val evRepo = eventRepo
+        val consoleLog = pool.consoleLog.value
+
+        val persistentUrls = pool.getRelayUrls().toSet()
+        val dmUrls = pool.getDmRelayUrls().toSet()
+        val ephemeralUrls = pool.getEphemeralRelayUrls().toSet()
+        val trackedUrls = tracker.getAllTrackedUrls()
+
+        val allUrls = persistentUrls + dmUrls + ephemeralUrls + trackedUrls
+
+        val errorCounts = countErrors(consoleLog)
+        val badRelays = tracker.getBadRelays()
+        val cooldownReasons = extractCooldownReasons(consoleLog)
+
+        // Build relay → authors map from scoreboard
+        val scoredRelays = scoreBoard?.getScoredRelays() ?: emptyList()
+        val relayAuthors = mutableMapOf<String, Set<String>>()
+        val relayAuthorCounts = mutableMapOf<String, Int>()
+        for (sr in scoredRelays) {
+            relayAuthors[sr.url] = sr.authors
+            relayAuthorCounts[sr.url] = sr.coverCount
+        }
+
+        val summaries = allUrls.map { url ->
+            val relayType = when {
+                url in persistentUrls -> RelayType.PERSISTENT
+                url in dmUrls -> RelayType.DM
+                else -> RelayType.EPHEMERAL
+            }
+            val info = infoRepo?.getInfo(url)
+            val operatorPubkey = info?.pubkey
+            val operatorProfile = if (operatorPubkey != null) evRepo?.getProfileData(operatorPubkey) else null
+
+            // Get top inbox authors (show up to 5 profile pictures)
+            val authors = relayAuthors[url] ?: emptySet()
+            val authorSummaries = authors.take(5).map { pubkey ->
+                val profile = evRepo?.getProfileData(pubkey)
+                AuthorSummary(
+                    pubkey = pubkey,
+                    displayName = profile?.displayString,
+                    picture = profile?.picture
+                )
+            }
+
+            RelayHealthSummary(
+                url = url,
+                isConnected = pool.isRelayConnected(url),
+                isBad = url in badRelays,
+                badReason = tracker.getBadRelayReason(url),
+                cooldownRemaining = pool.getRelayCooldownRemaining(url),
+                cooldownReason = cooldownReasons[url],
+                stats = tracker.getStats(url),
+                recentErrors = errorCounts[url] ?: 0,
+                sessionHistory = tracker.getSessionHistory(url),
+                activeSession = tracker.getActiveSession(url),
+                relayType = relayType,
+                iconUrl = infoRepo?.getIconUrl(url),
+                relayName = info?.name,
+                operatorPubkey = operatorPubkey,
+                operatorName = operatorProfile?.displayString,
+                operatorPicture = operatorProfile?.picture,
+                inboxAuthors = authorSummaries,
+                inboxAuthorCount = relayAuthorCounts[url] ?: 0
+            )
+        }
+
+        val currentState = _state.value
+        val filtered = when (currentState.filter) {
+            HealthFilter.ALL -> summaries
+            HealthFilter.BAD_ONLY -> summaries.filter { it.isBad }
+            HealthFilter.ERRORS_ONLY -> summaries.filter { it.recentErrors > 0 || (it.stats?.totalFailures ?: 0) > 0 }
+        }
+
+        val sorted = when (currentState.sortMode) {
+            HealthSortMode.STATUS -> filtered.sortedWith(
+                compareByDescending<RelayHealthSummary> { it.isBad }
+                    .thenByDescending { it.cooldownRemaining > 0 }
+                    .thenByDescending { !it.isConnected }
+                    .thenBy { it.url }
+            )
+            HealthSortMode.FAILURES -> filtered.sortedByDescending { it.stats?.totalFailures ?: 0 }
+            HealthSortMode.EVENTS -> filtered.sortedByDescending { it.stats?.totalEventsReceived ?: 0 }
+            HealthSortMode.NAME -> filtered.sortedBy { it.url }
+        }
+
+        _state.value = currentState.copy(
+            relays = sorted,
+            totalConnected = summaries.count { it.isConnected },
+            totalRelays = summaries.size,
+            totalBad = summaries.count { it.isBad }
+        )
+    }
+
+    private fun countErrors(log: List<ConsoleLogEntry>): Map<String, Int> {
+        val counts = mutableMapOf<String, Int>()
+        for (entry in log) {
+            if (entry.type == ConsoleLogType.CONN_FAILURE || entry.type == ConsoleLogType.OK_REJECTED) {
+                counts[entry.relayUrl] = (counts[entry.relayUrl] ?: 0) + 1
+            }
+        }
+        return counts
+    }
+
+    /** Extract the most recent failure/close message per relay as cooldown reason. */
+    private fun extractCooldownReasons(log: List<ConsoleLogEntry>): Map<String, String> {
+        val reasons = mutableMapOf<String, String>()
+        // Walk newest-first to get most recent reason per relay
+        for (entry in log.asReversed()) {
+            if (entry.relayUrl in reasons) continue
+            if (entry.type == ConsoleLogType.CONN_FAILURE || entry.type == ConsoleLogType.CONN_CLOSED) {
+                reasons[entry.relayUrl] = entry.message
+            }
+        }
+        return reasons
+    }
+}


### PR DESCRIPTION
## Summary
- New **Relay Health** screen accessible from Settings in the navigation drawer
- Shows all relays (persistent, DM, ephemeral) with real-time connection status, relay icons (via NIP-11 prefetch), and operator profiles
- Displays inbox author coverage from the scoreboard with overlapping profile pictures (matching the "covers N" data from the feed relay picker)
- Shows cooldown reasons (from console log failure entries) and bad relay reasons (zero-event sessions, disconnects, rate limits)
- Supports sorting by status/failures/events/name and filtering by all/bad-only/errors-only
- Tapping a relay navigates to the existing RelayDetailScreen for a deep dive

## Changes
- **New**: `RelayHealthScreen.kt` — health dashboard UI
- **New**: `RelayHealthViewModel.kt` — aggregates data from RelayPool, RelayHealthTracker, RelayScoreBoard, RelayInfoRepository, and EventRepository
- **Modified**: `RelayHealthTracker.kt` — exposed session history/active sessions, added bad relay reasons tracking
- **Modified**: `RelayPool.kt` — added `getEphemeralRelayUrls()` and `getAllRelayUrls()`
- **Modified**: `RelayDetailScreen.kt` — made format helpers `internal` for reuse
- **Modified**: `Navigation.kt`, `FeedScreen.kt`, `WispDrawerContent.kt` — wired up route and drawer item

## Test plan
- [ ] Drawer shows "Relay Health" item under Settings
- [ ] Screen loads with all relays listed with icons and connection status dots
- [ ] Relay icons load (not just fallback letters)
- [ ] Inbox author profile pictures appear for scored relays
- [ ] Bad relays show reason text (e.g. "8/10 sessions received 0 events")
- [ ] Cooldown relays show reason text from last failure
- [ ] Sorting and filtering chips work
- [ ] Tapping a relay navigates to RelayDetailScreen
- [ ] Stats update every ~2 seconds