### PR TITLE
Add media loading and video autoplay settings

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/wisp/app/MainActivity.kt
@@ -12,9 +12,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import com.wisp.app.repo.InterfacePreferences
+import com.wisp.app.ui.component.LocalMediaSettings
+import com.wisp.app.ui.component.MediaSettings
 import com.wisp.app.ui.theme.WispTheme
 
 class MainActivity : FragmentActivity() {
@@ -29,6 +32,12 @@ class MainActivity : FragmentActivity() {
             var accentColor by remember { mutableStateOf(Color(interfacePrefs.getAccentColor())) }
             var isLargeText by remember { mutableStateOf(interfacePrefs.isLargeText()) }
             var themeName by remember { mutableStateOf(interfacePrefs.getTheme()) }
+            var mediaSettings by remember {
+                mutableStateOf(MediaSettings(
+                    autoLoadMedia = interfacePrefs.isAutoLoadMedia(),
+                    videoAutoPlay = interfacePrefs.isVideoAutoPlay()
+                ))
+            }
 
             LaunchedEffect(isDarkTheme) {
                 enableEdgeToEdge(
@@ -46,20 +55,26 @@ class MainActivity : FragmentActivity() {
             }
 
             WispTheme(isDarkTheme = isDarkTheme, accentColor = accentColor, isLargeText = isLargeText, themeName = themeName) {
-                WispNavHost(
-                    isDarkTheme = isDarkTheme,
-                    onToggleTheme = {
-                        isDarkTheme = !isDarkTheme
-                        prefs.edit().putBoolean("dark_theme", isDarkTheme).apply()
-                    },
-                    accentColor = accentColor,
-                    isLargeText = isLargeText,
-                    onInterfaceChanged = {
-                        accentColor = Color(interfacePrefs.getAccentColor())
-                        isLargeText = interfacePrefs.isLargeText()
-                        themeName = interfacePrefs.getTheme()
-                    }
-                )
+                CompositionLocalProvider(LocalMediaSettings provides mediaSettings) {
+                    WispNavHost(
+                        isDarkTheme = isDarkTheme,
+                        onToggleTheme = {
+                            isDarkTheme = !isDarkTheme
+                            prefs.edit().putBoolean("dark_theme", isDarkTheme).apply()
+                        },
+                        accentColor = accentColor,
+                        isLargeText = isLargeText,
+                        onInterfaceChanged = {
+                            accentColor = Color(interfacePrefs.getAccentColor())
+                            isLargeText = interfacePrefs.isLargeText()
+                            themeName = interfacePrefs.getTheme()
+                            mediaSettings = MediaSettings(
+                                autoLoadMedia = interfacePrefs.isAutoLoadMedia(),
+                                videoAutoPlay = interfacePrefs.isVideoAutoPlay()
+                            )
+                        }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
@@ -19,4 +19,10 @@ class InterfacePreferences(context: Context) {
 
     fun isClientTagEnabled(): Boolean = prefs.getBoolean("client_tag_enabled", true)
     fun setClientTagEnabled(enabled: Boolean) = prefs.edit().putBoolean("client_tag_enabled", enabled).apply()
+
+    fun isAutoLoadMedia(): Boolean = prefs.getBoolean("auto_load_media", true)
+    fun setAutoLoadMedia(enabled: Boolean) = prefs.edit().putBoolean("auto_load_media", enabled).apply()
+
+    fun isVideoAutoPlay(): Boolean = prefs.getBoolean("video_auto_play", true)
+    fun setVideoAutoPlay(enabled: Boolean) = prefs.edit().putBoolean("video_auto_play", enabled).apply()
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -89,12 +89,22 @@ import com.wisp.app.nostr.NostrUriData
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.Nip05Repository
 import com.wisp.app.util.MediaDownloader
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.PlayArrow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.Request
 import org.json.JSONObject
 import java.net.URLEncoder
+
+data class MediaSettings(
+    val autoLoadMedia: Boolean = true,
+    val videoAutoPlay: Boolean = true
+)
+
+val LocalMediaSettings = compositionLocalOf { MediaSettings() }
 
 /**
  * Bundles event-generic action callbacks so quoted notes can render
@@ -1085,10 +1095,43 @@ private fun formatQuotedTimestamp(epoch: Long): String {
 @kotlin.OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ImageWithContextMenu(url: String, onFullScreen: () -> Unit) {
+    val autoLoad = LocalMediaSettings.current.autoLoadMedia
+    var loaded by remember { mutableStateOf(autoLoad) }
     var showMenu by remember { mutableStateOf(false) }
     val context = LocalContext.current
     val clipboardManager = LocalClipboardManager.current
     val scope = rememberCoroutineScope()
+
+    if (!loaded) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { loaded = true },
+            color = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Image,
+                    contentDescription = "Load image",
+                    modifier = Modifier.size(40.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Tap to load",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+        return
+    }
 
     Box {
         AsyncImage(
@@ -1128,6 +1171,40 @@ private fun ImageWithContextMenu(url: String, onFullScreen: () -> Unit) {
 @OptIn(UnstableApi::class)
 @Composable
 private fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positionMs: Long) -> Unit) {
+    val mediaSettings = LocalMediaSettings.current
+    var loaded by remember { mutableStateOf(mediaSettings.autoLoadMedia) }
+
+    if (!loaded) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { loaded = true },
+            color = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.PlayArrow,
+                    contentDescription = "Load video",
+                    modifier = Modifier.size(48.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Tap to load",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+        return
+    }
+
     val context = LocalContext.current
     val view = LocalView.current
     var videoAspectRatio by remember { mutableFloatStateOf(16f / 9f) }
@@ -1181,7 +1258,7 @@ private fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (position
                 val totalHeight = bounds.height
                 val visibleFraction = if (totalHeight > 0) visibleHeight / totalHeight else 0f
                 if (visibleFraction > 0.5f) {
-                    if (!exoPlayer.isPlaying && !userPaused) exoPlayer.play()
+                    if (mediaSettings.videoAutoPlay && !exoPlayer.isPlaying && !userPaused) exoPlayer.play()
                 } else {
                     if (exoPlayer.isPlaying) exoPlayer.pause()
                     userPaused = false
@@ -1256,6 +1333,40 @@ private fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (position
 @OptIn(UnstableApi::class)
 @Composable
 private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
+    val mediaSettings = LocalMediaSettings.current
+    var loaded by remember { mutableStateOf(mediaSettings.autoLoadMedia) }
+
+    if (!loaded) {
+        Surface(
+            modifier = modifier
+                .heightIn(max = 500.dp)
+                .aspectRatio(16f / 9f)
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { loaded = true },
+            color = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.PlayArrow,
+                    contentDescription = "Load video",
+                    modifier = Modifier.size(48.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Tap to load",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+        return
+    }
+
     val context = LocalContext.current
     val view = LocalView.current
     var videoAspectRatio by remember { mutableFloatStateOf(16f / 9f) }
@@ -1308,7 +1419,7 @@ private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
                 val totalHeight = bounds.height
                 val visibleFraction = if (totalHeight > 0) visibleHeight / totalHeight else 0f
                 if (visibleFraction > 0.5f) {
-                    if (!exoPlayer.isPlaying && !userPaused) exoPlayer.play()
+                    if (mediaSettings.videoAutoPlay && !exoPlayer.isPlaying && !userPaused) exoPlayer.play()
                 } else {
                     if (exoPlayer.isPlaying) exoPlayer.pause()
                     userPaused = false

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -66,6 +66,8 @@ fun InterfaceScreen(
     var isLargeText by remember { mutableStateOf(interfacePrefs.isLargeText()) }
     var newNotesHidden by remember { mutableStateOf(interfacePrefs.isNewNotesButtonHidden()) }
     var clientTagEnabled by remember { mutableStateOf(interfacePrefs.isClientTagEnabled()) }
+    var autoLoadMedia by remember { mutableStateOf(interfacePrefs.isAutoLoadMedia()) }
+    var videoAutoPlay by remember { mutableStateOf(interfacePrefs.isVideoAutoPlay()) }
     var selectedTheme by remember { mutableStateOf(interfacePrefs.getTheme()) }
     var isCustomTheme by remember { mutableStateOf(selectedTheme == "custom") }
 
@@ -274,6 +276,59 @@ fun InterfaceScreen(
                     onCheckedChange = {
                         newNotesHidden = it
                         interfacePrefs.setNewNotesButtonHidden(it)
+                        onChanged()
+                    }
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Media section
+            Text(
+                text = "Media",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Auto-load media", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Automatically download images and videos in notes. When off, tap to load.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = autoLoadMedia,
+                    onCheckedChange = {
+                        autoLoadMedia = it
+                        interfacePrefs.setAutoLoadMedia(it)
+                        onChanged()
+                    }
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Video autoplay", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Automatically play videos when they scroll into view",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = videoAutoPlay,
+                    onCheckedChange = {
+                        videoAutoPlay = it
+                        interfacePrefs.setVideoAutoPlay(it)
                         onChanged()
                     }
                 )


### PR DESCRIPTION
## Summary
- Adds two new toggles under a "Media" section in Interface Settings: **Auto-load media** and **Video autoplay**
- When auto-load is off, images and videos show a styled tap-to-load placeholder instead of downloading automatically
- When video autoplay is off, videos load but don't auto-play when scrolling into view
- Uses `CompositionLocal` (`LocalMediaSettings`) to provide settings down the composable tree, avoiding parameter threading through every call site
- Both default to `true`, preserving current behavior

## Test plan
- [ ] Toggle "Auto-load media" off — images/videos in notes show placeholder with icon, tap to load
- [ ] Toggle "Video autoplay" off — videos load but don't play until user taps play
- [ ] Both toggles on — current behavior, no regression
- [ ] Settings persist across app restart