### PR TITLE
feat: add NIP-23 long-form article support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 20
-        versionName = "0.5.2"
+        versionCode = 21
+        versionName = "0.6.0"
 
         ndk {
             abiFilters += "arm64-v8a"


### PR DESCRIPTION
## Summary
- Add NIP-23 long-form article (kind 30023) reading support with a dedicated article reader screen featuring markdown rendering, metadata display, and engagement stats
- Improve article engagement reliability with a-tag filters and EOSE awaiting
- Fix quoted NIP-23 articles getting stuck in loading state
- Bump version to 0.6.0

## Test plan
- [ ] Open feed and verify long-form articles render with proper previews
- [ ] Tap an article to open the reader screen and verify markdown rendering
- [ ] Verify article engagement counts (reactions, reposts, zaps) load correctly
- [ ] Verify quoted NIP-23 articles render inline without getting stuck loading
- [ ] Check article reader on user profile screens