### PR TITLE
fix: attribute reply counts to direct parent instead of thread root

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -100,8 +100,8 @@ class EventRouter(
                     }
                     1 -> {
                         eventRepo.cacheEvent(event)
-                        val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
-                        if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+                        val parentId = Nip10.getReplyTarget(event)
+                        if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
                     }
                     else -> eventRepo.cacheEvent(event)
                 }
@@ -121,8 +121,8 @@ class EventRouter(
             val myPubkey = getUserPubkey()
             if (myPubkey != null && event.kind == 1) {
                 eventRepo.cacheEvent(event)
-                val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
-                if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+                val parentId = Nip10.getReplyTarget(event)
+                if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
                 notifRepo.addEvent(event, myPubkey, replyToMyEvent = true)
                 if (eventRepo.getProfileData(event.pubkey) == null) {
                     metadataFetcher.addToPendingProfiles(event.pubkey)
@@ -141,8 +141,8 @@ class EventRouter(
         } else if (subscriptionId == "self-notes") {
             eventRepo.cacheEvent(event)
             if (event.kind == 1) {
-                val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
-                if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+                val parentId = Nip10.getReplyTarget(event)
+                if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
             }
         } else if (subscriptionId.startsWith("quote-")) {
             eventRepo.cacheEvent(event)
@@ -152,8 +152,8 @@ class EventRouter(
         } else if (subscriptionId.startsWith("reply-count-")) {
             if (event.kind == 1) {
                 eventRepo.cacheEvent(event)
-                val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
-                if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+                val parentId = Nip10.getReplyTarget(event)
+                if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
             }
         } else if (subscriptionId.startsWith("zap-count-") || subscriptionId.startsWith("zap-rcpt-")) {
             if (event.kind == 9735) {
@@ -183,8 +183,8 @@ class EventRouter(
                 }
                 1 -> {
                     eventRepo.cacheEvent(event)
-                    val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
-                    if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+                    val parentId = Nip10.getReplyTarget(event)
+                    if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
                 }
             }
             // Engagement events win the dedup race against "notif" subscription,

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/HashtagFeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/HashtagFeedViewModel.kt
@@ -92,9 +92,8 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
                             7 -> eventRepo.addEvent(relayEvent.event)
                             9735 -> eventRepo.addEvent(relayEvent.event)
                             1 -> {
-                                val rootId = Nip10.getRootId(relayEvent.event)
-                                    ?: Nip10.getReplyTarget(relayEvent.event)
-                                if (rootId != null) eventRepo.addReplyCount(rootId, relayEvent.event.id)
+                                val parentId = Nip10.getReplyTarget(relayEvent.event)
+                                if (parentId != null) eventRepo.addReplyCount(parentId, relayEvent.event.id)
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
@@ -199,8 +199,8 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
                         7 -> eventRepo.addEvent(event)
                         9735 -> eventRepo.addEvent(event)
                         1 -> {
-                            val rootId = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event)
-                            if (rootId != null) eventRepo.addReplyCount(rootId, event.id)
+                            val parentId = Nip10.getReplyTarget(event)
+                            if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
                         }
                     }
                     return@collect


### PR DESCRIPTION
## Summary
- Reply counts in threads were showing zero for all notes because `Nip10.getRootId()` was used to attribute counts, always pointing to the thread root instead of the direct parent
- Since `addReplyCount` deduplicates by reply event ID, when ThreadViewModel later tried to attribute counts correctly via `getReplyTarget()`, the calls were silently ignored
- Changed all call sites in EventRouter, UserProfileViewModel, and HashtagFeedViewModel to use `Nip10.getReplyTarget()` so counts go to the direct parent

## Test plan
- [ ] Open a thread with nested replies — verify reply counts show correctly on intermediate notes
- [ ] Check reply counts on root notes in the feed still increment
- [ ] Verify counts on user profile and hashtag feed screens