### PR TITLE
fix: prevent nostr: prefix on bech32 IDs inside URLs and improve relay errors

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -163,9 +163,9 @@ class Relay(
                         _connectionErrors.tryEmit(ConsoleLogEntry(
                             relayUrl = config.url,
                             type = ConsoleLogType.CONN_FAILURE,
-                            message = t.message ?: "Unknown error"
+                            message = t.message ?: t.javaClass.simpleName
                         ))
-                        _failures.tryEmit(RelayFailure(config.url, response?.code, t.message ?: "Unknown error"))
+                        _failures.tryEmit(RelayFailure(config.url, response?.code, t.message ?: t.javaClass.simpleName))
                         reconnect()
                     }
                 }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -397,7 +397,7 @@ class RelayPool {
             }
         }
         scope.launch(parentJob) {
-            relay.connectionErrors.collect { addConsoleEntry(it) }
+            relay.connectionErrors.collect { if (appIsActive) addConsoleEntry(it) }
         }
         scope.launch(parentJob) {
             relay.connectionState.collect { connected ->

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -36,8 +36,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
-// Matches bare bech32 IDs not already preceded by "nostr:"
-private val BARE_BECH32_REGEX = Regex("(?<!nostr:)(?<![a-z0-9])((note1|nevent1|npub1|nprofile1)[a-z0-9]{10,})")
+// Matches bare bech32 IDs not already preceded by "nostr:" or embedded in a URL
+private val BARE_BECH32_REGEX = Regex("(?<!nostr:)(?<![a-z0-9/.:#])((note1|nevent1|npub1|nprofile1)[a-z0-9]{10,})")
 
 class ComposeViewModel(app: Application, private val savedStateHandle: SavedStateHandle) : AndroidViewModel(app) {
     private val keyRepo = KeyRepository(app)


### PR DESCRIPTION
## Summary
- Fix bare bech32 auto-prefix regex incorrectly matching `npub1`/`note1`/`nevent1`/`nprofile1` strings embedded in URLs (e.g. blossom band hostnames like `npub1xxx.blossom.band`), which caused published content to contain mangled URLs like `https://nostr:npub1xxx.blossom.band/...`
- Use exception class name instead of generic "Unknown error" for relay connection failures
- Suppress relay connection error console logs when app is backgrounded

## Test plan
- [ ] Compose a note containing a blossom URL with an npub in the hostname and verify the URL is not modified on publish
- [ ] Paste a bare npub/note ID and verify it still gets auto-prefixed with `nostr:`
- [ ] Verify relay connection errors show the actual exception type instead of "Unknown error"
- [ ] Background the app and verify relay errors don't flood the console log