### PR TITLE
fix: improve DM loading for remote signer with decryption progress

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -926,7 +926,9 @@ fun WispNavHost(
             val pubkey = backStackEntry.arguments?.getString("pubkey") ?: return@composable
             val dmConvoViewModel: DmConversationViewModel = viewModel()
             LaunchedEffect(pubkey) {
+                feedViewModel.refreshDmsAndNotifications()
                 dmConvoViewModel.init(pubkey, feedViewModel.dmRepo, feedViewModel.relayListRepo, feedViewModel.relayPool)
+                activeSigner?.let { dmConvoViewModel.decryptPending(it, feedViewModel.muteRepo) }
             }
             val peerProfile = feedViewModel.eventRepo.getProfileData(pubkey)
             val userPubkey = feedViewModel.getUserPubkey()

--- a/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
@@ -39,6 +39,26 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
     private val _hasUnreadDms = MutableStateFlow(false)
     val hasUnreadDms: StateFlow<Boolean> = _hasUnreadDms
 
+    /** Number of gift wraps waiting to be decrypted (remote signer mode). */
+    private val _pendingDecryptCount = MutableStateFlow(0)
+    val pendingDecryptCount: StateFlow<Int> = _pendingDecryptCount
+
+    /** True while any coroutine is actively decrypting pending gift wraps. */
+    private val _decrypting = MutableStateFlow(false)
+    val decrypting: StateFlow<Boolean> = _decrypting
+    private val decryptingRefCount = java.util.concurrent.atomic.AtomicInteger(0)
+
+    fun markDecryptingStart() {
+        decryptingRefCount.incrementAndGet()
+        _decrypting.value = true
+    }
+
+    fun markDecryptingEnd() {
+        if (decryptingRefCount.decrementAndGet() <= 0) {
+            _decrypting.value = false
+        }
+    }
+
     fun addMessage(msg: DmMessage, peerPubkey: String) {
         synchronized(lock) {
             val existingMsgId = seenGiftWraps.get(msg.giftWrapId)
@@ -124,6 +144,16 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
             // Dedup by event id
             if (pendingGiftWraps.any { it.event.id == event.id }) return
             pendingGiftWraps.add(PendingGiftWrap(event, relayUrl))
+            _pendingDecryptCount.value = pendingGiftWraps.size
+        }
+    }
+
+    /** Pop a single pending gift wrap for decryption. Returns null when empty. */
+    fun takeNextPendingGiftWrap(): PendingGiftWrap? {
+        return synchronized(pendingLock) {
+            val wrap = pendingGiftWraps.removeFirstOrNull()
+            _pendingDecryptCount.value = pendingGiftWraps.size
+            wrap
         }
     }
 
@@ -131,6 +161,7 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
         return synchronized(pendingLock) {
             val copy = pendingGiftWraps.toList()
             pendingGiftWraps.clear()
+            _pendingDecryptCount.value = 0
             copy
         }
     }
@@ -148,9 +179,12 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
         }
         synchronized(pendingLock) {
             pendingGiftWraps.clear()
+            _pendingDecryptCount.value = 0
         }
         _conversationList.value = emptyList()
         _hasUnreadDms.value = false
+        _decrypting.value = false
+        decryptingRefCount.set(0)
         prefs?.edit()?.clear()?.apply()
     }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
