### PR TITLE
fix: add missing params key to NWC get_balance request

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip47.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip47.kt
@@ -143,6 +143,7 @@ object Nip47 {
         val content = when (request) {
             is NwcRequest.GetBalance -> buildJsonObject {
                 put("method", "get_balance")
+                put("params", buildJsonObject {})
             }
             is NwcRequest.PayInvoice -> buildJsonObject {
                 put("method", "pay_invoice")


### PR DESCRIPTION
## Summary
- NIP-47 requires the `params` key in all NWC request JSON payloads, even when empty
- The `GetBalance` request was the only request type omitting it, producing `{"method": "get_balance"}` instead of `{"method": "get_balance", "params": {}}`
- This caused `KeyError: 'params'` crashes on strict wallet backends (e.g. Electrum)

## Test plan
- [ ] Build with `./gradlew assembleDebug`
- [ ] Connect to a wallet that previously failed (e.g. Electrum) and verify `get_balance` succeeds
- [ ] Verify other NWC operations (pay_invoice, make_invoice, list_transactions) still work