### PR TITLE
Fix: route video playback through Tor proxy

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     implementation(libs.bouncycastle)
     implementation(libs.media3.exoplayer)
     implementation(libs.media3.exoplayer.hls)
+    implementation(libs.media3.datasource.okhttp)
     implementation(libs.media3.ui)
     implementation(libs.biometric)
     implementation(libs.splashscreen)

--- a/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
@@ -1,5 +1,9 @@
 package com.wisp.app.relay
 
+import android.content.Context
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import okhttp3.Dispatcher
 import okhttp3.Dns
 import okhttp3.OkHttpClient
@@ -68,6 +72,14 @@ object HttpClientFactory {
             imageClient = it
             imageClientBuiltWithTor = torNow
         }
+    }
+
+    fun createExoPlayer(context: Context): ExoPlayer {
+        val client = createHttpClient(connectTimeoutSeconds = 10, readTimeoutSeconds = 30)
+        val dataSourceFactory = OkHttpDataSource.Factory(client)
+        return ExoPlayer.Builder(context)
+            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
+            .build()
     }
 
     fun createHttpClient(

--- a/app/src/main/kotlin/com/wisp/app/ui/component/FullScreenVideoPlayer.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/FullScreenVideoPlayer.kt
@@ -41,6 +41,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import com.wisp.app.R
+import com.wisp.app.relay.HttpClientFactory
 import com.wisp.app.util.MediaDownloader
 import kotlinx.coroutines.launch
 
@@ -60,7 +61,7 @@ fun FullScreenVideoPlayer(
         val scope = rememberCoroutineScope()
 
         val exoPlayer = remember(videoUrl) {
-            ExoPlayer.Builder(context).build().apply {
+            HttpClientFactory.createExoPlayer(context).apply {
                 setMediaItem(MediaItem.fromUri(Uri.parse(videoUrl)))
                 prepare()
                 seekTo(startPositionMs)

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import com.wisp.app.relay.HttpClientFactory
 import androidx.media3.ui.PlayerView
 import coil3.compose.AsyncImage
 import com.wisp.app.R
@@ -1112,7 +1113,7 @@ private fun ImageWithContextMenu(url: String, onFullScreen: () -> Unit) {
 private fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positionMs: Long) -> Unit) {
     val context = LocalContext.current
     val exoPlayer = remember(url) {
-        ExoPlayer.Builder(context).build().apply {
+        HttpClientFactory.createExoPlayer(context).apply {
             setMediaItem(MediaItem.fromUri(Uri.parse(url)))
             prepare()
             playWhenReady = false
@@ -1167,7 +1168,7 @@ private fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (position
 private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val exoPlayer = remember(url) {
-        ExoPlayer.Builder(context).build().apply {
+        HttpClientFactory.createExoPlayer(context).apply {
             setMediaItem(MediaItem.fromUri(Uri.parse(url)))
             prepare()
             playWhenReady = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ security-crypto = { group = "androidx.security", name = "security-crypto", versi
 bouncycastle = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
 media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
 media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3" }
+media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "media3" }
 media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
 biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }


### PR DESCRIPTION
## Summary
- ExoPlayer was using its default HTTP data source, completely bypassing the SOCKS proxy when Tor mode was enabled — leaking the user's real IP to video hosting servers
- Added `media3-datasource-okhttp` dependency and created `HttpClientFactory.createExoPlayer()` which configures ExoPlayer with a Tor-aware OkHttpClient
- Updated all 3 ExoPlayer creation sites (inline player, inline player with fullscreen, fullscreen player) to use the new factory

## Test plan
- [ ] Enable Tor mode, play a video, and verify traffic routes through Tor (video should load noticeably slower)
- [ ] Disable Tor mode, play a video, and verify it still loads normally
- [ ] Test fullscreen video playback with Tor enabled