### PR TITLE
Fix wallet transaction showing null for zap messages

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -1059,7 +1059,8 @@ private fun TransactionRow(tx: Nip47.Transaction) {
         // Description + time
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                tx.description?.takeIf { it.isNotBlank() } ?: if (isIncoming) "Received" else "Sent",
+                tx.description?.takeIf { it.isNotBlank() && it != "null" }
+                    ?: if (isIncoming) "⚡ Zap!" else "Sent",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,


### PR DESCRIPTION
## Summary
- Show "⚡ Zap!" instead of "null" for incoming wallet transactions with no description
- Also handles literal "null" string from NWC responses

## Test plan
- [ ] Connect NWC wallet and view transaction history
- [ ] Verify incoming zaps without a message show "⚡ Zap!" instead of "null"
- [ ] Verify transactions with actual descriptions still display correctly