### PR TITLE
fix: rename Wisp theme to Custom and hide accent picker for presets

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
@@ -14,6 +14,6 @@ class InterfacePreferences(context: Context) {
     fun isNewNotesButtonHidden(): Boolean = prefs.getBoolean("new_notes_button_hidden", false)
     fun setNewNotesButtonHidden(hidden: Boolean) = prefs.edit().putBoolean("new_notes_button_hidden", hidden).apply()
 
-    fun getTheme(): String = prefs.getString("theme", "wisp") ?: "wisp"
+    fun getTheme(): String = prefs.getString("theme", "custom") ?: "custom"
     fun setTheme(theme: String) = prefs.edit().putString("theme", theme).apply()
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -66,7 +66,7 @@ fun InterfaceScreen(
     var isLargeText by remember { mutableStateOf(interfacePrefs.isLargeText()) }
     var newNotesHidden by remember { mutableStateOf(interfacePrefs.isNewNotesButtonHidden()) }
     var selectedTheme by remember { mutableStateOf(interfacePrefs.getTheme()) }
-    var isCustomTheme by remember { mutableStateOf(selectedTheme == "wisp") }
+    var isCustomTheme by remember { mutableStateOf(selectedTheme == "custom") }
 
     val savedColor = remember { Color(interfacePrefs.getAccentColor()) }
     val initialHsv = remember {
@@ -179,7 +179,7 @@ fun InterfaceScreen(
                             isDark = true,
                             onClick = {
                                 selectedTheme = theme.name
-                                isCustomTheme = theme.name == "wisp"
+                                isCustomTheme = theme.name == "custom"
                                 interfacePrefs.setTheme(theme.name)
                                 onChanged()
                             }
@@ -190,62 +190,64 @@ fun InterfaceScreen(
 
             Spacer(Modifier.height(24.dp))
 
-            // Accent Color section
-            Text(
-                text = "Accent Color",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Spacer(Modifier.height(12.dp))
-
-            // Preview swatch
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(CircleShape)
-                        .background(currentColor)
-                )
-                Spacer(Modifier.padding(start = 12.dp))
+            if (isCustomTheme) {
+                // Accent Color section
                 Text(
-                    text = "Preview",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    text = "Accent Color",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
+                Spacer(Modifier.height(12.dp))
+
+                // Preview swatch
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(currentColor)
+                    )
+                    Spacer(Modifier.padding(start = 12.dp))
+                    Text(
+                        text = "Preview",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                // Saturation/Brightness square
+                SatBrightnessSquare(
+                    hue = hue,
+                    saturation = saturation,
+                    brightness = brightness,
+                    onChanged = { s, b ->
+                        saturation = s
+                        brightness = b
+                        interfacePrefs.setAccentColor(
+                            android.graphics.Color.HSVToColor(floatArrayOf(hue, s, b))
+                        )
+                        onChanged()
+                    }
+                )
+
+                Spacer(Modifier.height(12.dp))
+
+                // Hue slider
+                HueBar(
+                    hue = hue,
+                    onHueChanged = { h ->
+                        hue = h
+                        interfacePrefs.setAccentColor(
+                            android.graphics.Color.HSVToColor(floatArrayOf(h, saturation, brightness))
+                        )
+                        onChanged()
+                    }
+                )
+
+                Spacer(Modifier.height(24.dp))
             }
-
-            Spacer(Modifier.height(16.dp))
-
-            // Saturation/Brightness square
-            SatBrightnessSquare(
-                hue = hue,
-                saturation = saturation,
-                brightness = brightness,
-                onChanged = { s, b ->
-                    saturation = s
-                    brightness = b
-                    interfacePrefs.setAccentColor(
-                        android.graphics.Color.HSVToColor(floatArrayOf(hue, s, b))
-                    )
-                    onChanged()
-                }
-            )
-
-            Spacer(Modifier.height(12.dp))
-
-            // Hue slider
-            HueBar(
-                hue = hue,
-                onHueChanged = { h ->
-                    hue = h
-                    interfacePrefs.setAccentColor(
-                        android.graphics.Color.HSVToColor(floatArrayOf(h, saturation, brightness))
-                    )
-                    onChanged()
-                }
-            )
-
-            Spacer(Modifier.height(24.dp))
 
             // New Notes Button section
             Text(

--- a/app/src/main/kotlin/com/wisp/app/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/theme/Theme.kt
@@ -44,11 +44,11 @@ fun WispTheme(
     isDarkTheme: Boolean = true,
     accentColor: Color = Color(0xFFFF9800),
     isLargeText: Boolean = false,
-    themeName: String = "wisp",
+    themeName: String = "custom",
     content: @Composable () -> Unit
 ) {
     val themePreset = remember(themeName) { Themes.getTheme(themeName) }
-    val isCustomTheme = themeName == "wisp"
+    val isCustomTheme = themeName == "custom"
 
     val primary = if (isCustomTheme) accentColor else themePreset.dark.primary
     val secondary = remember(primary) { lightenColor(primary) }

--- a/app/src/main/kotlin/com/wisp/app/ui/theme/Themes.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/theme/Themes.kt
@@ -5,8 +5,8 @@ import androidx.compose.ui.graphics.Color
 object Themes {
     val themes = listOf(
         ThemePreset(
-            name = "wisp",
-            displayName = "Wisp",
+            name = "custom",
+            displayName = "Custom",
             dark = ThemeColors(
                 primary = Color(0xFFFF9800),
                 secondary = Color(0xFFFFB74D),


### PR DESCRIPTION
## Summary
- Rename the "Wisp" theme to "Custom" across Themes.kt, Theme.kt, InterfacePreferences.kt, and InterfaceScreen.kt
- Wrap the accent color picker section in `if (isCustomTheme)` so it only appears when the Custom theme is selected
- Preset themes (Nord, Dracula, etc.) no longer show the irrelevant color picker

## Test plan
- [ ] Settings → Interface → verify "Custom" label on theme card
- [ ] Select a preset theme (e.g. Nord) → accent color section disappears
- [ ] Select "Custom" → accent color section reappears with correct color
- [ ] Changing accent color still updates the theme live