### PR TITLE
Fix private zap toggle not detecting recipient DM relays

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -812,6 +812,7 @@ fun WispNavHost(
                 zapError = feedViewModel.zapError,
                 zapInProgressIds = profileZapInProgress,
                 canPrivateZap = feedViewModel.relayPool.hasDmRelays() && feedViewModel.relayListRepo.hasDmRelays(pubkey),
+                fetchDmRelays = { pk -> feedViewModel.fetchDmRelaysIfMissing(pk) && feedViewModel.relayPool.hasDmRelays() },
                 ownLists = feedViewModel.listRepo.ownLists.collectAsState().value,
                 onAddToList = { dTag, pk -> feedViewModel.addToList(dTag, pk) },
                 onRemoveFromList = { dTag, pk -> feedViewModel.removeFromList(dTag, pk) },
@@ -971,6 +972,15 @@ fun WispNavHost(
 
             if (threadZapTarget != null) {
                 val threadZapRecipient = threadZapTarget!!.pubkey
+                val threadUserHasDmRelays = feedViewModel.relayPool.hasDmRelays()
+                var threadRecipientHasDmRelays by remember(threadZapRecipient) {
+                    mutableStateOf(feedViewModel.relayListRepo.hasDmRelays(threadZapRecipient))
+                }
+                if (threadUserHasDmRelays && !threadRecipientHasDmRelays) {
+                    LaunchedEffect(threadZapRecipient) {
+                        threadRecipientHasDmRelays = feedViewModel.fetchDmRelaysIfMissing(threadZapRecipient)
+                    }
+                }
                 ZapDialog(
                     isWalletConnected = isNwcConnected,
                     onDismiss = { threadZapTarget = null },
@@ -980,7 +990,7 @@ fun WispNavHost(
                         feedViewModel.sendZap(event, amountMsats, message, isAnonymous, isPrivate)
                     },
                     onGoToWallet = { navController.navigate(Routes.WALLET) },
-                    canPrivateZap = feedViewModel.relayPool.hasDmRelays() && feedViewModel.relayListRepo.hasDmRelays(threadZapRecipient)
+                    canPrivateZap = threadUserHasDmRelays && threadRecipientHasDmRelays
                 )
             }
             val threadSetListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
@@ -1184,6 +1194,15 @@ fun WispNavHost(
 
             if (articleZapTarget != null) {
                 val zapRecipient = articleZapTarget!!.pubkey
+                val articleUserHasDmRelays = feedViewModel.relayPool.hasDmRelays()
+                var articleRecipientHasDmRelays by remember(zapRecipient) {
+                    mutableStateOf(feedViewModel.relayListRepo.hasDmRelays(zapRecipient))
+                }
+                if (articleUserHasDmRelays && !articleRecipientHasDmRelays) {
+                    LaunchedEffect(zapRecipient) {
+                        articleRecipientHasDmRelays = feedViewModel.fetchDmRelaysIfMissing(zapRecipient)
+                    }
+                }
                 ZapDialog(
                     isWalletConnected = isNwcConnected,
                     onDismiss = { articleZapTarget = null },
@@ -1193,7 +1212,7 @@ fun WispNavHost(
                         feedViewModel.sendZap(event, amountMsats, message, isAnonymous, isPrivate)
                     },
                     onGoToWallet = { navController.navigate(Routes.WALLET) },
-                    canPrivateZap = feedViewModel.relayPool.hasDmRelays() && feedViewModel.relayListRepo.hasDmRelays(zapRecipient)
+                    canPrivateZap = articleUserHasDmRelays && articleRecipientHasDmRelays
                 )
             }
 
@@ -1653,6 +1672,15 @@ fun WispNavHost(
 
             if (notifZapTarget != null) {
                 val notifZapRecipient = notifZapTarget!!.pubkey
+                val notifUserHasDmRelays = feedViewModel.relayPool.hasDmRelays()
+                var notifRecipientHasDmRelays by remember(notifZapRecipient) {
+                    mutableStateOf(feedViewModel.relayListRepo.hasDmRelays(notifZapRecipient))
+                }
+                if (notifUserHasDmRelays && !notifRecipientHasDmRelays) {
+                    LaunchedEffect(notifZapRecipient) {
+                        notifRecipientHasDmRelays = feedViewModel.fetchDmRelaysIfMissing(notifZapRecipient)
+                    }
+                }
                 ZapDialog(
                     isWalletConnected = isNwcConnected,
                     onDismiss = { notifZapTarget = null },
@@ -1662,7 +1690,7 @@ fun WispNavHost(
                         feedViewModel.sendZap(event, amountMsats, message, isAnonymous, isPrivate)
                     },
                     onGoToWallet = { navController.navigate(Routes.WALLET) },
-                    canPrivateZap = feedViewModel.relayPool.hasDmRelays() && feedViewModel.relayListRepo.hasDmRelays(notifZapRecipient)
+                    canPrivateZap = notifUserHasDmRelays && notifRecipientHasDmRelays
                 )
             }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -302,6 +302,15 @@ fun FeedScreen(
 
     if (zapTargetEvent != null) {
         val zapRecipient = zapTargetEvent!!.pubkey
+        val userHasDmRelays = viewModel.relayPool.hasDmRelays()
+        var recipientHasDmRelays by remember(zapRecipient) {
+            mutableStateOf(viewModel.relayListRepo.hasDmRelays(zapRecipient))
+        }
+        if (userHasDmRelays && !recipientHasDmRelays) {
+            LaunchedEffect(zapRecipient) {
+                recipientHasDmRelays = viewModel.fetchDmRelaysIfMissing(zapRecipient)
+            }
+        }
         ZapDialog(
             isWalletConnected = isWalletConnected,
             onDismiss = { zapTargetEvent = null },
@@ -311,7 +320,7 @@ fun FeedScreen(
                 viewModel.sendZap(event, amountMsats, message, isAnonymous, isPrivate)
             },
             onGoToWallet = onWallet,
-            canPrivateZap = viewModel.relayPool.hasDmRelays() && viewModel.relayListRepo.hasDmRelays(zapRecipient)
+            canPrivateZap = userHasDmRelays && recipientHasDmRelays
         )
     }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -127,6 +127,7 @@ fun UserProfileScreen(
     zapError: SharedFlow<String>? = null,
     zapInProgressIds: Set<String> = emptySet(),
     canPrivateZap: Boolean = false,
+    fetchDmRelays: (suspend (String) -> Boolean)? = null,
     ownLists: List<FollowSet> = emptyList(),
     onAddToList: ((String, String) -> Unit)? = null,
     onRemoveFromList: ((String, String) -> Unit)? = null,
@@ -182,6 +183,14 @@ fun UserProfileScreen(
     }
 
     if (zapTargetEvent != null) {
+        val zapRecipient = zapTargetEvent!!.pubkey
+        var resolvedCanPrivateZap by remember(zapRecipient) { mutableStateOf(canPrivateZap) }
+        if (!canPrivateZap && fetchDmRelays != null) {
+            LaunchedEffect(zapRecipient) {
+                val result = fetchDmRelays(zapRecipient)
+                if (result) resolvedCanPrivateZap = true
+            }
+        }
         ZapDialog(
             isWalletConnected = isWalletConnected,
             onDismiss = { zapTargetEvent = null },
@@ -191,7 +200,7 @@ fun UserProfileScreen(
                 onZap(event, amountMsats, message, isAnonymous, isPrivate)
             },
             onGoToWallet = onWallet,
-            canPrivateZap = canPrivateZap
+            canPrivateZap = resolvedCanPrivateZap
         )
     }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -51,13 +51,16 @@ import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.RelaySet
 import android.content.Context
+import com.wisp.app.nostr.Filter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 enum class FeedType { FOLLOWS, EXTENDED_FOLLOWS, RELAY, LIST }
 
@@ -495,6 +498,42 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
             )
             relayPool.sendToWriteRelays(ClientMessage.event(event))
         }
+    }
+
+    /**
+     * Fetch DM relays (kind 10050) for a pubkey if not already cached.
+     * Returns true if the pubkey has DM relays (from cache or fresh fetch).
+     */
+    suspend fun fetchDmRelaysIfMissing(pubkey: String): Boolean {
+        if (relayListRepo.hasDmRelays(pubkey)) return true
+
+        val subId = "zap_dm_relay_${pubkey.take(8)}"
+        val filter = Filter(
+            kinds = listOf(Nip51.KIND_DM_RELAYS),
+            authors = listOf(pubkey),
+            limit = 1
+        )
+        val reqMsg = ClientMessage.req(subId, filter)
+        for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+            relayPool.sendToRelayOrEphemeral(url, reqMsg, skipBadCheck = true)
+        }
+        relayPool.sendToAll(reqMsg)
+
+        val result = withTimeoutOrNull(4000L) {
+            relayPool.relayEvents.first { it.subscriptionId == subId }
+        }
+
+        val closeMsg = ClientMessage.close(subId)
+        for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+            relayPool.sendToRelay(url, closeMsg)
+        }
+        relayPool.sendToAll(closeMsg)
+
+        if (result != null) {
+            relayListRepo.updateDmRelaysFromEvent(result.event)
+        }
+
+        return relayListRepo.hasDmRelays(pubkey)
     }
 
     override fun onCleared() {


### PR DESCRIPTION
## Summary
- Private zap toggle was disabled unless the recipient's DM relays (kind 10050) were already in the LRU cache, which only happened if you'd previously opened a DM conversation with them
- Now when the zap dialog opens, if the recipient's DM relays aren't cached, a live fetch is triggered from indexer relays (4s timeout) and the toggle updates reactively via `LaunchedEffect`
- Applied to all 5 ZapDialog call sites: feed, thread, article, notifications, and user profile screens

## Test plan
- [ ] Open zap dialog on a note from someone you haven't DM'd — private toggle should enable after a brief moment if they have DM relays published
- [ ] Verify private zap toggle still works immediately when relays are already cached
- [ ] Verify private zap toggle stays disabled for users who genuinely have no DM relays
- [ ] Test from thread, article, notification, and profile screens