@@ -90,6 +90,8 @@ fun DmConversationScreen(
     val uploadProgress by viewModel.uploadProgress.collectAsState()
     val peerDelivery by viewModel.peerDeliveryRelays.collectAsState()
     val userDmRelays by viewModel.userDmRelays.collectAsState()
+    val decrypting by viewModel.decrypting.collectAsState()
+    val pendingDecryptCount by viewModel.pendingDecryptCount.collectAsState()
     val listState = rememberLazyListState()
     var showRelayInfo by remember { mutableStateOf(false) }
     val totalRelayCount = (peerDelivery.urls.size + userDmRelays.size)
@@ -252,6 +254,30 @@ fun DmConversationScreen(
                 .navigationBarsPadding()
                 .imePadding()
         ) {
+            // Decrypting indicator (remote signer mode)
+            AnimatedVisibility(visible = decrypting) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .padding(horizontal = 16.dp, vertical = 6.dp)
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = if (pendingDecryptCount > 0) "Decrypting messages ($pendingDecryptCount remaining)..."
+                               else "Decrypting messages...",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
             LazyColumn(
                 state = listState,
                 modifier = Modifier

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/DmConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/DmConversationViewModel.kt
@@ -14,6 +14,7 @@ import com.wisp.app.nostr.Nip17
 import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.NostrSigner
 import com.wisp.app.nostr.SignerCancelledException
+import com.wisp.app.repo.MuteRepository
 import com.wisp.app.nostr.hexToByteArray
 import com.wisp.app.nostr.toHex
 import com.wisp.app.relay.RelayConfig
@@ -25,6 +26,7 @@ import com.wisp.app.repo.RelayListRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -60,6 +62,12 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _userDmRelays = MutableStateFlow<List<String>>(emptyList())
     val userDmRelays: StateFlow<List<String>> = _userDmRelays
+
+    private val _decrypting = MutableStateFlow(false)
+    val decrypting: StateFlow<Boolean> = _decrypting
+
+    private val _pendingDecryptCount = MutableStateFlow(0)
+    val pendingDecryptCount: StateFlow<Int> = _pendingDecryptCount
 
     private var peerPubkey: String = ""
     private var dmRepo: DmRepository? = null
@@ -97,6 +105,59 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch {
             dmRepository.conversationList.collect {
                 _messages.value = dmRepository.getConversation(peerPubkey)
+            }
+        }
+
+        // Mirror the repo's decrypting/pending state for the UI
+        viewModelScope.launch {
+            dmRepository.decrypting.collect { _decrypting.value = it }
+        }
+        viewModelScope.launch {
+            dmRepository.pendingDecryptCount.collect { _pendingDecryptCount.value = it }
+        }
+    }
+
+    /**
+     * Decrypt pending gift wraps using the remote signer.
+     * Shares the same pending queue as DmListViewModel — both screens can drive
+     * decryption and progress is visible from either.
+     */
+    fun decryptPending(signer: NostrSigner, muteRepo: MuteRepository? = null) {
+        val repo = dmRepo ?: return
+        val myPubkey = signer.pubkeyHex
+
+        viewModelScope.launch(Dispatchers.Default) {
+            if (repo.pendingDecryptCount.value == 0) return@launch
+
+            repo.markDecryptingStart()
+            try {
+                while (true) {
+                    val wrap = repo.takeNextPendingGiftWrap() ?: break
+                    try {
+                        val rumor = Nip17.unwrapGiftWrapRemote(signer, wrap.event) ?: continue
+                        val peerPubkey = if (rumor.pubkey == myPubkey) {
+                            rumor.tags.firstOrNull { it.size >= 2 && it[0] == "p" }?.get(1) ?: continue
+                        } else {
+                            rumor.pubkey
+                        }
+
+                        if (muteRepo?.isBlocked(peerPubkey) == true) continue
+
+                        val msg = DmMessage(
+                            id = "${wrap.event.id}:${rumor.createdAt}",
+                            senderPubkey = rumor.pubkey,
+                            content = rumor.content,
+                            createdAt = rumor.createdAt,
+                            giftWrapId = wrap.event.id,
+                            relayUrls = if (wrap.relayUrl.isNotEmpty()) setOf(wrap.relayUrl) else emptySet()
+                        )
+                        repo.addMessage(msg, peerPubkey)
+                    } catch (_: Exception) {
+                        // Individual wrap failed, continue with the rest
+                    }
+                }
+            } finally {
+                repo.markDecryptingEnd()
             }
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/DmListViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/DmListViewModel.kt
@@ -75,8 +75,11 @@ class DmListViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    private val _decrypting = MutableStateFlow(false)
-    val decrypting: StateFlow<Boolean> = _decrypting
+    val decrypting: StateFlow<Boolean>
+        get() = dmRepo?.decrypting ?: MutableStateFlow(false)
+
+    val pendingDecryptCount: StateFlow<Int>
+        get() = dmRepo?.pendingDecryptCount ?: MutableStateFlow(0)
 
     /**
      * Decrypt pending gift wraps using the remote signer, one at a time.
@@ -87,12 +90,12 @@ class DmListViewModel(app: Application) : AndroidViewModel(app) {
         val myPubkey = signer.pubkeyHex
 
         viewModelScope.launch(Dispatchers.Default) {
-            val pending = repo.takePendingGiftWraps()
-            if (pending.isEmpty()) return@launch
+            if (repo.pendingDecryptCount.value == 0) return@launch
 
-            _decrypting.value = true
+            repo.markDecryptingStart()
             try {
-                for (wrap in pending) {
+                while (true) {
+                    val wrap = repo.takeNextPendingGiftWrap() ?: break
                     try {
                         val rumor = Nip17.unwrapGiftWrapRemote(signer, wrap.event) ?: continue
                         val peerPubkey = if (rumor.pubkey == myPubkey) {
@@ -117,7 +120,7 @@ class DmListViewModel(app: Application) : AndroidViewModel(app) {
                     }
                 }
             } finally {
-                _decrypting.value = false
+                repo.markDecryptingEnd()
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Root cause**: Remote signer decryption requires two network round-trips per gift wrap. Previously, bulk decryption only ran from the DM list screen, so opening a conversation before it finished showed incomplete messages with no feedback.
- Moves decrypting/pending state to `DmRepository` so it's shared across both DM list and conversation screens
- Pops pending wraps one at a time instead of bulk-take, preventing loss on cancellation and allowing concurrent decryption from either screen
- Triggers decryption and DM subscription refresh when entering a conversation directly
- Shows an animated "Decrypting messages (N remaining)..." banner in the conversation screen

## Test plan
- [ ] Open DM conversation in remote signer mode — verify decrypting banner appears and messages load progressively
- [ ] Navigate back to DM list while decrypting — verify decryption continues and progress is visible
- [ ] Return to conversation — verify all messages present
- [ ] Test with local signer (no remote) — verify no decrypting banner appears
- [ ] Verify no regression in sending DMs