### PR TITLE
fix: prevent NPE crash from OkHttp executor shutdown race

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
@@ -82,6 +82,19 @@ object HttpClientFactory {
             .build()
     }
 
+    fun safeShutdownClient(client: OkHttpClient) {
+        client.dispatcher.cancelAll()
+        client.connectionPool.evictAll()
+        client.dispatcher.executorService.shutdown()
+        try {
+            if (!client.dispatcher.executorService.awaitTermination(2, TimeUnit.SECONDS)) {
+                client.dispatcher.executorService.shutdownNow()
+            }
+        } catch (_: InterruptedException) {
+            client.dispatcher.executorService.shutdownNow()
+        }
+    }
+
     fun createHttpClient(
         connectTimeoutSeconds: Long = 10,
         readTimeoutSeconds: Long = 10,

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -1011,11 +1011,13 @@ class RelayPool {
         val dmUrls = allDmUrls ?: dmRelays.map { it.config.url }.toList()
         Log.d("RLC", "[Pool] swapClientAndReconnect — persistent=${configs.size} dm=${dmUrls.size}")
 
+        val oldClient = client
         disconnectAll()
         client = HttpClientFactory.createRelayClient()
         clientBuiltWithTor = TorManager.isEnabled()
         updateRelays(configs)
         updateDmRelays(dmUrls)
+        scope.launch { HttpClientFactory.safeShutdownClient(oldClient) }
     }
 
     fun disconnectAll() {

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayProber.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayProber.kt
@@ -161,8 +161,7 @@ object RelayProber {
             }
         }
 
-        client.dispatcher.executorService.shutdown()
-        client.connectionPool.evictAll()
+        HttpClientFactory.safeShutdownClient(client)
         return events
     }
 
@@ -208,10 +207,8 @@ object RelayProber {
             }
         }.awaitAll()
 
-        nip11Client.dispatcher.executorService.shutdown()
-        nip11Client.connectionPool.evictAll()
-        wsClient.dispatcher.executorService.shutdown()
-        wsClient.connectionPool.evictAll()
+        HttpClientFactory.safeShutdownClient(nip11Client)
+        HttpClientFactory.safeShutdownClient(wsClient)
 
         results
     }


### PR DESCRIPTION
## Summary
- Add `safeShutdownClient()` helper to `HttpClientFactory` that cancels in-flight calls, evicts connections, and awaits executor termination before shutdown — preventing NPE when OkHttp threads are still processing WebSocket close frames
- Replace raw `shutdown()` + `evictAll()` calls in `RelayProber` (2 locations) with the safe helper
- Fix leaked `OkHttpClient` in `RelayPool.swapClientAndReconnect()` by cleaning up the old client after creating the new one

## Test plan
- [x] Build and install on device
- [ ] Trigger relay probing (onboarding or relay settings) — no NPE crashes in logcat
- [ ] Toggle Tor on/off to exercise `swapClientAndReconnect()` — no thread leaks or crashes