### PR TITLE
Fix quoted NIP-23 articles stuck loading forever

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/MetadataFetcher.kt
@@ -47,7 +47,7 @@ class MetadataFetcher(
     // Quoted event fetching
     private val scannedQuoteEvents = mutableSetOf<String>()
     private val failedQuoteFetches = mutableMapOf<String, Long>() // eventId -> timestamp of failure
-    private val nostrNoteUriRegex = Regex("""nostr:(note1|nevent1)[a-z0-9]+""")
+    private val nostrNoteUriRegex = Regex("""nostr:(note1|nevent1|naddr1)[a-z0-9]+""")
     private val validHexId = Regex("""^[0-9a-f]{64}$""")
 
     // Pubkeys that have been attempted MAX times and never found — stop fetching from feeds.
@@ -256,8 +256,14 @@ class MetadataFetcher(
             }
         for (match in nostrNoteUriRegex.findAll(event.content)) {
             val decoded = Nip19.decodeNostrUri(match.value)
-            if (decoded is NostrUriData.NoteRef) {
-                requestQuotedEvent(decoded.eventId, decoded.relays)
+            when (decoded) {
+                is NostrUriData.NoteRef -> requestQuotedEvent(decoded.eventId, decoded.relays)
+                is NostrUriData.AddressRef -> {
+                    val kind = decoded.kind ?: continue
+                    val author = decoded.author ?: continue
+                    requestAddressableEvent(kind, author, decoded.dTag, decoded.relays)
+                }
+                else -> {}
             }
         }
     }
@@ -273,7 +279,7 @@ class MetadataFetcher(
                     addToPendingProfiles(reposter)
                 }
             }
-            if (event.kind == 1 && event.id !in scannedQuoteEvents) {
+            if ((event.kind == 1 || event.kind == 30023) && event.id !in scannedQuoteEvents) {
                 scannedQuoteEvents.add(event.id)
                 fetchQuotedEvents(event)
             }


### PR DESCRIPTION
## Summary
- Add `naddr1` to the nostr URI regex so `fetchQuotedEvents()` recognizes quoted long-form article references
- Decode `AddressRef` URIs and call `requestAddressableEvent()` to fetch the quoted article from relays
- Scan kind 30023 events for embedded quotes during profile sweeps (previously only kind 1)

## Test plan
- [ ] Find a note that quotes a NIP-23 article via `nostr:naddr1...` and verify the article card loads instead of spinning forever
- [ ] Verify regular quoted notes (`nostr:note1...`, `nostr:nevent1...`) still work as before
- [ ] Verify articles in the feed that themselves contain quoted references resolve correctly