### PR TITLE
feat: NIP-23 long-form article reader with engagement

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -185,6 +185,7 @@ fun WispNavHost(
             SigningMode.LOCAL -> {
                 authViewModel.keyRepo.getKeypair()?.let { LocalSigner(it.privkey, it.pubkey) }
             }
+            SigningMode.READ_ONLY -> null
             null -> null
         }
     }
@@ -460,6 +461,14 @@ fun WispNavHost(
                 onAuthenticated = { isNewAccount ->
                     if (isNewAccount) {
                         navController.navigate(Routes.ONBOARDING_PROFILE) {
+                            popUpTo(Routes.AUTH) { inclusive = true }
+                        }
+                    } else if (authViewModel.keyRepo.isReadOnly()) {
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        feedViewModel.initRelays()
+                        authViewModel.keyRepo.markOnboardingComplete()
+                        navController.navigate(Routes.LOADING) {
                             popUpTo(Routes.AUTH) { inclusive = true }
                         }
                     } else {
@@ -817,7 +826,10 @@ fun WispNavHost(
                 onAddNoteToList = { eventId -> addToListEventId = eventId },
                 onSendDm = if (!isOwnProfile) {{ navController.navigate("dm/$pubkey") }} else null,
                 signer = activeSigner,
-                translationRepo = feedViewModel.translationRepo
+                translationRepo = feedViewModel.translationRepo,
+                onArticleClick = { kind, articleAuthor, articleDTag ->
+                    navController.navigate("article/$kind/$articleAuthor/${java.net.URLEncoder.encode(articleDTag, "UTF-8")}")
+                }
             )
         }
 
@@ -1135,7 +1147,91 @@ fun WispNavHost(
             val articleViewModel: ArticleViewModel = viewModel()
             LaunchedEffect(kind, author, dTag) {
                 articleViewModel.loadArticle(kind, author, dTag, feedViewModel.eventRepo)
+                val articleEvent = feedViewModel.eventRepo.findAddressableEvent(kind, author, dTag)
+                articleViewModel.loadComments(
+                    author = author,
+                    dTag = dTag,
+                    articleEventId = articleEvent?.id,
+                    eventRepo = feedViewModel.eventRepo,
+                    relayPool = feedViewModel.relayPool,
+                    outboxRouter = feedViewModel.outboxRouter,
+                    subManager = feedViewModel.subManager,
+                    metadataFetcher = feedViewModel.metadataFetcher,
+                    topRelayUrls = feedViewModel.getScoredRelays().take(5).map { it.url },
+                    relayListRepo = feedViewModel.relayListRepo,
+                    relayHintStore = feedViewModel.relayHintStore
+                )
             }
+            var articleZapTarget by remember { mutableStateOf<com.wisp.app.nostr.NostrEvent?>(null) }
+            val articleZapInProgress by feedViewModel.zapInProgress.collectAsState()
+            var articleZapAnimatingIds by remember { mutableStateOf(emptySet<String>()) }
+            val isNwcConnected = feedViewModel.nwcRepo.hasConnection()
+            val articleSetListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
+            val articleBookmarkedIds by feedViewModel.bookmarkRepo.bookmarkedIds.collectAsState()
+            val articleListedIds = remember(articleSetListedIds, articleBookmarkedIds) { articleSetListedIds + articleBookmarkedIds }
+            val articlePinnedIds by feedViewModel.pinRepo.pinnedIds.collectAsState()
+            val articleResolvedEmojis by feedViewModel.customEmojiRepo.resolvedEmojis.collectAsState()
+            val articleUnicodeEmojis by feedViewModel.customEmojiRepo.unicodeEmojis.collectAsState()
+            var showArticleEmojiLibrary by remember { mutableStateOf(false) }
+
+            LaunchedEffect(Unit) {
+                feedViewModel.zapSuccess.collect { eventId ->
+                    articleZapAnimatingIds = articleZapAnimatingIds + eventId
+                    kotlinx.coroutines.delay(1500)
+                    articleZapAnimatingIds = articleZapAnimatingIds - eventId
+                }
+            }
+
+            if (articleZapTarget != null) {
+                val zapRecipient = articleZapTarget!!.pubkey
+                ZapDialog(
+                    isWalletConnected = isNwcConnected,
+                    onDismiss = { articleZapTarget = null },
+                    onZap = { amountMsats, message, isAnonymous, isPrivate ->
+                        val event = articleZapTarget ?: return@ZapDialog
+                        articleZapTarget = null
+                        feedViewModel.sendZap(event, amountMsats, message, isAnonymous, isPrivate)
+                    },
+                    onGoToWallet = { navController.navigate(Routes.WALLET) },
+                    canPrivateZap = feedViewModel.relayPool.hasDmRelays() && feedViewModel.relayListRepo.hasDmRelays(zapRecipient)
+                )
+            }
+
+            val articleNoteActions = remember {
+                com.wisp.app.ui.component.NoteActions(
+                    onReply = { event ->
+                        replyTarget = event
+                        quoteTarget = null
+                        composeViewModel.clear()
+                        navController.navigate(Routes.COMPOSE)
+                    },
+                    onReact = { event, emoji -> feedViewModel.toggleReaction(event, emoji) },
+                    onRepost = { event -> feedViewModel.sendRepost(event) },
+                    onQuote = { event ->
+                        quoteTarget = event
+                        replyTarget = null
+                        composeViewModel.clear()
+                        navController.navigate(Routes.COMPOSE)
+                    },
+                    onZap = { event -> articleZapTarget = event },
+                    onProfileClick = { pubkey -> navController.navigate("profile/$pubkey") },
+                    onNoteClick = { eventId -> navController.navigate("thread/$eventId") },
+                    onAddToList = { eventId -> addToListEventId = eventId },
+                    onFollowAuthor = { pubkey -> feedViewModel.toggleFollow(pubkey) },
+                    onBlockAuthor = { pubkey -> feedViewModel.blockUser(pubkey) },
+                    onPin = { eventId -> feedViewModel.togglePin(eventId) },
+                    isFollowing = { pubkey -> feedViewModel.contactRepo.isFollowing(pubkey) },
+                    userPubkey = feedViewModel.getUserPubkey(),
+                    nip05Repo = feedViewModel.nip05Repo,
+                    onHashtagClick = { tag ->
+                        navController.navigate("hashtag/${java.net.URLEncoder.encode(tag, "UTF-8")}")
+                    },
+                    onArticleClick = { k, a, d ->
+                        navController.navigate("article/$k/$a/${java.net.URLEncoder.encode(d, "UTF-8")}")
+                    }
+                )
+            }
+
             ArticleScreen(
                 viewModel = articleViewModel,
                 eventRepo = feedViewModel.eventRepo,
@@ -1143,8 +1239,43 @@ fun WispNavHost(
                 onProfileClick = { pubkey -> navController.navigate("profile/$pubkey") },
                 onHashtagClick = { tag ->
                     navController.navigate("hashtag/${java.net.URLEncoder.encode(tag, "UTF-8")}")
-                }
+                },
+                onReply = { event ->
+                    replyTarget = event
+                    quoteTarget = null
+                    composeViewModel.clear()
+                    navController.navigate(Routes.COMPOSE)
+                },
+                onReact = { event, emoji -> feedViewModel.toggleReaction(event, emoji) },
+                onRepost = { event -> feedViewModel.sendRepost(event) },
+                onQuote = { event ->
+                    quoteTarget = event
+                    replyTarget = null
+                    composeViewModel.clear()
+                    navController.navigate(Routes.COMPOSE)
+                },
+                onZap = { event -> articleZapTarget = event },
+                onAddToList = { eventId -> addToListEventId = eventId },
+                noteActions = articleNoteActions,
+                zapAnimatingIds = articleZapAnimatingIds,
+                zapInProgressIds = articleZapInProgress,
+                listedIds = articleListedIds,
+                pinnedIds = articlePinnedIds,
+                userPubkey = feedViewModel.getUserPubkey(),
+                resolvedEmojis = articleResolvedEmojis,
+                unicodeEmojis = articleUnicodeEmojis,
+                onOpenEmojiLibrary = { showArticleEmojiLibrary = true }
             )
+
+            if (showArticleEmojiLibrary) {
+                com.wisp.app.ui.component.EmojiLibrarySheet(
+                    currentEmojis = articleUnicodeEmojis,
+                    onAddEmojis = { emojis ->
+                        emojis.forEach { feedViewModel.customEmojiRepo.addUnicodeEmoji(it) }
+                    },
+                    onDismiss = { showArticleEmojiLibrary = false }
+                )
+            }
         }
 
         composable(Routes.SAFETY) {

--- a/app/src/main/kotlin/com/wisp/app/nostr/Filter.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Filter.kt
@@ -14,6 +14,7 @@ data class Filter(
     val dTags: List<String>? = null,
     val tTags: List<String>? = null,
     val qTags: List<String>? = null,
+    val aTags: List<String>? = null,
     val since: Long? = null,
     val until: Long? = null,
     val limit: Int? = null,
@@ -28,6 +29,7 @@ data class Filter(
         dTags?.let { put("#d", buildJsonArray { it.forEach { d -> add(JsonPrimitive(d)) } }) }
         tTags?.let { put("#t", buildJsonArray { it.forEach { t -> add(JsonPrimitive(t)) } }) }
         qTags?.let { put("#q", buildJsonArray { it.forEach { q -> add(JsonPrimitive(q)) } }) }
+        aTags?.let { put("#a", buildJsonArray { it.forEach { a -> add(JsonPrimitive(a)) } }) }
         since?.let { put("since", JsonPrimitive(it)) }
         until?.let { put("until", JsonPrimitive(it)) }
         limit?.let { put("limit", JsonPrimitive(it)) }

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -195,7 +195,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         if (!seenEventIds.add(event.id)) return  // atomic dedup across all relay threads
         if (event.created_at > System.currentTimeMillis() / 1000 + 30) return  // reject future-dated notes (30s grace for clock skew)
         if (muteRepo?.isBlocked(event.pubkey) == true) return
-        if (event.kind == 1 && muteRepo?.containsMutedWord(event.content) == true) return
+        if ((event.kind == 1 || event.kind == 30023) && muteRepo?.containsMutedWord(event.content) == true) return
         if (deletedEventsRepo?.isDeleted(event.id) == true) return
         // Engagement events (reactions, reposts) are only needed for their
         // side effects (counts, details, etc.) — skip eventCache to avoid evicting the
@@ -219,6 +219,9 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                 // Only show root notes in feed, not replies
                 val isReply = event.tags.any { it.size >= 2 && it[0] == "e" }
                 if (!isReply) binaryInsert(event, fromFeed = true)
+            }
+            30023 -> {
+                binaryInsert(event, fromFeed = true)
             }
             6 -> {
                 // Repost: parse embedded event from content and insert it into the feed
@@ -273,7 +276,9 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             }
             7 -> addReaction(event)
             9735 -> {
-                val targetId = Nip57.getZappedEventId(event) ?: return
+                val targetId = Nip57.getZappedEventId(event)
+                    ?: resolveAddressableTarget(event)
+                    ?: return
                 // Per-target dedup — atomic get-or-create under lock to prevent
                 // concurrent threads from creating separate sets for the same target
                 val dedupSet = synchronized(countedZapIds) {
@@ -310,7 +315,9 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     }
 
     private fun addReaction(event: NostrEvent) {
-        val targetEventId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1) ?: return
+        val targetEventId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
+            ?: resolveAddressableTarget(event)
+            ?: return
         // Per-target dedup — evicts alongside the count cache so re-fetched data can be re-counted
         val dedupSet = countedReactionIds.get(targetEventId)
             ?: mutableSetOf<String>().also { countedReactionIds.put(targetEventId, it) }
@@ -349,6 +356,21 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         }
         reactionDirty = true
         markVersionDirty()
+    }
+
+    /**
+     * Resolve an engagement event's target when it only has an a-tag (addressable
+     * coordinate like "30023:<pubkey>:<dtag>") and no e-tag. Looks up the cached
+     * addressable event to return its event ID, so engagement counts are keyed correctly.
+     */
+    private fun resolveAddressableTarget(event: NostrEvent): String? {
+        val aTag = event.tags.lastOrNull { it.size >= 2 && it[0] == "a" }?.get(1) ?: return null
+        val parts = aTag.split(":", limit = 3)
+        if (parts.size < 3) return null
+        val kind = parts[0].toIntOrNull() ?: return null
+        val author = parts[1]
+        val dTag = parts[2]
+        return findAddressableEvent(kind, author, dTag)?.id
     }
 
     private fun effectiveSortTime(event: NostrEvent): Long =
@@ -779,6 +801,11 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                     relayHintStore?.extractHintsFromTags(event)
                     relayFeedBinaryInsert(event)
                 }
+            }
+            30023 -> {
+                eventCache.put(event.id, event)
+                relayHintStore?.extractHintsFromTags(event)
+                relayFeedBinaryInsert(event)
             }
             6 -> {
                 if (event.content.isNotBlank()) {

--- a/app/src/main/kotlin/com/wisp/app/repo/KeyRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/KeyRepository.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.encodeToString
 
-enum class SigningMode { LOCAL, REMOTE }
+enum class SigningMode { LOCAL, REMOTE, READ_ONLY }
 
 class KeyRepository(private val context: Context) {
     private val masterKey = MasterKey.Builder(context)
@@ -87,10 +87,21 @@ class KeyRepository(private val context: Context) {
             .apply()
     }
 
-    fun getSigningMode(): SigningMode {
-        val mode = encPrefs.getString("signing_mode", null)
-        return if (mode == SigningMode.REMOTE.name) SigningMode.REMOTE else SigningMode.LOCAL
+    fun savePubkeyReadOnly(pubkeyHex: String) {
+        encPrefs.edit()
+            .putString("pubkey", pubkeyHex)
+            .putString("signing_mode", SigningMode.READ_ONLY.name)
+            .remove("privkey")
+            .remove("signer_package")
+            .apply()
     }
+
+    fun getSigningMode(): SigningMode {
+        val mode = encPrefs.getString("signing_mode", null) ?: return SigningMode.LOCAL
+        return try { SigningMode.valueOf(mode) } catch (_: Exception) { SigningMode.LOCAL }
+    }
+
+    fun isReadOnly(): Boolean = getSigningMode() == SigningMode.READ_ONLY
 
     fun getSignerPackage(): String? = encPrefs.getString("signer_package", null)
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ArticleScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ArticleScreen.kt
@@ -52,7 +52,12 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.ui.component.ProfilePicture
+import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.ui.component.ActionBar
+import com.wisp.app.ui.component.NoteActions
+import com.wisp.app.ui.component.PostCard
 import com.wisp.app.viewmodel.ArticleViewModel
+import kotlin.math.min
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -61,7 +66,22 @@ fun ArticleScreen(
     eventRepo: EventRepository,
     onBack: () -> Unit,
     onProfileClick: (String) -> Unit = {},
-    onHashtagClick: ((String) -> Unit)? = null
+    onHashtagClick: ((String) -> Unit)? = null,
+    onReply: (NostrEvent) -> Unit = {},
+    onReact: (NostrEvent, String) -> Unit = { _, _ -> },
+    onRepost: (NostrEvent) -> Unit = {},
+    onQuote: (NostrEvent) -> Unit = {},
+    onZap: (NostrEvent) -> Unit = {},
+    onAddToList: (String) -> Unit = {},
+    noteActions: NoteActions? = null,
+    zapAnimatingIds: Set<String> = emptySet(),
+    zapInProgressIds: Set<String> = emptySet(),
+    listedIds: Set<String> = emptySet(),
+    pinnedIds: Set<String> = emptySet(),
+    userPubkey: String? = null,
+    resolvedEmojis: Map<String, String> = emptyMap(),
+    unicodeEmojis: List<String> = emptyList(),
+    onOpenEmojiLibrary: (() -> Unit)? = null
 ) {
     val article by viewModel.article.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
@@ -69,9 +89,17 @@ fun ArticleScreen(
     val coverImage by viewModel.coverImage.collectAsState()
     val publishedAt by viewModel.publishedAt.collectAsState()
     val hashtags by viewModel.hashtags.collectAsState()
+    val comments by viewModel.comments.collectAsState()
+    val isCommentsLoading by viewModel.isCommentsLoading.collectAsState()
+
+    val reactionVersion by eventRepo.reactionVersion.collectAsState()
+    val replyCountVersion by eventRepo.replyCountVersion.collectAsState()
+    val zapVersion by eventRepo.zapVersion.collectAsState()
+    val repostVersion by eventRepo.repostVersion.collectAsState()
+    val profileVersion by eventRepo.profileVersion.collectAsState()
 
     val authorPubkey = article?.pubkey
-    val profile = remember(authorPubkey) { authorPubkey?.let { eventRepo.getProfileData(it) } }
+    val profile = remember(authorPubkey, profileVersion) { authorPubkey?.let { eventRepo.getProfileData(it) } }
 
     val blocks = remember(article) {
         article?.content?.let { parseMarkdownBlocks(it) } ?: emptyList()
@@ -205,6 +233,132 @@ fun ArticleScreen(
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
                             )
                         }
+                    }
+
+                    // Article action bar
+                    if (article != null) {
+                        item(key = "action-bar") {
+                            val articleEvent = article!!
+                            val likeCount = remember(reactionVersion, articleEvent.id) { eventRepo.getReactionCount(articleEvent.id) }
+                            // Use comment list size for consistency with the comments section below
+                            val replyCount = comments.size
+                            val zapSats = remember(zapVersion, articleEvent.id) { eventRepo.getZapSats(articleEvent.id) }
+                            val userEmojis = remember(reactionVersion, articleEvent.id, userPubkey) {
+                                userPubkey?.let { eventRepo.getUserReactionEmojis(articleEvent.id, it) } ?: emptySet()
+                            }
+                            val repostCount = remember(repostVersion, articleEvent.id) { eventRepo.getRepostCount(articleEvent.id) }
+                            val hasUserReposted = remember(repostVersion, articleEvent.id) { eventRepo.hasUserReposted(articleEvent.id) }
+                            val hasUserZapped = remember(zapVersion, articleEvent.id) { eventRepo.hasUserZapped(articleEvent.id) }
+                            val eventReactionEmojiUrls = remember(reactionVersion, articleEvent.id) { eventRepo.getReactionEmojiUrls(articleEvent.id) }
+
+                            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                            ActionBar(
+                                onReply = { onReply(articleEvent) },
+                                onReact = { emoji -> onReact(articleEvent, emoji) },
+                                userReactionEmojis = userEmojis,
+                                onRepost = { onRepost(articleEvent) },
+                                onQuote = { onQuote(articleEvent) },
+                                hasUserReposted = hasUserReposted,
+                                onZap = { onZap(articleEvent) },
+                                hasUserZapped = hasUserZapped,
+                                onAddToList = { onAddToList(articleEvent.id) },
+                                isInList = articleEvent.id in listedIds,
+                                likeCount = likeCount,
+                                repostCount = repostCount,
+                                replyCount = replyCount,
+                                zapSats = zapSats,
+                                isZapAnimating = articleEvent.id in zapAnimatingIds,
+                                isZapInProgress = articleEvent.id in zapInProgressIds,
+                                reactionEmojiUrls = eventReactionEmojiUrls,
+                                resolvedEmojis = resolvedEmojis,
+                                unicodeEmojis = unicodeEmojis,
+                                onOpenEmojiLibrary = onOpenEmojiLibrary,
+                                modifier = Modifier.padding(horizontal = 8.dp)
+                            )
+                        }
+                    }
+
+                    // Comments header
+                    item(key = "comments-header") {
+                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        ) {
+                            Text(
+                                text = "Comments",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            if (comments.isNotEmpty()) {
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    text = "(${comments.size})",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                        if (isCommentsLoading && comments.isEmpty()) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 16.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator(
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(8.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    // Comment items
+                    items(comments.size, key = { "comment-${comments[it].first.id}" }) { index ->
+                        val (event, depth) = comments[index]
+                        val commentProfile = remember(profileVersion, event.pubkey) { eventRepo.getProfileData(event.pubkey) }
+                        val commentLikeCount = remember(reactionVersion, event.id) { eventRepo.getReactionCount(event.id) }
+                        val commentReplyCount = remember(replyCountVersion, event.id) { eventRepo.getReplyCount(event.id) }
+                        val commentZapSats = remember(zapVersion, event.id) { eventRepo.getZapSats(event.id) }
+                        val commentUserEmojis = remember(reactionVersion, event.id, userPubkey) {
+                            userPubkey?.let { eventRepo.getUserReactionEmojis(event.id, it) } ?: emptySet()
+                        }
+                        val commentRepostCount = remember(repostVersion, event.id) { eventRepo.getRepostCount(event.id) }
+                        val commentHasUserReposted = remember(repostVersion, event.id) { eventRepo.hasUserReposted(event.id) }
+                        val commentHasUserZapped = remember(zapVersion, event.id) { eventRepo.hasUserZapped(event.id) }
+                        val commentReactionEmojiUrls = remember(reactionVersion, event.id) { eventRepo.getReactionEmojiUrls(event.id) }
+                        PostCard(
+                            event = event,
+                            profile = commentProfile,
+                            onReply = { onReply(event) },
+                            onProfileClick = { onProfileClick(event.pubkey) },
+                            onNavigateToProfile = onProfileClick,
+                            onNoteClick = {},
+                            onReact = { emoji -> onReact(event, emoji) },
+                            userReactionEmojis = commentUserEmojis,
+                            onRepost = { onRepost(event) },
+                            onQuote = { onQuote(event) },
+                            hasUserReposted = commentHasUserReposted,
+                            repostCount = commentRepostCount,
+                            onZap = { onZap(event) },
+                            hasUserZapped = commentHasUserZapped,
+                            likeCount = commentLikeCount,
+                            replyCount = commentReplyCount,
+                            zapSats = commentZapSats,
+                            isZapAnimating = event.id in zapAnimatingIds,
+                            isZapInProgress = event.id in zapInProgressIds,
+                            eventRepo = eventRepo,
+                            reactionEmojiUrls = commentReactionEmojiUrls,
+                            resolvedEmojis = resolvedEmojis,
+                            unicodeEmojis = unicodeEmojis,
+                            onOpenEmojiLibrary = onOpenEmojiLibrary,
+                            isOwnEvent = event.pubkey == userPubkey,
+                            onAddToList = { onAddToList(event.id) },
+                            isInList = event.id in listedIds,
+                            noteActions = noteActions,
+                            modifier = Modifier.padding(start = (min(depth, 4) * 24).dp)
+                        )
                     }
 
                     item(key = "footer") { Spacer(Modifier.height(32.dp)) }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/AuthScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/AuthScreen.kt
@@ -187,7 +187,7 @@ fun AuthScreen(
         OutlinedTextField(
             value = nsecInput,
             onValueChange = { viewModel.updateNsecInput(it) },
-            label = { Text("nsec...") },
+            label = { Text("nsec or npub...") },
             singleLine = true,
             visualTransformation = if (nsecVisible) VisualTransformation.None else PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -85,6 +86,7 @@ import com.wisp.app.viewmodel.InitLoadingState
 import com.wisp.app.viewmodel.PowStatus
 import com.wisp.app.viewmodel.RelayFeedStatus
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.ui.draw.clip
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -718,7 +720,31 @@ fun FeedScreen(
                             state = listState,
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            items(items = feed, key = { it.id }, contentType = { "post" }) { event ->
+                            items(items = feed, key = { it.id }, contentType = { if (it.kind == 30023) "article" else "post" }) { event ->
+                                if (event.kind == 30023) {
+                                    FeedArticleItem(
+                                        event = event,
+                                        viewModel = viewModel,
+                                        userPubkey = userPubkey,
+                                        profileVersion = profileVersion,
+                                        reactionVersion = reactionVersion,
+                                        replyCountVersion = replyCountVersion,
+                                        zapVersion = zapVersion,
+                                        repostVersion = repostVersion,
+                                        isZapAnimating = event.id in zapAnimatingIds,
+                                        isZapInProgress = event.id in zapInProgress,
+                                        isInList = event.id in listedIds,
+                                        onArticleClick = onArticleClick,
+                                        onProfileClick = onProfileClick,
+                                        onReply = { onReply(event) },
+                                        onReact = { emoji -> onReact(event, emoji) },
+                                        onRepost = { onRepost(event) },
+                                        onQuote = { onQuote(event) },
+                                        onZap = { zapTargetEvent = event },
+                                        onAddToList = { onAddToList(event.id) },
+                                        onOpenEmojiLibrary = { showEmojiLibrary = true }
+                                    )
+                                } else {
                                 FeedItem(
                                     event = event,
                                     viewModel = viewModel,
@@ -755,6 +781,7 @@ fun FeedScreen(
                                     onOpenEmojiLibrary = { showEmojiLibrary = true },
                                     translationVersion = translationVersion
                                 )
+                                }
                             }
                             if (initialLoadDone) {
                                 item(key = "load-more", contentType = "loader") {
@@ -944,6 +971,170 @@ private fun FeedItem(
         translationState = translationState,
         onTranslate = { viewModel.translateEvent(event.id, event.content) }
     )
+}
+
+@Composable
+private fun FeedArticleItem(
+    event: NostrEvent,
+    viewModel: FeedViewModel,
+    userPubkey: String?,
+    profileVersion: Int,
+    reactionVersion: Int,
+    replyCountVersion: Int,
+    zapVersion: Int,
+    repostVersion: Int,
+    isZapAnimating: Boolean,
+    isZapInProgress: Boolean = false,
+    isInList: Boolean = false,
+    onArticleClick: ((Int, String, String) -> Unit)?,
+    onProfileClick: (String) -> Unit,
+    onReply: () -> Unit,
+    onReact: (String) -> Unit,
+    onRepost: () -> Unit,
+    onQuote: () -> Unit,
+    onZap: () -> Unit,
+    onAddToList: () -> Unit = {},
+    onOpenEmojiLibrary: (() -> Unit)? = null
+) {
+    val title = remember(event) { event.tags.firstOrNull { it.size >= 2 && it[0] == "title" }?.get(1) }
+    val summary = remember(event) { event.tags.firstOrNull { it.size >= 2 && it[0] == "summary" }?.get(1) }
+    val image = remember(event) { event.tags.firstOrNull { it.size >= 2 && it[0] == "image" }?.get(1) }
+    val dTag = remember(event) { event.tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.get(1) ?: "" }
+    val publishedAt = remember(event) {
+        event.tags.firstOrNull { it.size >= 2 && it[0] == "published_at" }?.get(1)?.toLongOrNull()
+    }
+    val profileData = remember(profileVersion, event.pubkey) {
+        viewModel.eventRepo.getProfileData(event.pubkey)
+    }
+    val likeCount = remember(reactionVersion, event.id) { viewModel.eventRepo.getReactionCount(event.id) }
+    val replyCount = remember(replyCountVersion, event.id) { viewModel.eventRepo.getReplyCount(event.id) }
+    val zapSats = remember(zapVersion, event.id) { viewModel.eventRepo.getZapSats(event.id) }
+    val userEmojis = remember(reactionVersion, event.id, userPubkey) {
+        userPubkey?.let { viewModel.eventRepo.getUserReactionEmojis(event.id, it) } ?: emptySet()
+    }
+    val repostCount = remember(repostVersion, event.id) { viewModel.eventRepo.getRepostCount(event.id) }
+    val hasUserReposted = remember(repostVersion, event.id) { viewModel.eventRepo.hasUserReposted(event.id) }
+    val hasUserZapped = remember(zapVersion, event.id) { viewModel.eventRepo.hasUserZapped(event.id) }
+    val resolvedEmojis by viewModel.customEmojiRepo.resolvedEmojis.collectAsState()
+    val unicodeEmojis by viewModel.customEmojiRepo.unicodeEmojis.collectAsState()
+    val eventReactionEmojiUrls = remember(reactionVersion, event.id) {
+        viewModel.eventRepo.getReactionEmojiUrls(event.id)
+    }
+
+    val displayName = profileData?.displayString
+        ?: "${event.pubkey.take(8)}...${event.pubkey.takeLast(4)}"
+
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surface,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .then(
+                if (onArticleClick != null) Modifier.clickable { onArticleClick(30023, event.pubkey, dTag) }
+                else Modifier
+            )
+    ) {
+        Column {
+            if (image != null) {
+                coil3.compose.AsyncImage(
+                    model = image,
+                    contentDescription = title,
+                    contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 180.dp)
+                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                )
+            }
+            Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+                // Author row
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                ) {
+                    ProfilePicture(
+                        url = profileData?.picture,
+                        size = 28,
+                        modifier = Modifier.clickable { onProfileClick(event.pubkey) }
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = displayName,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable { onProfileClick(event.pubkey) }
+                    )
+                    val timestamp = publishedAt ?: event.created_at
+                    Text(
+                        text = formatFeedArticleTimestamp(timestamp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+                // Article badge + title
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Surface(
+                        shape = RoundedCornerShape(4.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Text(
+                            text = "ARTICLE",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                    Text(
+                        text = title ?: "Untitled Article",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                if (!summary.isNullOrBlank()) {
+                    Text(
+                        text = summary,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 3,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
+            // Action bar
+            com.wisp.app.ui.component.ActionBar(
+                onReply = onReply,
+                onReact = onReact,
+                userReactionEmojis = userEmojis,
+                onRepost = onRepost,
+                onQuote = onQuote,
+                hasUserReposted = hasUserReposted,
+                onZap = onZap,
+                hasUserZapped = hasUserZapped,
+                onAddToList = onAddToList,
+                isInList = isInList,
+                likeCount = likeCount,
+                repostCount = repostCount,
+                replyCount = replyCount,
+                zapSats = zapSats,
+                isZapAnimating = isZapAnimating,
+                isZapInProgress = isZapInProgress,
+                reactionEmojiUrls = eventReactionEmojiUrls,
+                resolvedEmojis = resolvedEmojis,
+                unicodeEmojis = unicodeEmojis,
+                onOpenEmojiLibrary = onOpenEmojiLibrary,
+                modifier = Modifier.padding(horizontal = 4.dp)
+            )
+        }
+    }
 }
 
 @Composable
@@ -1875,5 +2066,18 @@ fun BroadcastStatusBar(
                 }
             }
         }
+    }
+}
+
+private fun formatFeedArticleTimestamp(epoch: Long): String {
+    val now = System.currentTimeMillis() / 1000
+    val diff = now - epoch
+    return when {
+        diff < 60 -> "now"
+        diff < 3600 -> "${diff / 60}m"
+        diff < 86400 -> "${diff / 3600}h"
+        diff < 604800 -> "${diff / 86400}d"
+        else -> java.text.SimpleDateFormat("MMM d", java.util.Locale.US)
+            .format(java.util.Date(epoch * 1000))
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -141,7 +141,8 @@ fun UserProfileScreen(
     onAddNoteToList: (String) -> Unit = {},
     onSendDm: (() -> Unit)? = null,
     signer: com.wisp.app.nostr.NostrSigner? = null,
-    translationRepo: TranslationRepository? = null
+    translationRepo: TranslationRepository? = null,
+    onArticleClick: ((Int, String, String) -> Unit)? = null
 ) {
     val profile by viewModel.profile.collectAsState()
     val isFollowing by viewModel.isFollowing.collectAsState()
@@ -453,6 +454,16 @@ fun UserProfileScreen(
                         item { EmptyTabContent("No notes yet") }
                     } else {
                         items(items = rootNotes, key = { it.id }) { event ->
+                            if (event.kind == 30023) {
+                                ProfileArticleCard(
+                                    event = event,
+                                    profile = profile,
+                                    eventRepo = eventRepo,
+                                    onArticleClick = onArticleClick,
+                                    onProfileClick = onNavigateToProfile
+                                )
+                                return@items
+                            }
                             val likeCount = reactionVersion.let { eventRepo?.getReactionCount(event.id) ?: 0 }
                             val replyCount = replyCountVersion.let { eventRepo?.getReplyCount(event.id) ?: 0 }
                             val repostCount = repostVersion.let { eventRepo?.getRepostCount(event.id) ?: 0 }
@@ -1299,6 +1310,91 @@ private fun BlockedContentOverlay(onReveal: () -> Unit) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.7f)
             )
+        }
+    }
+}
+
+@Composable
+private fun ProfileArticleCard(
+    event: NostrEvent,
+    profile: ProfileData?,
+    eventRepo: EventRepository?,
+    onArticleClick: ((Int, String, String) -> Unit)?,
+    onProfileClick: ((String) -> Unit)?
+) {
+    val title = remember(event) { event.tags.firstOrNull { it.size >= 2 && it[0] == "title" }?.get(1) }
+    val summary = remember(event) { event.tags.firstOrNull { it.size >= 2 && it[0] == "summary" }?.get(1) }
+    val image = remember(event) { event.tags.firstOrNull { it.size >= 2 && it[0] == "image" }?.get(1) }
+    val dTag = remember(event) { event.tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.get(1) ?: "" }
+    val publishedAt = remember(event) {
+        event.tags.firstOrNull { it.size >= 2 && it[0] == "published_at" }?.get(1)?.toLongOrNull()
+    }
+
+    androidx.compose.material3.Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surface,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .then(
+                if (onArticleClick != null) Modifier.clickable { onArticleClick(30023, event.pubkey, dTag) }
+                else Modifier
+            )
+    ) {
+        Column {
+            if (image != null) {
+                coil3.compose.AsyncImage(
+                    model = image,
+                    contentDescription = title,
+                    contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(180.dp)
+                )
+            }
+            Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    androidx.compose.material3.Surface(
+                        shape = RoundedCornerShape(4.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Text(
+                            text = "ARTICLE",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                    Text(
+                        text = title ?: "Untitled Article",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                if (!summary.isNullOrBlank()) {
+                    Text(
+                        text = summary,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 3,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+                if (publishedAt != null) {
+                    Text(
+                        text = java.text.SimpleDateFormat("MMM d, yyyy", java.util.Locale.US)
+                            .format(java.util.Date(publishedAt * 1000)),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                        modifier = Modifier.padding(top = 6.dp)
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ArticleViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ArticleViewModel.kt
@@ -2,8 +2,19 @@ package com.wisp.app.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wisp.app.nostr.ClientMessage
+import com.wisp.app.nostr.Filter
+import com.wisp.app.nostr.Nip10
+import com.wisp.app.nostr.Nip57
 import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.relay.OutboxRouter
+import com.wisp.app.relay.RelayPool
+import com.wisp.app.relay.SubscriptionManager
 import com.wisp.app.repo.EventRepository
+import com.wisp.app.repo.MetadataFetcher
+import com.wisp.app.repo.RelayHintStore
+import com.wisp.app.repo.RelayListRepository
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +38,30 @@ class ArticleViewModel : ViewModel() {
 
     private val _hashtags = MutableStateFlow<List<String>>(emptyList())
     val hashtags: StateFlow<List<String>> = _hashtags
+
+    // Comments
+    private val _comments = MutableStateFlow<List<Pair<NostrEvent, Int>>>(emptyList())
+    val comments: StateFlow<List<Pair<NostrEvent, Int>>> = _comments
+
+    private val _isCommentsLoading = MutableStateFlow(false)
+    val isCommentsLoading: StateFlow<Boolean> = _isCommentsLoading
+
+    private val commentEvents = mutableMapOf<String, NostrEvent>()
+    private var collectorJob: Job? = null
+    private var engagementCollectorJob: Job? = null
+    private var rebuildJob: Job? = null
+    private var loadJob: Job? = null
+    private var metadataBatchJob: Job? = null
+    private var relayPoolRef: RelayPool? = null
+    private var topRelayUrls: List<String> = emptyList()
+    private var relayListRepoRef: RelayListRepository? = null
+    private var relayHintStoreRef: RelayHintStore? = null
+    private val activeSubIds = mutableListOf<String>()
+
+    // Incremental metadata tracking
+    private val metadataSubscribedIds = mutableSetOf<String>()
+    private val pendingMetadataIds = mutableSetOf<String>()
+    private var metadataBatchIndex = 0
 
     fun loadArticle(kind: Int, author: String, dTag: String, eventRepo: EventRepository) {
         viewModelScope.launch {
@@ -53,6 +88,277 @@ class ArticleViewModel : ViewModel() {
         }
     }
 
+    fun loadComments(
+        author: String,
+        dTag: String,
+        articleEventId: String?,
+        eventRepo: EventRepository,
+        relayPool: RelayPool,
+        outboxRouter: OutboxRouter,
+        subManager: SubscriptionManager,
+        metadataFetcher: MetadataFetcher,
+        topRelayUrls: List<String>,
+        relayListRepo: RelayListRepository? = null,
+        relayHintStore: RelayHintStore? = null
+    ) {
+        this.relayPoolRef = relayPool
+        this.topRelayUrls = topRelayUrls
+        this.relayListRepoRef = relayListRepo
+        this.relayHintStoreRef = relayHintStore
+        _isCommentsLoading.value = true
+
+        val coordinate = "30023:$author:$dTag"
+        val commentSubId = "article-comments"
+        activeSubIds.add(commentSubId)
+
+        // Also subscribe via e-tag if we have the article event ID — many clients
+        // reply with e-tags pointing to the article event, not a-tags
+        val eTagSubId = "article-comments-etag"
+        if (articleEventId != null) {
+            activeSubIds.add(eTagSubId)
+        }
+
+        // Collect comment events from both subscriptions
+        collectorJob?.cancel()
+        collectorJob = viewModelScope.launch {
+            relayPool.relayEvents.collect { (event, relayUrl, subId) ->
+                if (subId == commentSubId || subId == eTagSubId) {
+                    if (event.kind != 1) return@collect
+                    val isNew = event.id !in commentEvents
+                    if (isNew) {
+                        commentEvents[event.id] = event
+                        eventRepo.cacheEvent(event)
+                        eventRepo.addEventRelay(event.id, relayUrl)
+                        if (eventRepo.getProfileData(event.pubkey) == null) {
+                            metadataFetcher.addToPendingProfiles(event.pubkey)
+                        }
+                        // Track for incremental engagement subscriptions
+                        synchronized(pendingMetadataIds) {
+                            pendingMetadataIds.add(event.id)
+                        }
+                        scheduleRebuild(articleEventId)
+                    }
+                }
+            }
+        }
+
+        // Collect engagement events (reactions, zaps, reposts)
+        engagementCollectorJob?.cancel()
+        engagementCollectorJob = viewModelScope.launch {
+            relayPool.relayEvents.collect { (event, _, subId) ->
+                if (!subId.startsWith("article-engage")) return@collect
+                when (event.kind) {
+                    7, 6 -> eventRepo.addEvent(event)
+                    9735 -> {
+                        eventRepo.addEvent(event)
+                        val zapperPubkey = Nip57.getZapperPubkey(event)
+                        if (zapperPubkey != null && eventRepo.getProfileData(zapperPubkey) == null) {
+                            metadataFetcher.addToPendingProfiles(zapperPubkey)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Two-phase loading matching ThreadViewModel pattern
+        loadJob = viewModelScope.launch {
+            // Phase 1a: Subscribe for comments via `a` tag on author's read relays + top relays
+            val commentFilter = Filter(kinds = listOf(1), aTags = listOf(coordinate))
+            outboxRouter.subscribeToUserReadRelays(commentSubId, author, commentFilter)
+            val aTagMsg = ClientMessage.req(commentSubId, commentFilter)
+            for (url in topRelayUrls) {
+                relayPool.sendToRelayOrEphemeral(url, aTagMsg)
+            }
+
+            // Phase 1b: Also subscribe via e-tag — many clients reply with e-tags
+            if (articleEventId != null) {
+                val eTagFilter = Filter(kinds = listOf(1), eTags = listOf(articleEventId))
+                outboxRouter.subscribeToUserReadRelays(eTagSubId, author, eTagFilter)
+                val eTagMsg = ClientMessage.req(eTagSubId, eTagFilter)
+                for (url in topRelayUrls) {
+                    relayPool.sendToRelayOrEphemeral(url, eTagMsg)
+                }
+            }
+
+            // Wait for EOSE from both subscriptions
+            subManager.awaitEoseWithTimeout(commentSubId, 5_000)
+            if (articleEventId != null) {
+                subManager.awaitEoseWithTimeout(eTagSubId, 3_000)
+            }
+            _isCommentsLoading.value = false
+            metadataFetcher.sweepMissingProfiles()
+
+            // Phase 2: Seed reply counts from loaded comments + subscribe engagement
+            subscribeEngagement(relayPool, articleEventId, coordinate, author, eventRepo, subManager)
+
+            // Start incremental engagement batching for late-arriving comments
+            startMetadataBatching(relayPool, author)
+        }
+    }
+
+    /**
+     * Subscribe for engagement data (reactions, zaps, reposts) on the article event
+     * itself and all comment events. Seeds reply counts upfront from loaded comments.
+     * Awaits EOSE for article engagement to ensure reliable counts.
+     */
+    private suspend fun subscribeEngagement(
+        relayPool: RelayPool,
+        articleEventId: String?,
+        coordinate: String,
+        authorPubkey: String,
+        eventRepo: EventRepository,
+        subManager: SubscriptionManager
+    ) {
+        // Seed reply counts from already-loaded comments (before engagement subscriptions)
+        for (event in commentEvents.values) {
+            val parentId = Nip10.getReplyTarget(event) ?: articleEventId ?: continue
+            eventRepo.addReplyCount(parentId, event.id)
+        }
+
+        // Collect all event IDs we need engagement for: article + comments
+        val allEventIds = mutableListOf<String>()
+        if (articleEventId != null) allEventIds.add(articleEventId)
+        allEventIds.addAll(commentEvents.keys)
+        if (allEventIds.isEmpty() && articleEventId == null) return
+
+        // Track these as already subscribed for incremental batching
+        metadataSubscribedIds.addAll(allEventIds)
+
+        // Phase 1a: Article engagement via e-tag (high priority) — await EOSE
+        if (articleEventId != null) {
+            val eTagSubId = "article-engage"
+            activeSubIds.add(eTagSubId)
+            val eTagFilter = Filter(kinds = listOf(7, 6, 9735), eTags = listOf(articleEventId))
+            sendToEngagementRelays(relayPool, eTagSubId, eTagFilter, authorPubkey)
+            subManager.awaitEoseWithTimeout(eTagSubId, 3_500)
+        }
+
+        // Phase 1b: Article engagement via a-tag coordinate — many clients reference
+        // addressable events by coordinate ("30023:<pubkey>:<dtag>") instead of event ID
+        val aTagSubId = "article-engage-a"
+        activeSubIds.add(aTagSubId)
+        val aTagFilter = Filter(kinds = listOf(7, 6, 9735), aTags = listOf(coordinate))
+        sendToEngagementRelays(relayPool, aTagSubId, aTagFilter, authorPubkey)
+        subManager.awaitEoseWithTimeout(aTagSubId, 3_500)
+
+        // Phase 2: Comment engagement (lower priority) — chunked, fire-and-forget
+        val commentIds = commentEvents.keys.toList()
+        if (commentIds.isNotEmpty()) {
+            commentIds.chunked(50).forEachIndexed { index, batch ->
+                val subId = "article-engage-${index + 1}"
+                activeSubIds.add(subId)
+                val filter = Filter(kinds = listOf(7, 6, 9735), eTags = batch)
+                sendToEngagementRelays(relayPool, subId, filter, authorPubkey)
+            }
+        }
+    }
+
+    /**
+     * Batch pending event IDs every 500ms into new engagement subscriptions.
+     * Late-arriving comments get their engagement data fetched incrementally.
+     */
+    private fun startMetadataBatching(relayPool: RelayPool, authorPubkey: String) {
+        metadataBatchJob = viewModelScope.launch {
+            while (true) {
+                delay(500)
+                val batch = synchronized(pendingMetadataIds) {
+                    val newIds = pendingMetadataIds.filter { it !in metadataSubscribedIds }
+                    pendingMetadataIds.clear()
+                    if (newIds.isEmpty()) null
+                    else {
+                        metadataSubscribedIds.addAll(newIds)
+                        newIds.toList()
+                    }
+                } ?: continue
+                metadataBatchIndex++
+                val subId = "article-engage-b$metadataBatchIndex"
+                activeSubIds.add(subId)
+                val filter = Filter(kinds = listOf(7, 6, 9735), eTags = batch)
+                sendToEngagementRelays(relayPool, subId, filter, authorPubkey)
+            }
+        }
+    }
+
+    /**
+     * Send subscription to author's read relays + top scored relays.
+     * Mirrors ThreadViewModel.sendToEngagementRelays().
+     */
+    private fun sendToEngagementRelays(
+        relayPool: RelayPool, subId: String, filter: Filter, authorPubkey: String
+    ) {
+        val msg = ClientMessage.req(subId, filter)
+        val sent = mutableSetOf<String>()
+        for (url in getAuthorRelays(authorPubkey)) {
+            if (relayPool.sendToRelayOrEphemeral(url, msg)) sent.add(url)
+        }
+        for (url in topRelayUrls) {
+            if (url !in sent) relayPool.sendToRelayOrEphemeral(url, msg)
+        }
+    }
+
+    private fun getAuthorRelays(pubkey: String): List<String> {
+        val nip65 = relayListRepoRef?.getReadRelays(pubkey)
+        if (!nip65.isNullOrEmpty()) return nip65
+        val hints = relayHintStoreRef?.getHints(pubkey)
+        if (!hints.isNullOrEmpty()) return hints.toList()
+        return emptyList()
+    }
+
+    private fun scheduleRebuild(articleEventId: String?) {
+        rebuildJob?.cancel()
+        rebuildJob = viewModelScope.launch {
+            delay(100)
+            rebuildTree(articleEventId)
+        }
+    }
+
+    private fun rebuildTree(articleEventId: String?) {
+        val parentToChildren = mutableMapOf<String, MutableList<NostrEvent>>()
+
+        for (event in commentEvents.values) {
+            val replyTarget = Nip10.getReplyTarget(event)
+            val parentId = when {
+                replyTarget != null && replyTarget in commentEvents -> replyTarget
+                replyTarget != null && replyTarget == articleEventId -> "root"
+                else -> "root"
+            }
+            parentToChildren.getOrPut(parentId) { mutableListOf() }.add(event)
+        }
+
+        for (children in parentToChildren.values) {
+            children.sortBy { it.created_at }
+        }
+
+        val result = mutableListOf<Pair<NostrEvent, Int>>()
+        val visited = mutableSetOf<String>()
+
+        val rootChildren = parentToChildren["root"] ?: emptyList()
+        for (child in rootChildren) {
+            if (child.id in visited) continue
+            visited.add(child.id)
+            result.add(child to 0)
+            dfs(child.id, 1, parentToChildren, result, visited)
+        }
+
+        _comments.value = result
+    }
+
+    private fun dfs(
+        parentId: String,
+        depth: Int,
+        parentToChildren: Map<String, List<NostrEvent>>,
+        result: MutableList<Pair<NostrEvent, Int>>,
+        visited: MutableSet<String>
+    ) {
+        val children = parentToChildren[parentId] ?: return
+        for (child in children) {
+            if (child.id in visited) continue
+            visited.add(child.id)
+            result.add(child to depth)
+            dfs(child.id, depth + 1, parentToChildren, result, visited)
+        }
+    }
+
     private fun parseAndEmit(event: NostrEvent) {
         _article.value = event
         _title.value = event.tags.firstOrNull { it.size >= 2 && it[0] == "title" }?.get(1)
@@ -60,5 +366,18 @@ class ArticleViewModel : ViewModel() {
         _publishedAt.value = event.tags.firstOrNull { it.size >= 2 && it[0] == "published_at" }?.get(1)?.toLongOrNull()
         _hashtags.value = event.tags.filter { it.size >= 2 && it[0] == "t" }.map { it[1] }
         _isLoading.value = false
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        collectorJob?.cancel()
+        engagementCollectorJob?.cancel()
+        rebuildJob?.cancel()
+        loadJob?.cancel()
+        metadataBatchJob?.cancel()
+        relayPoolRef?.let { pool ->
+            for (subId in activeSubIds) pool.closeOnAllRelays(subId)
+        }
+        activeSubIds.clear()
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/AuthViewModel.kt
@@ -44,11 +44,23 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun logIn(): Boolean {
-        val nsec = _nsecInput.value.trim()
-        if (nsec.isBlank()) {
-            _error.value = "Please enter your nsec key"
+        val input = _nsecInput.value.trim()
+        if (input.isBlank()) {
+            _error.value = "Please enter your key"
             return false
         }
+        return when {
+            input.startsWith("nsec1") -> loginWithNsec(input)
+            input.startsWith("npub1") -> loginWithNpub(input)
+            input.length == 64 && input.all { it in '0'..'9' || it in 'a'..'f' } -> loginWithPubkeyHex(input)
+            else -> {
+                _error.value = "Invalid key format — enter an nsec or npub"
+                false
+            }
+        }
+    }
+
+    private fun loginWithNsec(nsec: String): Boolean {
         return try {
             val privkey = Nip19.nsecDecode(nsec)
             val keypair = Keys.fromPrivkey(privkey)
@@ -60,6 +72,36 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
             true
         } catch (e: Exception) {
             _error.value = "Invalid nsec key: ${e.message}"
+            false
+        }
+    }
+
+    private fun loginWithNpub(npub: String): Boolean {
+        return try {
+            val pubkey = Nip19.npubDecode(npub)
+            val pubkeyHex = pubkey.toHex()
+            keyRepo.savePubkeyReadOnly(pubkeyHex)
+            keyRepo.reloadPrefs(pubkeyHex)
+            _npub.value = Nip19.npubEncode(pubkey)
+            _nsecInput.value = ""
+            _error.value = null
+            true
+        } catch (e: Exception) {
+            _error.value = "Invalid npub: ${e.message}"
+            false
+        }
+    }
+
+    private fun loginWithPubkeyHex(hex: String): Boolean {
+        return try {
+            keyRepo.savePubkeyReadOnly(hex)
+            keyRepo.reloadPrefs(hex)
+            _npub.value = Nip19.npubEncode(hex.hexToByteArray())
+            _nsecInput.value = ""
+            _error.value = null
+            true
+        } catch (e: Exception) {
+            _error.value = "Invalid pubkey: ${e.message}"
             false
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -342,7 +342,7 @@ class EventRouter(
                 eventRepo.addRelayFeedEvent(event)
                 onRelayFeedEventReceived()
                 eventRepo.addEventRelay(event.id, relayUrl)
-                if (event.kind == 1) {
+                if (event.kind == 1 || event.kind == 30023) {
                     metadataFetcher.fetchQuotedEvents(event)
                     if (eventRepo.getProfileData(event.pubkey) == null) {
                         metadataFetcher.addToPendingProfiles(event.pubkey)
@@ -360,7 +360,7 @@ class EventRouter(
             } else if (isFeedSub) {
                 eventRepo.addEvent(event)
                 eventRepo.addEventRelay(event.id, relayUrl)
-                if (event.kind == 1) {
+                if (event.kind == 1 || event.kind == 30023) {
                     metadataFetcher.fetchQuotedEvents(event)
                     if (eventRepo.getProfileData(event.pubkey) == null) {
                         metadataFetcher.addToPendingProfiles(event.pubkey)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -243,7 +243,7 @@ class FeedSubscriptionManager(
                     return
                 }
                 Log.d("RLC", "[FeedSub] resubscribeFeed: ${allAuthors.size} authors, ${indexerRelays.size} indexers, ${excludedUrls.size} excluded")
-                val notesFilter = Filter(kinds = listOf(1, 6), since = sinceTimestamp)
+                val notesFilter = Filter(kinds = listOf(1, 6, 30023), since = sinceTimestamp)
                 outboxRouter.subscribeByAuthors(
                     feedSubId, allAuthors, notesFilter,
                     indexerRelays = indexerRelays, blockedUrls = excludedUrls
@@ -280,7 +280,7 @@ class FeedSubscriptionManager(
                         subManager.awaitEoseCount(prefetchSubId, prefetchTarget, timeoutMs = 5000)
                         subManager.closeSubscription(prefetchSubId)
                         Log.d("RLC", "[FeedSub] list relay-list prefetch done, now subscribing feed")
-                        val notesFilter = Filter(kinds = listOf(1, 6), since = listSince)
+                        val notesFilter = Filter(kinds = listOf(1, 6, 30023), since = listSince)
                         val targeted = outboxRouter.subscribeByAuthors(
                             feedSubId, authors, notesFilter,
                             indexerRelays = indexerRelays, blockedUrls = excludedUrls
@@ -301,7 +301,7 @@ class FeedSubscriptionManager(
                     return
                 }
 
-                val notesFilter = Filter(kinds = listOf(1, 6), since = listSince)
+                val notesFilter = Filter(kinds = listOf(1, 6, 30023), since = listSince)
                 outboxRouter.subscribeByAuthors(
                     feedSubId, authors, notesFilter,
                     indexerRelays = indexerRelays, blockedUrls = excludedUrls
@@ -353,7 +353,7 @@ class FeedSubscriptionManager(
                     listOfNotNull(pubkeyHex) + firstDegree
                 }
                 if (allAuthors.isEmpty()) { isLoadingMore = false; return }
-                val templateFilter = Filter(kinds = listOf(1, 6), until = oldest - 1, limit = 50)
+                val templateFilter = Filter(kinds = listOf(1, 6, 30023), until = oldest - 1, limit = 50)
                 outboxRouter.subscribeByAuthors(
                     "loadmore", allAuthors, templateFilter,
                     indexerRelays = indexerRelays, blockedUrls = excludedUrls
@@ -363,7 +363,7 @@ class FeedSubscriptionManager(
                 val oldest = eventRepo.getOldestRelayFeedTimestamp() ?: run { isLoadingMore = false; return }
                 val relaySet = _selectedRelaySet.value
                 if (relaySet != null) {
-                    val filter = Filter(kinds = listOf(1, 6), until = oldest - 1, limit = 50)
+                    val filter = Filter(kinds = listOf(1, 6, 30023), until = oldest - 1, limit = 50)
                     val msg = ClientMessage.req("relay-loadmore", filter)
                     for (setUrl in relaySet.relays) {
                         relayPool.sendToRelayOrEphemeral(setUrl, msg, skipBadCheck = true)
@@ -371,7 +371,7 @@ class FeedSubscriptionManager(
                 } else {
                     val url = _selectedRelay.value
                     if (url != null) {
-                        val filter = Filter(kinds = listOf(1, 6), until = oldest - 1, limit = 50)
+                        val filter = Filter(kinds = listOf(1, 6, 30023), until = oldest - 1, limit = 50)
                         relayPool.sendToRelayOrEphemeral(url, ClientMessage.req("relay-loadmore", filter), skipBadCheck = true)
                     } else { isLoadingMore = false; return }
                 }
@@ -390,7 +390,7 @@ class FeedSubscriptionManager(
                         val prefetchTarget = maxOf(2, (connected * 0.2).toInt())
                         subManager.awaitEoseCount(prefetchSubId, prefetchTarget, timeoutMs = 5000)
                         subManager.closeSubscription(prefetchSubId)
-                        val templateFilter = Filter(kinds = listOf(1, 6), until = oldest - 1)
+                        val templateFilter = Filter(kinds = listOf(1, 6, 30023), until = oldest - 1)
                         outboxRouter.subscribeByAuthors(
                             "loadmore", authors, templateFilter,
                             indexerRelays = indexerRelays, blockedUrls = excludedUrls
@@ -406,7 +406,7 @@ class FeedSubscriptionManager(
                     return
                 }
 
-                val templateFilter = Filter(kinds = listOf(1, 6), until = oldest - 1)
+                val templateFilter = Filter(kinds = listOf(1, 6, 30023), until = oldest - 1)
                 outboxRouter.subscribeByAuthors(
                     "loadmore", authors, templateFilter,
                     indexerRelays = indexerRelays, blockedUrls = excludedUrls
@@ -464,7 +464,7 @@ class FeedSubscriptionManager(
         if (relaySet != null) {
             relayStatusMonitorJob?.cancel()
             _relayFeedStatus.value = RelayFeedStatus.Subscribing
-            val filter = Filter(kinds = listOf(1, 6), limit = 100)
+            val filter = Filter(kinds = listOf(1, 6, 30023), limit = 100)
             val msg = ClientMessage.req(relayFeedSubId, filter)
             val sentUrls = mutableSetOf<String>()
             for (setUrl in relaySet.relays) {
@@ -491,7 +491,7 @@ class FeedSubscriptionManager(
             if (status is RelayFeedStatus.Cooldown || status is RelayFeedStatus.BadRelay) {
                 return
             }
-            val filter = Filter(kinds = listOf(1, 6), limit = 100)
+            val filter = Filter(kinds = listOf(1, 6, 30023), limit = 100)
             val msg = ClientMessage.req(relayFeedSubId, filter)
             val sent = relayPool.sendToRelayOrEphemeral(url, msg, skipBadCheck = true)
             if (!sent) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -153,6 +153,11 @@ class StartupCoordinator(
     fun reloadForNewAccount() {
         val newPubkey = getUserPubkey()
 
+        // Clear stale data from previous account
+        notifRepo.clear()
+        eventRepo.clearAll()
+        dmRepo.clear()
+
         // Reload per-account prefs for new pubkey
         eventRepo.currentUserPubkey = newPubkey
         keyRepo.reloadPrefs(newPubkey)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
@@ -146,7 +146,7 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
 
         // Request fresh profile, posts, follow list, and relay list
         val profileFilter = Filter(kinds = listOf(0), authors = listOf(pubkey), limit = 1)
-        val postsFilter = Filter(kinds = listOf(1, 6), authors = listOf(pubkey), limit = 50)
+        val postsFilter = Filter(kinds = listOf(1, 6, 30023), authors = listOf(pubkey), limit = 50)
         val followFilter = Filter(kinds = listOf(3), authors = listOf(pubkey), limit = 1)
         val relayFilter = Filter(kinds = listOf(10002), authors = listOf(pubkey), limit = 1)
         val pinFilter = Filter(kinds = listOf(10001), authors = listOf(pubkey), limit = 1)
@@ -236,6 +236,16 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
                                     current.sortByDescending { it.created_at }
                                     _replies.value = current
                                 }
+                            }
+                        }
+                        30023 -> {
+                            eventRepo.cacheEvent(event)
+                            if (event.created_at < oldestNoteTimestamp) oldestNoteTimestamp = event.created_at
+                            val current = _rootNotes.value.toMutableList()
+                            if (current.none { it.id == event.id }) {
+                                current.add(event)
+                                current.sortByDescending { _repostSortTime[it.id] ?: it.created_at }
+                                _rootNotes.value = current
                             }
                         }
                         6 -> {
@@ -392,7 +402,7 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
         if (oldestNoteTimestamp == Long.MAX_VALUE) { isLoadingMoreNotes = false; return }
 
         val pool = relayPoolRef ?: run { isLoadingMoreNotes = false; return }
-        val filter = Filter(kinds = listOf(1, 6), authors = listOf(targetPubkey), until = oldestNoteTimestamp - 1, limit = 50)
+        val filter = Filter(kinds = listOf(1, 6, 30023), authors = listOf(targetPubkey), until = oldestNoteTimestamp - 1, limit = 50)
 
         val router = outboxRouterRef
         if (router != null) {


### PR DESCRIPTION
## Summary
- Add NIP-23 (kind 30023) long-form article reader with markdown rendering, cover images, hashtags, and full engagement bar (reactions, zaps, reposts, comments)
- Improve article engagement reliability by mirroring ThreadViewModel patterns: EOSE awaiting, reply count seeding, chunked filters, incremental batching for late-arriving comments
- Add a-tag coordinate filters for engagement queries so reactions/zaps indexed by addressable reference are found, with fallback resolution in EventRepository for engagement events without e-tags

## Test plan
- [ ] Open a long-form article from the feed and verify it renders with title, cover image, content, and hashtags
- [ ] Verify engagement counts (reactions, zaps, reposts, comments) load consistently on articles
- [ ] Compare engagement counts with another client (e.g. Amethyst) for the same article
- [ ] Open a kind 1 note thread and verify engagement still works correctly (regression check)
- [ ] Test articles from user profile screens navigate correctly