### PR TITLE
Enable sentence capitalization in compose text field

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.content.contentReceiver
 import androidx.compose.foundation.content.hasMediaType
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.foundation.text.input.TextFieldLineLimits
@@ -360,6 +362,7 @@ fun ComposeScreen(
                             }
                         }),
                     enabled = enabled,
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
                     lineLimits = TextFieldLineLimits.MultiLine(),
                     textStyle = MaterialTheme.typography.bodyLarge.copy(
                         color = MaterialTheme.colorScheme.onSurface


### PR DESCRIPTION
## Summary
- Set `KeyboardCapitalization.Sentences` on the compose screen's `BasicTextField` so the keyboard auto-capitalizes the first letter of new sentences and after line breaks

## Test plan
- [ ] Open compose screen and verify the keyboard starts with shift enabled
- [ ] Type a sentence ending with `.` `?` or `!` and verify the next letter is auto-capitalized
- [ ] Press enter and verify the next line starts capitalized