### PR TITLE
Add save draft button to compose screen

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -648,6 +648,10 @@ fun WispNavHost(
                 replyTo = replyTarget,
                 quoteTo = quoteTarget,
                 onBack = { navController.popBackStack() },
+                onSaveDraft = {
+                    composeViewModel.saveDraft(feedViewModel.relayPool, replyTarget, activeSigner)
+                    navController.popBackStack()
+                },
                 outboxRouter = feedViewModel.outboxRouter,
                 eventRepo = feedViewModel.eventRepo,
                 profileRepo = feedViewModel.profileRepo,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -106,6 +107,7 @@ fun ComposeScreen(
     replyTo: NostrEvent?,
     quoteTo: NostrEvent? = null,
     onBack: () -> Unit,
+    onSaveDraft: () -> Unit = {},
     outboxRouter: com.wisp.app.relay.OutboxRouter? = null,
     eventRepo: EventRepository? = null,
     profileRepo: ProfileRepository? = null,
@@ -405,7 +407,10 @@ fun ComposeScreen(
 
                 // Attach row with preview toggle
                 Spacer(Modifier.height(4.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     IconButton(
                         onClick = {
                             photoPickerLauncher.launch(
@@ -448,6 +453,16 @@ fun ComposeScreen(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
+                    }
+
+                    Spacer(Modifier.weight(1f))
+
+                    if (content.text.isNotBlank()) {
+                        TextButton(
+                            onClick = onSaveDraft
+                        ) {
+                            Text("Save draft")
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Adds a "Save draft" text button on the right side of the compose toolbar, opposite the existing media/NSFW/PoW icons
- Button appears only when the user has typed content, and triggers the same NIP-37 draft save that happens automatically on back navigation
- Makes draft saving more discoverable and explicit for users

## Test plan
- [ ] Open compose screen, verify no "Save draft" button when text field is empty
- [ ] Type some content, verify "Save draft" button appears on the right
- [ ] Tap "Save draft", verify it saves and navigates back
- [ ] Open drafts list, verify the saved draft appears