### PR TITLE
fix: prevent WebSocket NPE from cancel/send race and deflate mismatch

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,7 +23,9 @@
 -keep class org.bouncycastle.** { *; }
 -dontwarn org.bouncycastle.**
 
-# OkHttp
+# OkHttp — keep class names so crash stack traces are readable
+-keep class okhttp3.** { *; }
+-keep class okio.** { *; }
 -dontwarn okhttp3.internal.platform.**
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**

--- a/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/HttpClientFactory.kt
@@ -43,11 +43,16 @@ object HttpClientFactory {
             .connectTimeout(connectTimeout, TimeUnit.SECONDS)
             .pingInterval(30, TimeUnit.SECONDS)
             .readTimeout(0, TimeUnit.MILLISECONDS)
-            .addNetworkInterceptor { chain ->
-                val response = chain.proceed(chain.request())
-                response.newBuilder()
+            // Strip permessage-deflate from the REQUEST so the server never negotiates
+            // compression. The previous approach (network interceptor stripping the
+            // response header) left the request header intact — servers that support
+            // deflate would negotiate it, then send compressed frames to a client with
+            // no inflater, causing ProtocolException and a reconnect loop.
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
                     .removeHeader("Sec-WebSocket-Extensions")
                     .build()
+                chain.proceed(request)
             }
 
         if (isTor) {

--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -200,9 +200,8 @@ class Relay(
         val ws = webSocket
         if (ws != null && isConnected) {
             onBytesSent?.invoke(config.url, message.length)
-            // OkHttp's MessageDeflater (permessage-deflate) is not thread-safe.
-            // Concurrent ws.send() calls crash with "Failed requirement" in deflate().
-            // Serialize all writes to the same WebSocket.
+            // Serialize all writes — OkHttp's WebSocket writer is not thread-safe.
+            // Also prevents cancel() (which acquires sendLock) from racing with send().
             synchronized(sendLock) {
                 return ws.send(message)
             }
@@ -250,11 +249,12 @@ class Relay(
             webSocket = null
             pendingReconnect?.cancel(false)
             pendingReconnect = null
-            // Always cancel() for immediate TCP teardown. Graceful close(1000) leaves
-            // OkHttp's reader thread alive waiting for the server's close frame — if we
-            // reconnect immediately (e.g. forceReconnectAll), the stale reader can crash
-            // with ArrayIndexOutOfBoundsException in Okio's buffer (size=0, byteCount=8192).
-            ws?.cancel()
+            // Acquire sendLock before cancel() to ensure no in-flight send() or
+            // drainPendingMessages() is using the WebSocket when we tear it down.
+            // Without this, cancel() can null OkHttp's internal writer mid-send → NPE.
+            if (ws != null) {
+                synchronized(sendLock) { ws.cancel() }
+            }
         }
     }
 
@@ -268,7 +268,9 @@ class Relay(
             webSocket = null
             pendingReconnect?.cancel(false)
             pendingReconnect = null
-            ws?.cancel()
+            if (ws != null) {
+                synchronized(sendLock) { ws.cancel() }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- **Cancel/send race fix**: `disconnect()` and `forceDisconnect()` now acquire `sendLock` before calling `ws.cancel()`, preventing OkHttp's internal writer from being nulled while `send()` or `drainPendingMessages()` is in-flight
- **Deflate fix**: Moved `Sec-WebSocket-Extensions` header stripping from a network interceptor (response) to an application interceptor (request), so servers never negotiate permessage-deflate — the previous approach left the request header intact, causing ProtocolException reconnect loops on deflate-capable relays
- **ProGuard keep rules**: Added `-keep` rules for `okhttp3.**` and `okio.**` so future crash stack traces show real class/method names instead of obfuscated symbols

## Test plan
- [ ] Verify relay connections still establish and receive events normally
- [ ] Verify disconnect/reconnect cycles (background/foreground, Tor toggle) don't crash
- [ ] Verify release build crash reports show readable OkHttp stack traces
- [ ] Monitor for NPE crash reports in 0.7.1+