### PR TITLE
feat: add npub read-only login

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -182,6 +182,7 @@ fun WispNavHost(
             SigningMode.LOCAL -> {
                 authViewModel.keyRepo.getKeypair()?.let { LocalSigner(it.privkey, it.pubkey) }
             }
+            SigningMode.READ_ONLY -> null
             null -> null
         }
     }
@@ -457,6 +458,14 @@ fun WispNavHost(
                 onAuthenticated = { isNewAccount ->
                     if (isNewAccount) {
                         navController.navigate(Routes.ONBOARDING_PROFILE) {
+                            popUpTo(Routes.AUTH) { inclusive = true }
+                        }
+                    } else if (authViewModel.keyRepo.isReadOnly()) {
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        feedViewModel.initRelays()
+                        authViewModel.keyRepo.markOnboardingComplete()
+                        navController.navigate(Routes.LOADING) {
                             popUpTo(Routes.AUTH) { inclusive = true }
                         }
                     } else {

--- a/app/src/main/kotlin/com/wisp/app/repo/KeyRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/KeyRepository.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.encodeToString
 
-enum class SigningMode { LOCAL, REMOTE }
+enum class SigningMode { LOCAL, REMOTE, READ_ONLY }
 
 class KeyRepository(private val context: Context) {
     private val masterKey = MasterKey.Builder(context)
@@ -87,10 +87,21 @@ class KeyRepository(private val context: Context) {
             .apply()
     }
 
-    fun getSigningMode(): SigningMode {
-        val mode = encPrefs.getString("signing_mode", null)
-        return if (mode == SigningMode.REMOTE.name) SigningMode.REMOTE else SigningMode.LOCAL
+    fun savePubkeyReadOnly(pubkeyHex: String) {
+        encPrefs.edit()
+            .putString("pubkey", pubkeyHex)
+            .putString("signing_mode", SigningMode.READ_ONLY.name)
+            .remove("privkey")
+            .remove("signer_package")
+            .apply()
     }
+
+    fun getSigningMode(): SigningMode {
+        val mode = encPrefs.getString("signing_mode", null) ?: return SigningMode.LOCAL
+        return try { SigningMode.valueOf(mode) } catch (_: Exception) { SigningMode.LOCAL }
+    }
+
+    fun isReadOnly(): Boolean = getSigningMode() == SigningMode.READ_ONLY
 
     fun getSignerPackage(): String? = encPrefs.getString("signer_package", null)
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/AuthScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/AuthScreen.kt
@@ -187,7 +187,7 @@ fun AuthScreen(
         OutlinedTextField(
             value = nsecInput,
             onValueChange = { viewModel.updateNsecInput(it) },
-            label = { Text("nsec...") },
+            label = { Text("nsec or npub...") },
             singleLine = true,
             visualTransformation = if (nsecVisible) VisualTransformation.None else PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/AuthViewModel.kt
@@ -44,11 +44,23 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun logIn(): Boolean {
-        val nsec = _nsecInput.value.trim()
-        if (nsec.isBlank()) {
-            _error.value = "Please enter your nsec key"
+        val input = _nsecInput.value.trim()
+        if (input.isBlank()) {
+            _error.value = "Please enter your key"
             return false
         }
+        return when {
+            input.startsWith("nsec1") -> loginWithNsec(input)
+            input.startsWith("npub1") -> loginWithNpub(input)
+            input.length == 64 && input.all { it in '0'..'9' || it in 'a'..'f' } -> loginWithPubkeyHex(input)
+            else -> {
+                _error.value = "Invalid key format — enter an nsec or npub"
+                false
+            }
+        }
+    }
+
+    private fun loginWithNsec(nsec: String): Boolean {
         return try {
             val privkey = Nip19.nsecDecode(nsec)
             val keypair = Keys.fromPrivkey(privkey)
@@ -60,6 +72,36 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
             true
         } catch (e: Exception) {
             _error.value = "Invalid nsec key: ${e.message}"
+            false
+        }
+    }
+
+    private fun loginWithNpub(npub: String): Boolean {
+        return try {
+            val pubkey = Nip19.npubDecode(npub)
+            val pubkeyHex = pubkey.toHex()
+            keyRepo.savePubkeyReadOnly(pubkeyHex)
+            keyRepo.reloadPrefs(pubkeyHex)
+            _npub.value = Nip19.npubEncode(pubkey)
+            _nsecInput.value = ""
+            _error.value = null
+            true
+        } catch (e: Exception) {
+            _error.value = "Invalid npub: ${e.message}"
+            false
+        }
+    }
+
+    private fun loginWithPubkeyHex(hex: String): Boolean {
+        return try {
+            keyRepo.savePubkeyReadOnly(hex)
+            keyRepo.reloadPrefs(hex)
+            _npub.value = Nip19.npubEncode(hex.hexToByteArray())
+            _nsecInput.value = ""
+            _error.value = null
+            true
+        } catch (e: Exception) {
+            _error.value = "Invalid pubkey: ${e.message}"
             false
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -153,6 +153,11 @@ class StartupCoordinator(
     fun reloadForNewAccount() {
         val newPubkey = getUserPubkey()
 
+        // Clear stale data from previous account
+        notifRepo.clear()
+        eventRepo.clearAll()
+        dmRepo.clear()
+
         // Reload per-account prefs for new pubkey
         eventRepo.currentUserPubkey = newPubkey
         keyRepo.reloadPrefs(newPubkey)


### PR DESCRIPTION
## Summary
- Allow login with npub or 64-char hex pubkey for read-only browsing — signer is null so all write actions silently no-op
- Add `READ_ONLY` signing mode to `KeyRepository` with `savePubkeyReadOnly()` and `isReadOnly()`
- Refactor `AuthViewModel.logIn()` to detect input type (nsec/npub/hex) and route accordingly
- Read-only login skips existing-user onboarding and goes straight to loading screen
- Fix pre-existing bug: clear stale notifications, events, and DMs in `reloadForNewAccount()` so account switches don't show old data

## Test plan
- [ ] Login with an npub → skips onboarding → lands on feed with that user's content
- [ ] Login with 64-char hex pubkey → same behavior
- [ ] Tap reply/react/repost/compose → nothing happens (silent no-op)
- [ ] Navigate to profiles, notifications, relays → all viewable
- [ ] DMs tab → conversations empty (can't decrypt)
- [ ] Keys screen → shows npub only
- [ ] Logout → back to auth screen
- [ ] Login with nsec → full functionality still works
- [ ] Login with remote signer → still works
- [ ] Logout of one account, login to another → notifications show new account's data