### PR TITLE
feat: add haptic feedback for social interactions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 
     <queries>

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -42,6 +42,7 @@ import com.wisp.app.repo.SigningMode
 import android.content.Context
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import com.wisp.app.ui.component.HapticHelper
 import com.wisp.app.ui.component.NotifBlipSound
 import com.wisp.app.ui.component.WispBottomBar
 import com.wisp.app.ui.component.ZapDialog
@@ -375,10 +376,41 @@ fun WispNavHost(
     DisposableEffect(Unit) {
         onDispose { notifBlipSound.release() }
     }
+    LaunchedEffect(Unit) { HapticHelper.init(context) }
     val currentNotifSoundEnabled by rememberUpdatedState(notifSoundEnabled)
     LaunchedEffect(Unit) {
         notificationsViewModel.notifReceived.collect {
-            if (currentNotifSoundEnabled) notifBlipSound.play()
+            if (currentNotifSoundEnabled) {
+                notifBlipSound.play()
+                HapticHelper.blip()
+            }
+        }
+    }
+    LaunchedEffect(Unit) {
+        notificationsViewModel.zapReceived.collect {
+            if (currentNotifSoundEnabled) HapticHelper.zapBuzz()
+        }
+    }
+    LaunchedEffect(Unit) {
+        notificationsViewModel.replyReceived.collect {
+            if (currentNotifSoundEnabled) HapticHelper.pulse()
+        }
+    }
+    LaunchedEffect(Unit) {
+        feedViewModel.reactionSent.collect { HapticHelper.blip() }
+    }
+    LaunchedEffect(Unit) {
+        feedViewModel.zapSuccess.collect { HapticHelper.zapBuzz() }
+    }
+    LaunchedEffect(Unit) {
+        var fired = false
+        feedViewModel.relayPool.broadcastState.collect { state ->
+            if (state != null && state.accepted > 0 && !fired) {
+                fired = true
+                HapticHelper.pulse()
+            } else if (state == null) {
+                fired = false
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/component/HapticHelper.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/HapticHelper.kt
@@ -1,0 +1,42 @@
+package com.wisp.app.ui.component
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+
+object HapticHelper {
+    private var vibrator: Vibrator? = null
+
+    fun init(context: Context) {
+        vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val manager = context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+            manager.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+    }
+
+    fun blip() {
+        val v = vibrator ?: return
+        v.vibrate(VibrationEffect.createOneShot(30, 80))
+    }
+
+    fun pulse() {
+        val v = vibrator ?: return
+        v.vibrate(VibrationEffect.createOneShot(80, 150))
+    }
+
+    fun zapBuzz() {
+        val v = vibrator ?: return
+        v.vibrate(
+            VibrationEffect.createWaveform(
+                longArrayOf(0, 60, 40, 100),
+                intArrayOf(0, 200, 0, 255),
+                -1
+            )
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -274,6 +274,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val zapInProgress: StateFlow<Set<String>> = socialActions.zapInProgress
     val zapSuccess: SharedFlow<String> = socialActions.zapSuccess
     val zapError: SharedFlow<String> = socialActions.zapError
+    val reactionSent: SharedFlow<Unit> = socialActions.reactionSent
 
     fun getUserPubkey(): String? = keyRepo.getPubkeyHex()
     fun resetNewNoteCount() = eventRepo.resetNewNoteCount()

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
@@ -66,6 +66,9 @@ class SocialActionManager(
     private val _zapError = MutableSharedFlow<String>(extraBufferCapacity = 8)
     val zapError: SharedFlow<String> = _zapError
 
+    private val _reactionSent = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
+    val reactionSent: SharedFlow<Unit> = _reactionSent
+
     fun toggleFollow(pubkey: String) {
         val s = getSigner() ?: return
         val currentList = contactRepo.getFollowList()
@@ -200,6 +203,7 @@ class SocialActionManager(
                     val msg = ClientMessage.event(reactionEvent)
                     outboxRouter.publishToInbox(msg, event.pubkey)
                     eventRepo.addEvent(reactionEvent)
+                    _reactionSent.tryEmit(Unit)
                 }
             } catch (_: Exception) {}
         }


### PR DESCRIPTION
## Summary
- Add three-tier vibration feedback: blip (30ms, reactions), pulse (80ms, replies/broadcast), and intense buzz (waveform, zaps)
- Notification haptics gated by existing sound toggle; user-initiated haptics (reaction sent, zap sent, broadcast accepted) always fire
- New `HapticHelper` singleton, `reactionSent` SharedFlow in SocialActionManager, VIBRATE permission

## Test plan
- [ ] Send a reaction — feel small blip
- [ ] Send a zap — feel intense buzz on success
- [ ] Publish a note — feel medium pulse when first relay accepts
- [ ] Receive reaction/reply/zap notifications — feel blip/pulse/buzz respectively
- [ ] Toggle notification sound off — notification haptics stop, user-initiated haptics still fire