### PR TITLE
Add client tag to outgoing events

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip57.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip57.kt
@@ -116,7 +116,8 @@ object Nip57 {
         amountMsats: Long,
         relayUrls: List<String>,
         lnurl: String,
-        message: String = ""
+        message: String = "",
+        extraTags: List<List<String>> = emptyList()
     ): NostrEvent {
         val tags = mutableListOf<List<String>>()
         tags.add(listOf("p", recipientPubkey))
@@ -124,6 +125,7 @@ object Nip57 {
         tags.add(listOf("relays") + relayUrls)
         tags.add(listOf("amount", amountMsats.toString()))
         tags.add(listOf("lnurl", lnurl))
+        tags.addAll(extraTags)
 
         return NostrEvent.create(
             privkey = senderPrivkey,
@@ -141,7 +143,8 @@ object Nip57 {
         amountMsats: Long,
         relayUrls: List<String>,
         lnurl: String,
-        message: String = ""
+        message: String = "",
+        extraTags: List<List<String>> = emptyList()
     ): NostrEvent {
         val tags = mutableListOf<List<String>>()
         tags.add(listOf("p", recipientPubkey))
@@ -149,6 +152,7 @@ object Nip57 {
         tags.add(listOf("relays") + relayUrls)
         tags.add(listOf("amount", amountMsats.toString()))
         tags.add(listOf("lnurl", lnurl))
+        tags.addAll(extraTags)
 
         return signer.signEvent(kind = 9734, content = message, tags = tags)
     }

--- a/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
@@ -16,4 +16,7 @@ class InterfacePreferences(context: Context) {
 
     fun getTheme(): String = prefs.getString("theme", "custom") ?: "custom"
     fun setTheme(theme: String) = prefs.edit().putString("theme", theme).apply()
+
+    fun isClientTagEnabled(): Boolean = prefs.getBoolean("client_tag_enabled", true)
+    fun setClientTagEnabled(enabled: Boolean) = prefs.edit().putBoolean("client_tag_enabled", enabled).apply()
 }

--- a/app/src/main/kotlin/com/wisp/app/repo/ZapSender.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/ZapSender.kt
@@ -11,7 +11,8 @@ class ZapSender(
     private val nwcRepo: NwcRepository,
     private val relayPool: RelayPool,
     private val relayListRepo: RelayListRepository,
-    private val httpClient: OkHttpClient
+    private val httpClient: OkHttpClient,
+    private val interfacePrefs: InterfacePreferences
 ) {
     var signer: NostrSigner? = null
 
@@ -55,6 +56,12 @@ class ZapSender(
                 .ifEmpty { relayPool.getRelayUrls().take(3) }
         }
 
+        val extraTags = if (interfacePrefs.isClientTagEnabled()) {
+            listOf(listOf("client", "Wisp"))
+        } else {
+            emptyList()
+        }
+
         val zapRequest = if (isAnonymous) {
             val throwaway = Keys.generate()
             Nip57.buildZapRequest(
@@ -65,7 +72,8 @@ class ZapSender(
                 amountMsats = amountMsats,
                 relayUrls = relayUrls,
                 lnurl = recipientLud16,
-                message = message
+                message = message,
+                extraTags = extraTags
             )
         } else {
             val s = signer
@@ -79,7 +87,8 @@ class ZapSender(
                     amountMsats = amountMsats,
                     relayUrls = relayUrls,
                     lnurl = recipientLud16,
-                    message = message
+                    message = message,
+                    extraTags = extraTags
                 )
                 keypair != null -> Nip57.buildZapRequest(
                     senderPrivkey = keypair.privkey,
@@ -89,7 +98,8 @@ class ZapSender(
                     amountMsats = amountMsats,
                     relayUrls = relayUrls,
                     lnurl = recipientLud16,
-                    message = message
+                    message = message,
+                    extraTags = extraTags
                 )
                 else -> return Result.failure(Exception("No signer or keypair available"))
             }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -147,6 +147,10 @@ fun PostCard(
     }
     var contentRevealed by remember { mutableStateOf(false) }
 
+    val clientName = remember(event.id) {
+        event.tags.firstOrNull { it.size >= 2 && it[0] == "client" }?.get(1)
+    }
+
     val hasReactionDetails = reactionDetails.isNotEmpty() || zapDetails.isNotEmpty() || repostDetails.isNotEmpty()
     var expandedDetails by remember { mutableStateOf(false) }
     var showTranslation by remember { mutableStateOf(true) }
@@ -684,6 +688,9 @@ fun PostCard(
                 }
                 if (displayIcons.isNotEmpty()) {
                     SeenOnSection(relayIcons = displayIcons, onRelayClick = onRelayClick)
+                }
+                if (clientName != null) {
+                    ClientTagSection(clientName = clientName)
                 }
             }
         }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
@@ -498,6 +498,37 @@ fun SeenOnSection(
     }
 }
 
+@Composable
+fun ClientTagSection(
+    clientName: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Sent with",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = clientName,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
 private fun formatSats(sats: Long): String {
     return when {
         sats >= 1_000_000 -> "${sats / 1_000_000}M sats"

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -65,6 +65,7 @@ fun InterfaceScreen(
 ) {
     var isLargeText by remember { mutableStateOf(interfacePrefs.isLargeText()) }
     var newNotesHidden by remember { mutableStateOf(interfacePrefs.isNewNotesButtonHidden()) }
+    var clientTagEnabled by remember { mutableStateOf(interfacePrefs.isClientTagEnabled()) }
     var selectedTheme by remember { mutableStateOf(interfacePrefs.getTheme()) }
     var isCustomTheme by remember { mutableStateOf(selectedTheme == "custom") }
 
@@ -274,6 +275,36 @@ fun InterfaceScreen(
                         newNotesHidden = it
                         interfacePrefs.setNewNotesButtonHidden(it)
                         onChanged()
+                    }
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Client Tag section
+            Text(
+                text = "Client Tag",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Tag notes with Wisp", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Include a tag identifying Wisp as the client. This is visible to others.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = clientTagEnabled,
+                    onCheckedChange = {
+                        clientTagEnabled = it
+                        interfacePrefs.setClientTagEnabled(it)
                     }
                 )
             }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -26,6 +26,7 @@ import com.wisp.app.repo.KeyRepository
 import com.wisp.app.repo.MentionCandidate
 import com.wisp.app.repo.MentionSearchRepository
 import com.wisp.app.repo.EventRepository
+import com.wisp.app.repo.InterfacePreferences
 import com.wisp.app.repo.ProfileRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -40,6 +41,7 @@ private val BARE_BECH32_REGEX = Regex("(?<!nostr:)(?<![a-z0-9])((note1|nevent1|n
 
 class ComposeViewModel(app: Application, private val savedStateHandle: SavedStateHandle) : AndroidViewModel(app) {
     private val keyRepo = KeyRepository(app)
+    private val interfacePrefs = InterfacePreferences(app)
     val blossomRepo = BlossomRepository(app, keyRepo.getPubkeyHex())
 
     fun reloadBlossomRepo() {
@@ -359,6 +361,10 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             Nip18.appendNoteUri(content, quoteTo.id, relayHints, quoteTo.pubkey)
         } else {
             content
+        }
+
+        if (interfacePrefs.isClientTagEnabled()) {
+            tags.add(listOf("client", "Wisp"))
         }
 
         // Hand off to PowManager for background mining if PoW enabled

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -38,6 +38,7 @@ import com.wisp.app.repo.PinRepository
 import com.wisp.app.repo.ProfileRepository
 import com.wisp.app.repo.NwcRepository
 import com.wisp.app.repo.CustomEmojiRepository
+import com.wisp.app.repo.InterfacePreferences
 import com.wisp.app.repo.PowPreferences
 import com.wisp.app.repo.ZapPreferences
 import com.wisp.app.repo.RelayHintStore
@@ -186,8 +187,9 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
+    val interfacePrefs = InterfacePreferences(app)
     val nwcRepo = NwcRepository(app, relayPool, pubkeyHex)
-    val zapSender = ZapSender(keyRepo, nwcRepo, relayPool, relayListRepo, HttpClientFactory.createRelayClient())
+    val zapSender = ZapSender(keyRepo, nwcRepo, relayPool, relayListRepo, HttpClientFactory.createRelayClient(), interfacePrefs)
     val powManager = PowManager(powPrefs, relayPool, outboxRouter, eventRepo, viewModelScope)
 
     // -- Manager classes --
@@ -210,7 +212,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
 
     val socialActions: SocialActionManager = SocialActionManager(
         relayPool, outboxRouter, eventRepo, contactRepo, muteRepo, notifRepo, dmRepo,
-        pinRepo, deletedEventsRepo, nwcRepo, customEmojiRepo, zapSender, powPrefs, viewModelScope,
+        pinRepo, deletedEventsRepo, nwcRepo, customEmojiRepo, zapSender, powPrefs, interfacePrefs, viewModelScope,
         getSigner = { signer },
         getUserPubkey = { getUserPubkey() }
     )

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
@@ -24,6 +24,7 @@ import com.wisp.app.repo.NwcRepository
 import com.wisp.app.repo.PinRepository
 import com.wisp.app.repo.CustomEmojiRepository
 import com.wisp.app.repo.DeletedEventsRepository
+import com.wisp.app.repo.InterfacePreferences
 import com.wisp.app.repo.PowPreferences
 import com.wisp.app.repo.ZapSender
 import kotlinx.coroutines.CoroutineScope
@@ -53,6 +54,7 @@ class SocialActionManager(
     private val customEmojiRepo: CustomEmojiRepository,
     private val zapSender: ZapSender,
     private val powPrefs: PowPreferences,
+    private val interfacePrefs: InterfacePreferences,
     private val scope: CoroutineScope,
     private val getSigner: () -> NostrSigner?,
     private val getUserPubkey: () -> String?
@@ -138,7 +140,10 @@ class SocialActionManager(
         scope.launch {
             try {
                 val hint = outboxRouter.getRelayHint(event.pubkey)
-                val tags = Nip18.buildRepostTags(event, hint)
+                val tags = Nip18.buildRepostTags(event, hint).toMutableList()
+                if (interfacePrefs.isClientTagEnabled()) {
+                    tags.add(listOf("client", "Wisp"))
+                }
                 val repostEvent = s.signEvent(kind = 6, content = event.toJson(), tags = tags)
                 val msg = ClientMessage.event(repostEvent)
                 outboxRouter.publishToInbox(msg, event.pubkey)
@@ -178,6 +183,10 @@ class SocialActionManager(
                         }
                     } else {
                         Nip25.buildReactionTags(event)
+                    }
+
+                    if (interfacePrefs.isClientTagEnabled()) {
+                        tags = tags + listOf(listOf("client", "Wisp"))
                     }
 
                     val createdAt: Long


### PR DESCRIPTION
## Summary
- Add `["client", "Wisp"]` tag to notes/replies (kind 1), reactions (kind 7), reposts (kind 6), and zap requests (kind 9734)
- Add toggle in Interface settings ("Tag notes with Wisp") — on by default, can be disabled for privacy
- Display "Sent with [client]" in note detail view alongside relay info

## Test plan
- [ ] Publish a note — verify `["client", "Wisp"]` in event JSON
- [ ] Reply to a note — verify client tag present
- [ ] React to a note — verify client tag on kind 7
- [ ] Repost a note — verify client tag on kind 6
- [ ] Zap a note — verify client tag on kind 9734
- [ ] Toggle off in Interface settings — verify none of the above include client tag
- [ ] View a note with a client tag in thread view — verify "Sent with Wisp" appears in detail section