### PR TITLE
feat: add media upload to DM conversations

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -323,7 +323,7 @@ fun WispNavHost(
     val currentRoute = navBackStackEntry?.destination?.route
 
     val nonAppRoutes = setOf(Routes.AUTH, Routes.LOADING, Routes.ONBOARDING_PROFILE, Routes.ONBOARDING_SUGGESTIONS, Routes.EXISTING_USER_ONBOARDING)
-    val hideBottomBarRoutes = nonAppRoutes
+    val hideBottomBarRoutes = nonAppRoutes + Routes.DM_CONVERSATION
     val socialGraphDiscoveryState by feedViewModel.extendedNetworkRepo.discoveryState.collectAsState()
     val socialGraphComputing = currentRoute == Routes.SOCIAL_GRAPH && (
         socialGraphDiscoveryState is com.wisp.app.repo.DiscoveryState.FetchingFollowLists ||

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
@@ -1,5 +1,8 @@
 package com.wisp.app.ui.screen
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -13,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -23,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -44,6 +49,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -81,16 +87,24 @@ fun DmConversationScreen(
     val messageText by viewModel.messageText.collectAsState()
     val sending by viewModel.sending.collectAsState()
     val sendError by viewModel.sendError.collectAsState()
+    val uploadProgress by viewModel.uploadProgress.collectAsState()
     val peerDelivery by viewModel.peerDeliveryRelays.collectAsState()
     val userDmRelays by viewModel.userDmRelays.collectAsState()
     val listState = rememberLazyListState()
     var showRelayInfo by remember { mutableStateOf(false) }
     val totalRelayCount = (peerDelivery.urls.size + userDmRelays.size)
+    val context = LocalContext.current
+
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia()
+    ) { uris ->
+        if (uris.isNotEmpty()) viewModel.uploadMedia(uris, context.contentResolver, signer)
+    }
 
     // Auto-scroll to bottom when new messages arrive
     LaunchedEffect(messages.size) {
         if (messages.isNotEmpty()) {
-            listState.animateScrollToItem(messages.size - 1)
+            listState.animateScrollToItem(0)
         }
     }
 
@@ -235,6 +249,7 @@ fun DmConversationScreen(
         Column(
             modifier = Modifier
                 .padding(padding)
+                .navigationBarsPadding()
                 .imePadding()
         ) {
             LazyColumn(
@@ -242,17 +257,10 @@ fun DmConversationScreen(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth(),
-                reverseLayout = false
+                reverseLayout = true
             ) {
                 var lastDateKey = ""
-                for (msg in messages) {
-                    val dateKey = dayKey(msg.createdAt)
-                    if (dateKey != lastDateKey) {
-                        lastDateKey = dateKey
-                        item(key = "date-$dateKey") {
-                            DateHeader(formatDateHeader(msg.createdAt))
-                        }
-                    }
+                for (msg in messages.reversed()) {
                     item(key = msg.id) {
                         val icons = msg.relayUrls.map { url ->
                             url to relayInfoRepo?.getIconUrl(url)
@@ -267,10 +275,29 @@ fun DmConversationScreen(
                             onNoteClick = onNoteClick
                         )
                     }
+                    val dateKey = dayKey(msg.createdAt)
+                    if (dateKey != lastDateKey) {
+                        lastDateKey = dateKey
+                        item(key = "date-$dateKey") {
+                            DateHeader(formatDateHeader(msg.createdAt))
+                        }
+                    }
                 }
             }
 
-            // Error banner for signing failures
+            // Upload progress banner
+            AnimatedVisibility(visible = uploadProgress != null) {
+                Text(
+                    text = uploadProgress ?: "",
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 4.dp)
+                )
+            }
+
+            // Error banner for signing/upload failures
             AnimatedVisibility(visible = sendError != null) {
                 Text(
                     text = sendError ?: "",
@@ -294,6 +321,21 @@ fun DmConversationScreen(
                     .fillMaxWidth()
                     .padding(8.dp)
             ) {
+                IconButton(
+                    onClick = {
+                        photoPickerLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageAndVideo)
+                        )
+                    },
+                    enabled = uploadProgress == null && !sending
+                ) {
+                    Icon(
+                        Icons.Outlined.Image,
+                        contentDescription = "Attach media",
+                        tint = if (uploadProgress == null && !sending) MaterialTheme.colorScheme.onSurfaceVariant
+                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                    )
+                }
                 OutlinedTextField(
                     value = messageText,
                     onValueChange = { viewModel.updateMessageText(it) },

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/DmConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/DmConversationViewModel.kt
@@ -1,7 +1,10 @@
 package com.wisp.app.viewmodel
 
+import android.content.ContentResolver
+import android.net.Uri
 import android.util.Log
 import android.app.Application
+import android.webkit.MimeTypeMap
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.wisp.app.nostr.ClientMessage
@@ -15,6 +18,7 @@ import com.wisp.app.nostr.hexToByteArray
 import com.wisp.app.nostr.toHex
 import com.wisp.app.relay.RelayConfig
 import com.wisp.app.relay.RelayPool
+import com.wisp.app.repo.BlossomRepository
 import com.wisp.app.repo.DmRepository
 import com.wisp.app.repo.KeyRepository
 import com.wisp.app.repo.RelayListRepository
@@ -34,6 +38,7 @@ data class PeerDeliveryRelays(
 
 class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
     private val keyRepo = KeyRepository(app)
+    private val blossomRepo = BlossomRepository(app, keyRepo.getPubkeyHex())
 
     private val _messages = MutableStateFlow<List<DmMessage>>(emptyList())
     val messages: StateFlow<List<DmMessage>> = _messages
@@ -46,6 +51,9 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _sendError = MutableStateFlow<String?>(null)
     val sendError: StateFlow<String?> = _sendError
+
+    private val _uploadProgress = MutableStateFlow<String?>(null)
+    val uploadProgress: StateFlow<String?> = _uploadProgress
 
     private val _peerDeliveryRelays = MutableStateFlow(PeerDeliveryRelays())
     val peerDeliveryRelays: StateFlow<PeerDeliveryRelays> = _peerDeliveryRelays
@@ -99,6 +107,28 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
 
     fun clearSendError() {
         _sendError.value = null
+    }
+
+    fun uploadMedia(uris: List<Uri>, contentResolver: ContentResolver, signer: NostrSigner? = null) {
+        viewModelScope.launch {
+            val total = uris.size
+            for ((index, uri) in uris.withIndex()) {
+                try {
+                    _uploadProgress.value = if (total > 1) "Uploading ${index + 1}/$total..." else "Uploading..."
+                    val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                        ?: throw Exception("Cannot read file")
+                    val mimeType = contentResolver.getType(uri) ?: "application/octet-stream"
+                    val ext = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) ?: "bin"
+                    val url = blossomRepo.uploadMedia(bytes, mimeType, ext, signer)
+                    val current = _messageText.value
+                    _messageText.value = if (current.isBlank()) url else "$current\n$url"
+                } catch (e: Exception) {
+                    _sendError.value = "Upload failed: ${e.message}"
+                    break
+                }
+            }
+            _uploadProgress.value = null
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add Blossom media upload support in DM conversations via an attach icon next to the text input
- Hide bottom navigation bar on the DM conversation screen for a cleaner chat experience
- Use reverse layout on the message list so messages stay pinned above the keyboard when it opens
- Add proper navigationBarsPadding to prevent the input from sitting behind the system nav bar

## Test plan
- [ ] Open a DM conversation and tap the image icon to upload media
- [ ] Verify uploaded URL is inserted into the message text field
- [ ] Verify the bottom nav bar is hidden in DM conversations
- [ ] Verify the text input sits above the system navigation bar
- [ ] Open the keyboard and verify messages stay visible (not covered)
- [ ] Send a message with an attached media URL and verify it delivers