### PR TITLE
fix: crash on app resume from stale WebSocket reader

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -250,14 +250,11 @@ class Relay(
             webSocket = null
             pendingReconnect?.cancel(false)
             pendingReconnect = null
-            if (ws != null) {
-                if (wasConnected) {
-                    ws.close(1000, "Bye")
-                } else {
-                    // Force-close sockets stuck mid-handshake — close() can hang on unresponsive relays
-                    ws.cancel()
-                }
-            }
+            // Always cancel() for immediate TCP teardown. Graceful close(1000) leaves
+            // OkHttp's reader thread alive waiting for the server's close frame — if we
+            // reconnect immediately (e.g. forceReconnectAll), the stale reader can crash
+            // with ArrayIndexOutOfBoundsException in Okio's buffer (size=0, byteCount=8192).
+            ws?.cancel()
         }
     }
 


### PR DESCRIPTION
## Summary
- Use `ws.cancel()` instead of `ws.close(1000, "Bye")` in `Relay.disconnect()` to prevent `ArrayIndexOutOfBoundsException` on app resume
- Graceful close left OkHttp's reader thread alive waiting for the server's close frame — when `reconnectAll()`/`forceReconnectAll()` called `disconnect()` then immediately `connect()`, the stale reader thread would crash in Okio's buffer (`size=0, offset=0, byteCount=8192`)
- Safe because `onFailure` already checks `isCurrent` and drops stale socket callbacks

## Test plan
- [ ] Minimize the app, wait 30+ seconds, reopen — no crash
- [ ] Minimize briefly (<30s) and reopen — no crash
- [ ] Switch networks (wifi ↔ mobile) while app is backgrounded — reconnects cleanly