### PR TITLE
feat: add trending feed with metric and timeframe filters

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -843,6 +843,60 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         }
     }
 
+    fun addTrendingFeedEvent(event: NostrEvent) {
+        if (event.created_at > System.currentTimeMillis() / 1000 + 30) return
+        if (muteRepo?.isBlocked(event.pubkey) == true) return
+        if (deletedEventsRepo?.isDeleted(event.id) == true) return
+
+        when (event.kind) {
+            1 -> {
+                val isReply = event.tags.any { it.size >= 2 && it[0] == "e" }
+                if (!isReply) {
+                    eventCache.put(event.id, event)
+                    relayHintStore?.extractHintsFromTags(event)
+                    trendingFeedAppend(event)
+                }
+            }
+            30023 -> {
+                eventCache.put(event.id, event)
+                relayHintStore?.extractHintsFromTags(event)
+                trendingFeedAppend(event)
+            }
+            6 -> {
+                if (event.content.isNotBlank()) {
+                    try {
+                        val inner = NostrEvent.fromJson(event.content)
+                        if (muteRepo?.isBlocked(inner.pubkey) == true) return
+                        if (muteRepo?.containsMutedWord(inner.content) == true) return
+                        val authors = repostAuthors.get(inner.id)
+                            ?: mutableSetOf<String>().also { repostAuthors.put(inner.id, it) }
+                        authors.add(event.pubkey)
+                        if (event.pubkey == currentUserPubkey) {
+                            userReposts.put(inner.id, true)
+                        }
+                        repostDirty = true
+                        markVersionDirty()
+                        val isReply = inner.tags.any { it.size >= 2 && it[0] == "e" }
+                        if (!isReply) {
+                            eventCache.put(inner.id, inner)
+                            relayHintStore?.extractHintsFromTags(inner)
+                            feedSortTime.put(inner.id, event.created_at)
+                            trendingFeedAppend(inner)
+                        }
+                    } catch (_: Exception) {}
+                }
+            }
+        }
+    }
+
+    private fun trendingFeedAppend(event: NostrEvent) {
+        synchronized(relayFeedList) {
+            if (!relayFeedIds.add(event.id)) return
+            relayFeedList.add(event)  // append to end — preserves relay ordering
+        }
+        relayFeedInserted.trySend(Unit)
+    }
+
     private fun relayFeedBinaryInsert(event: NostrEvent, sortTime: Long = event.created_at) {
         synchronized(relayFeedList) {
             if (!relayFeedIds.add(event.id)) return

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -75,6 +75,9 @@ import com.wisp.app.ui.component.ZapDialog
 import com.wisp.app.repo.RelayInfoRepository
 import com.wisp.app.relay.ScoredRelay
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -85,7 +88,14 @@ import com.wisp.app.viewmodel.FeedViewModel
 import com.wisp.app.viewmodel.InitLoadingState
 import com.wisp.app.viewmodel.PowStatus
 import com.wisp.app.viewmodel.RelayFeedStatus
+import com.wisp.app.viewmodel.TrendingMetric
+import com.wisp.app.viewmodel.TrendingTimeframe
+import com.wisp.app.viewmodel.buildTrendingRelayUrl
+import androidx.compose.material.icons.automirrored.outlined.Reply
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.CurrencyBitcoin
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.ui.draw.clip
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -189,6 +199,8 @@ fun FeedScreen(
     val newNotesButtonHidden by viewModel.newNotesButtonHidden.collectAsState()
     val initLoadingState by viewModel.initLoadingState.collectAsState()
     val relayFeedStatus by viewModel.relayFeedStatus.collectAsState()
+    val trendingMetric by viewModel.trendingMetric.collectAsState()
+    val trendingTimeframe by viewModel.trendingTimeframe.collectAsState()
     val zapInProgress by viewModel.zapInProgress.collectAsState()
     val setListedIds by viewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
     val bookmarkedIds by viewModel.bookmarkRepo.bookmarkedIds.collectAsState()
@@ -474,6 +486,7 @@ fun FeedScreen(
                                             FeedType.LIST -> if (selectedList != null) {
                                                 selectedList!!.name
                                             } else "List"
+                                            FeedType.TRENDING -> "Trending"
                                         }
                                         Text(
                                             feedLabel,
@@ -535,6 +548,16 @@ fun FeedScreen(
                                             showListPicker = true
                                         },
                                         trailingIcon = if (feedType == FeedType.LIST) {{
+                                            Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                                        }} else null
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text("Trending") },
+                                        onClick = {
+                                            showFeedTypeDropdown = false
+                                            viewModel.setFeedType(FeedType.TRENDING)
+                                        },
+                                        trailingIcon = if (feedType == FeedType.TRENDING) {{
                                             Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
                                         }} else null
                                     )
@@ -662,6 +685,14 @@ fun FeedScreen(
                     relayFeedStatus = relayFeedStatus
                 )
             }
+            if (feedType == FeedType.TRENDING) {
+                TrendingFilterBar(
+                    metric = trendingMetric,
+                    timeframe = trendingTimeframe,
+                    onMetricChange = { viewModel.setTrendingMetric(it) },
+                    onTimeframeChange = { viewModel.setTrendingTimeframe(it) }
+                )
+            }
             Box(
                 modifier = Modifier.fillMaxSize()
             ) {
@@ -709,6 +740,13 @@ fun FeedScreen(
                                     status = relayFeedStatus,
                                     relayUrl = selectedRelay ?: "",
                                     onRetry = { viewModel.retryRelayFeed() }
+                                )
+                            }
+                            feedType == FeedType.TRENDING -> {
+                                RelayFeedEmptyState(
+                                    status = relayFeedStatus,
+                                    relayUrl = buildTrendingRelayUrl(trendingMetric, trendingTimeframe),
+                                    onRetry = { viewModel.setFeedType(FeedType.TRENDING) }
                                 )
                             }
                             initLoadingState != InitLoadingState.Done -> {
@@ -1611,6 +1649,94 @@ private fun NewNotesButton(
                     }
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun TrendingFilterBar(
+    metric: TrendingMetric,
+    timeframe: TrendingTimeframe,
+    onMetricChange: (TrendingMetric) -> Unit,
+    onTimeframeChange: (TrendingTimeframe) -> Unit
+) {
+    val metricIcon = @Composable { m: TrendingMetric ->
+        when (m) {
+            TrendingMetric.REACTIONS -> Icon(Icons.Outlined.FavoriteBorder, contentDescription = m.label, modifier = Modifier.size(16.dp))
+            TrendingMetric.REPLIES -> Icon(Icons.AutoMirrored.Outlined.Reply, contentDescription = m.label, modifier = Modifier.size(16.dp))
+            TrendingMetric.REPOSTS -> Icon(Icons.Outlined.Repeat, contentDescription = m.label, modifier = Modifier.size(16.dp))
+            TrendingMetric.ZAPS -> Icon(Icons.Outlined.CurrencyBitcoin, contentDescription = m.label, modifier = Modifier.size(16.dp))
+        }
+    }
+
+    var showTimeframeDropdown by remember { mutableStateOf(false) }
+
+    Surface(color = MaterialTheme.colorScheme.surface) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TrendingMetric.entries.forEach { m ->
+                    FilterChip(
+                        selected = m == metric,
+                        onClick = { onMetricChange(m) },
+                        label = { metricIcon(m) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                            selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimary
+                        )
+                    )
+                }
+                Spacer(Modifier.weight(1f))
+                Box {
+                    Surface(
+                        onClick = { showTimeframeDropdown = true },
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.surfaceVariant
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                timeframe.label,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(Modifier.width(2.dp))
+                            Icon(
+                                Icons.Default.ArrowDropDown,
+                                contentDescription = "Change timeframe",
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    DropdownMenu(
+                        expanded = showTimeframeDropdown,
+                        onDismissRequest = { showTimeframeDropdown = false }
+                    ) {
+                        TrendingTimeframe.entries.forEach { t ->
+                            DropdownMenuItem(
+                                text = { Text(t.label) },
+                                onClick = {
+                                    showTimeframeDropdown = false
+                                    onTimeframeChange(t)
+                                },
+                                trailingIcon = if (t == timeframe) {{
+                                    Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                                }} else null
+                            )
+                        }
+                    }
+                }
+            }
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
         }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -63,6 +63,7 @@ class EventRouter(
     private val getSigner: () -> NostrSigner?,
     private val getFeedSubId: () -> String,
     private val getRelayFeedSubId: () -> String,
+    private val getIsTrendingFeed: () -> Boolean,
     private val onRelayFeedEventReceived: () -> Unit
 ) {
     // Track newest created_at per (pubkey, kind) to prevent stale overwrites
@@ -339,7 +340,11 @@ class EventRouter(
                 subscriptionId == "relay-loadmore"
             if (isRelayFeedSub) {
                 eventRepo.cacheEvent(event)
-                eventRepo.addRelayFeedEvent(event)
+                if (getIsTrendingFeed()) {
+                    eventRepo.addTrendingFeedEvent(event)
+                } else {
+                    eventRepo.addRelayFeedEvent(event)
+                }
                 onRelayFeedEventReceived()
                 eventRepo.addEventRelay(event.id, relayUrl)
                 if (event.kind == 1 || event.kind == 30023) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -59,6 +59,7 @@ class FeedSubscriptionManager(
         // received by the main feed subscription can still appear in relay feeds.
         relayPool.registerDedupBypass("relay-feed-")
         relayPool.registerDedupBypass("relay-loadmore")
+        relayPool.registerDedupBypass("trending-feed-")
     }
 
     private val _feedType = MutableStateFlow(FeedType.FOLLOWS)
@@ -69,6 +70,12 @@ class FeedSubscriptionManager(
 
     private val _selectedRelaySet = MutableStateFlow<RelaySet?>(null)
     val selectedRelaySet: StateFlow<RelaySet?> = _selectedRelaySet
+
+    private val _trendingMetric = MutableStateFlow(TrendingMetric.REACTIONS)
+    val trendingMetric: StateFlow<TrendingMetric> = _trendingMetric
+
+    private val _trendingTimeframe = MutableStateFlow(TrendingTimeframe.TODAY)
+    val trendingTimeframe: StateFlow<TrendingTimeframe> = _trendingTimeframe
 
     private val _relayFeedStatus = MutableStateFlow<RelayFeedStatus>(RelayFeedStatus.Idle)
     val relayFeedStatus: StateFlow<RelayFeedStatus> = _relayFeedStatus
@@ -117,7 +124,7 @@ class FeedSubscriptionManager(
                 if (pubkeyHex != null) follows + pubkeyHex else follows
             }
             FeedType.LIST -> listRepo.selectedList.value?.members
-            else -> null  // EXTENDED_FOLLOWS and RELAY show everything
+            else -> null  // EXTENDED_FOLLOWS, RELAY, and TRENDING show everything
         })
     }
 
@@ -127,8 +134,11 @@ class FeedSubscriptionManager(
         _feedType.value = type
         applyAuthorFilterForFeedType(type)
 
-        // Tear down relay feed when leaving RELAY mode
+        // Tear down relay/trending feed when leaving those modes
         if (prev == FeedType.RELAY && type != FeedType.RELAY) {
+            unsubscribeRelayFeed()
+        }
+        if (prev == FeedType.TRENDING && type != FeedType.TRENDING) {
             unsubscribeRelayFeed()
         }
 
@@ -161,6 +171,10 @@ class FeedSubscriptionManager(
                 val listSince = System.currentTimeMillis() / 1000 - 60 * 60 * 24 * 7
                 eventRepo.rebuildFeedFromCache(sinceTimestamp = listSince)
                 resubscribeFeed()
+            }
+            FeedType.TRENDING -> {
+                eventRepo.clearRelayFeed()
+                subscribeTrendingFeed()
             }
         }
     }
@@ -197,6 +211,9 @@ class FeedSubscriptionManager(
         if (_feedType.value == FeedType.RELAY) {
             eventRepo.clearRelayFeed()
             subscribeRelayFeed()
+        } else if (_feedType.value == FeedType.TRENDING) {
+            eventRepo.clearRelayFeed()
+            subscribeTrendingFeed()
         }
     }
 
@@ -249,9 +266,9 @@ class FeedSubscriptionManager(
                     indexerRelays = indexerRelays, blockedUrls = excludedUrls
                 )
             }
-            FeedType.RELAY -> {
-                // RELAY feeds use subscribeRelayFeed() — should not reach here
-                Log.w("RLC", "[FeedSub] resubscribeFeed() called for RELAY type, skipping")
+            FeedType.RELAY, FeedType.TRENDING -> {
+                // RELAY/TRENDING feeds use their own subscribe methods — should not reach here
+                Log.w("RLC", "[FeedSub] resubscribeFeed() called for ${_feedType.value} type, skipping")
                 return
             }
             FeedType.LIST -> {
@@ -338,6 +355,7 @@ class FeedSubscriptionManager(
 
     fun loadMore() {
         if (isLoadingMore) return
+        if (_feedType.value == FeedType.TRENDING) return  // trending relay sends full ranked set
         isLoadingMore = true
 
         val indexerRelays = getIndexerRelays()
@@ -412,6 +430,7 @@ class FeedSubscriptionManager(
                     indexerRelays = indexerRelays, blockedUrls = excludedUrls
                 )
             }
+            FeedType.TRENDING -> return  // guarded above, but required for exhaustiveness
         }
 
         val loadMoreSubId = if (_feedType.value == FeedType.RELAY) "relay-loadmore" else "loadmore"
@@ -445,6 +464,53 @@ class FeedSubscriptionManager(
     fun resumeEngagement() {
         if (activeEngagementSubIds.isEmpty()) {
             subscribeEngagementForFeed()
+        }
+    }
+
+    // -- Trending feed --
+
+    fun setTrendingMetric(metric: TrendingMetric) {
+        _trendingMetric.value = metric
+        if (_feedType.value == FeedType.TRENDING) {
+            eventRepo.clearRelayFeed()
+            subscribeTrendingFeed()
+        }
+    }
+
+    fun setTrendingTimeframe(timeframe: TrendingTimeframe) {
+        _trendingTimeframe.value = timeframe
+        if (_feedType.value == FeedType.TRENDING) {
+            eventRepo.clearRelayFeed()
+            subscribeTrendingFeed()
+        }
+    }
+
+    private fun subscribeTrendingFeed() {
+        val oldSubId = relayFeedSubId
+        relayFeedGeneration++
+        relayFeedSubId = "trending-feed-$relayFeedGeneration"
+        relayPool.closeOnAllRelays(oldSubId)
+        relayFeedEoseJob?.cancel()
+        relayStatusMonitorJob?.cancel()
+
+        val url = buildTrendingRelayUrl(_trendingMetric.value, _trendingTimeframe.value)
+        _relayFeedStatus.value = RelayFeedStatus.Connecting
+
+        val filter = Filter(kinds = listOf(1, 6, 30023), limit = 100)
+        val msg = ClientMessage.req(relayFeedSubId, filter)
+        val sent = relayPool.sendToRelayOrEphemeral(url, msg, skipBadCheck = true)
+        if (!sent) {
+            _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Failed to connect to trending relay")
+            return
+        }
+
+        relayFeedEoseJob = scope.launch {
+            subManager.awaitEoseCount(relayFeedSubId, 1)
+            onRelayFeedEose()
+            subscribeEngagementForFeed()
+            withContext(processingContext) {
+                metadataFetcher.sweepMissingProfiles()
+            }
         }
     }
 
@@ -623,7 +689,7 @@ class FeedSubscriptionManager(
     }
 
     private fun onRelayFeedEose() {
-        if (_feedType.value != FeedType.RELAY) return
+        if (_feedType.value != FeedType.RELAY && _feedType.value != FeedType.TRENDING) return
         val status = _relayFeedStatus.value
         if (status is RelayFeedStatus.Connecting || status is RelayFeedStatus.Subscribing) {
             _relayFeedStatus.value = if (eventRepo.relayFeed.value.isEmpty()) {
@@ -636,7 +702,7 @@ class FeedSubscriptionManager(
 
     /** Mark status as Streaming when events start arriving. Called by EventRouter. */
     fun onRelayFeedEventReceived() {
-        if (_feedType.value != FeedType.RELAY) return
+        if (_feedType.value != FeedType.RELAY && _feedType.value != FeedType.TRENDING) return
         val status = _relayFeedStatus.value
         if (status is RelayFeedStatus.Subscribing || status is RelayFeedStatus.Connecting) {
             _relayFeedStatus.value = RelayFeedStatus.Streaming
@@ -649,7 +715,7 @@ class FeedSubscriptionManager(
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()
 
-        val feedEvents = if (_feedType.value == FeedType.RELAY) eventRepo.relayFeed.value else eventRepo.feed.value
+        val feedEvents = if (_feedType.value == FeedType.RELAY || _feedType.value == FeedType.TRENDING) eventRepo.relayFeed.value else eventRepo.feed.value
         if (feedEvents.isEmpty()) return
 
         val eventsByAuthor = mutableMapOf<String, MutableList<String>>()
@@ -733,6 +799,8 @@ class FeedSubscriptionManager(
         _initLoadingState.value = InitLoadingState.SearchingProfile
         _selectedRelay.value = null
         _selectedRelaySet.value = null
+        _trendingMetric.value = TrendingMetric.REACTIONS
+        _trendingTimeframe.value = TrendingTimeframe.TODAY
         isLoadingMore = false
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -63,7 +63,25 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
-enum class FeedType { FOLLOWS, EXTENDED_FOLLOWS, RELAY, LIST }
+enum class FeedType { FOLLOWS, EXTENDED_FOLLOWS, RELAY, LIST, TRENDING }
+
+enum class TrendingMetric(val slug: String, val label: String) {
+    REACTIONS("reactions", "Reactions"),
+    REPLIES("replies", "Replies"),
+    REPOSTS("reposts", "Reposts"),
+    ZAPS("zaps", "Zaps")
+}
+
+enum class TrendingTimeframe(val slug: String, val label: String) {
+    TODAY("today", "Today"),
+    WEEK("7d", "7d"),
+    MONTH("30d", "30d"),
+    YEAR("1y", "1y"),
+    ALL("all", "All")
+}
+
+fun buildTrendingRelayUrl(metric: TrendingMetric, timeframe: TrendingTimeframe): String =
+    "wss://feeds.nostrarchives.com/notes/trending/${metric.slug}/${timeframe.slug}"
 
 sealed interface RelayFeedStatus {
     data object Idle : RelayFeedStatus
@@ -207,6 +225,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         getSigner = { signer },
         getFeedSubId = { feedSub.feedSubId },
         getRelayFeedSubId = { feedSub.relayFeedSubId },
+        getIsTrendingFeed = { feedSub.feedType.value == FeedType.TRENDING },
         onRelayFeedEventReceived = { feedSub.onRelayFeedEventReceived() }
     )
 
@@ -241,7 +260,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val feed: StateFlow<List<NostrEvent>> = combine(
         feedSub.feedType, eventRepo.feed, eventRepo.relayFeed
     ) { type, main, relay ->
-        if (type == FeedType.RELAY) relay else main
+        if (type == FeedType.RELAY || type == FeedType.TRENDING) relay else main
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
     val newNoteCount: StateFlow<Int> = eventRepo.newNoteCount
 
@@ -272,6 +291,8 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val isRefreshing: StateFlow<Boolean> = feedSub.isRefreshing
     val relayFeedStatus: StateFlow<RelayFeedStatus> = feedSub.relayFeedStatus
     val loadingScreenComplete: StateFlow<Boolean> = feedSub.loadingScreenComplete
+    val trendingMetric: StateFlow<TrendingMetric> = feedSub.trendingMetric
+    val trendingTimeframe: StateFlow<TrendingTimeframe> = feedSub.trendingTimeframe
     val selectedList: StateFlow<com.wisp.app.nostr.FollowSet?> = listRepo.selectedList
     val zapInProgress: StateFlow<Set<String>> = socialActions.zapInProgress
     val zapSuccess: SharedFlow<String> = socialActions.zapSuccess
@@ -302,6 +323,8 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun refreshFeed() = feedSub.refreshFeed()
     fun retryRelayFeed() = feedSub.retryRelayFeed()
     fun loadMore() = feedSub.loadMore()
+    fun setTrendingMetric(metric: TrendingMetric) = feedSub.setTrendingMetric(metric)
+    fun setTrendingTimeframe(timeframe: TrendingTimeframe) = feedSub.setTrendingTimeframe(timeframe)
     fun pauseEngagement() = feedSub.pauseEngagement()
     fun resumeEngagement() = feedSub.resumeEngagement()
 


### PR DESCRIPTION
## Summary
- Add `FeedType.TRENDING` connecting to `wss://feeds.nostrarchives.com/notes/trending/{metric}/{timeframe}` endpoints
- Preserve relay arrival order (append instead of chronological binary insert) so trending rank is maintained
- Icon-based filter chips for metrics (reactions, replies, reposts, zaps) and a timeframe dropdown (today/7d/30d/1y/all) in a single-line sub-menu bar

## Files changed
- **FeedViewModel.kt** — `TRENDING` enum value, `TrendingMetric`/`TrendingTimeframe` enums, state exposure and delegates
- **EventRepository.kt** — `addTrendingFeedEvent()` + `trendingFeedAppend()` for arrival-order insertion
- **EventRouter.kt** — branch relay feed routing to trending append when trending is active
- **FeedSubscriptionManager.kt** — trending subscription lifecycle, metric/timeframe switching, dedup bypass registration
- **FeedScreen.kt** — "Trending" dropdown item, `TrendingFilterBar` composable with icon chips + timeframe dropdown

## Test plan
- [ ] Select "Trending" from feed dropdown — notes load in trending rank order
- [ ] Switch between metric chips (heart/reply/repost/zap icons) — feed clears and reloads
- [ ] Switch timeframe via dropdown (Today/7d/30d/1y/All) — feed clears and reloads
- [ ] Switch away from Trending to Follows/Relay/List and back — feed clears and reloads correctly
- [ ] Profile pictures and engagement counts load for trending notes