### PR TITLE
Fix zombie relay connections and reorder feed dropdown

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -819,36 +819,19 @@ class RelayPool {
         for (relayMap in activeSubscriptions.values) {
             relayMap.keys.retainAll { subId -> keepPrefixes.any { subId.startsWith(it) } }
         }
-        // Smart reconnect: only tear down relays that are disconnected.
-        // Healthy relays are kept alive to avoid thundering herd on short resume.
-        var reconnected = 0
-        val keptAlive = mutableListOf<Relay>()
+        // Always tear down and reconnect — we cannot trust isConnected after
+        // an OS sleep; the socket may be dead even though the flag says true.
         for (relay in relays) {
             relay.resetBackoff()
+            relay.disconnect()
+            relay.connect()
             relay.reconnectEnabled = true
-            if (relay.isConnected) {
-                keptAlive.add(relay)
-            } else {
-                relay.disconnect()
-                relay.connect()
-                reconnected++
-            }
         }
         for (relay in dmRelays) {
             relay.resetBackoff()
+            relay.disconnect()
+            relay.connect()
             relay.reconnectEnabled = true
-            if (relay.isConnected) {
-                keptAlive.add(relay)
-            } else {
-                relay.disconnect()
-                relay.connect()
-                reconnected++
-            }
-        }
-        // Resync subscriptions on kept-alive relays — connectionState won't fire
-        // for them, so they'd miss any new subscriptions without this.
-        for (relay in keptAlive) {
-            resyncSubscriptions(relay)
         }
         // Evict ALL ephemeral relays — they'll be recreated on demand.
         // Even "connected" ephemerals may be stale and have autoReconnect=false.
@@ -863,7 +846,7 @@ class RelayPool {
         ephemeralLastUsed.clear()
         isReconnecting = false
         val total = relays.size + dmRelays.size
-        Log.d("RLC", "[Pool] reconnectAll() END — reconnected $reconnected/$total relays (${keptAlive.size} kept alive), activeSubs remaining=${activeSubscriptions.size}")
+        Log.d("RLC", "[Pool] reconnectAll() END — reconnected $total relays, activeSubs remaining=${activeSubscriptions.size}")
         updateConnectedCount()
         return total
     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -532,6 +532,16 @@ fun FeedScreen(
                                         }} else null
                                     )
                                     DropdownMenuItem(
+                                        text = { Text("Trending") },
+                                        onClick = {
+                                            showFeedTypeDropdown = false
+                                            viewModel.setFeedType(FeedType.TRENDING)
+                                        },
+                                        trailingIcon = if (feedType == FeedType.TRENDING) {{
+                                            Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                                        }} else null
+                                    )
+                                    DropdownMenuItem(
                                         text = { Text("Relay") },
                                         onClick = {
                                             showFeedTypeDropdown = false
@@ -548,16 +558,6 @@ fun FeedScreen(
                                             showListPicker = true
                                         },
                                         trailingIcon = if (feedType == FeedType.LIST) {{
-                                            Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
-                                        }} else null
-                                    )
-                                    DropdownMenuItem(
-                                        text = { Text("Trending") },
-                                        onClick = {
-                                            showFeedTypeDropdown = false
-                                            viewModel.setFeedType(FeedType.TRENDING)
-                                        },
-                                        trailingIcon = if (feedType == FeedType.TRENDING) {{
                                             Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
                                         }} else null
                                     )


### PR DESCRIPTION
## Summary
- Remove "smart reconnect" `isConnected` branching in `reconnectAll()` that kept zombie sockets alive after OS sleep — always disconnect and reconnect all relays since OkHttp can't detect server-side TCP kills until the socket is used
- Reorder feed type dropdown: Follows → Extended → **Trending** → Relay → List

## Test plan
- [ ] Cold boot app — relays connect normally
- [ ] Minimize < 30s, reopen — no EOFException spam, relays reconnect cleanly
- [ ] Lock phone > 30s, unlock — force reconnect works, all subs re-established
- [ ] Feed dropdown shows Trending between Extended and Relay