### PR TITLE
fix: reconnect trending feed after app resume

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
@@ -21,6 +21,7 @@ class RelayLifecycleManager(
     private val context: Context,
     private val relayPool: RelayPool,
     private val scope: CoroutineScope,
+    private val onPreReconnect: (() -> Unit)? = null,
     private val onReconnected: (force: Boolean) -> Unit
 ) {
     private var connectivityJob: Job? = null
@@ -157,6 +158,10 @@ class RelayLifecycleManager(
                     Log.d("RLC", "[Lifecycle] → reconnectAll()")
                     relayPool.reconnectAll()
                 }
+                // Let callers start priority ephemeral connections (e.g. trending
+                // relay) so they connect in parallel with persistent relays instead
+                // of waiting until after awaitAnyConnected.
+                onPreReconnect?.invoke()
                 val minCount = if (force) 3 else 1
                 Log.d("RLC", "[Lifecycle] awaiting $minCount relays...")
                 relayPool.awaitAnyConnected(minCount = minCount, timeoutMs = 5_000)

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -945,6 +945,27 @@ class RelayPool {
         }
     }
 
+    /**
+     * Pre-connect an ephemeral relay without sending a message. Use this to start
+     * the WebSocket connection early so it's ready when the first REQ arrives.
+     */
+    fun preConnectEphemeral(url: String) {
+        ensureClientCurrent()
+        if (url in blockedUrls) return
+        if (!RelayConfig.isConnectableUrl(url)) return
+        if (ephemeralRelays.containsKey(url)) return
+        if (ephemeralRelays.size >= MAX_EPHEMERAL) return
+        val relay = Relay(RelayConfig(url, read = true, write = false), client, scope)
+        relay.autoReconnect = false
+        wireByteTracking(relay)
+        relayIndex[url] = relay
+        collectMessages(relay)
+        ephemeralRelays[url] = relay
+        ephemeralLastUsed[url] = System.currentTimeMillis()
+        relay.connect()
+        Log.d("RLC", "[Pool] preConnectEphemeral($url)")
+    }
+
     fun disconnectRelay(url: String) {
         relayIndex.remove(url)?.disconnect()
         relays.removeAll { it.config.url == url }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -497,15 +497,43 @@ class FeedSubscriptionManager(
         _relayFeedStatus.value = RelayFeedStatus.Connecting
 
         val filter = Filter(kinds = listOf(1, 6, 30023), limit = 100)
-        val msg = ClientMessage.req(relayFeedSubId, filter)
-        val sent = relayPool.sendToRelayOrEphemeral(url, msg, skipBadCheck = true)
-        if (!sent) {
-            _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Failed to connect to trending relay")
-            return
-        }
+        val currentGen = relayFeedGeneration
+        val subId = relayFeedSubId
 
         relayFeedEoseJob = scope.launch {
-            subManager.awaitEoseCount(relayFeedSubId, 1)
+            // The relay may already be pre-connecting (via onPreReconnect) or may
+            // need to be created fresh. sendToRelayOrEphemeral handles both cases
+            // and queues the REQ as a pending message if the WebSocket isn't open yet.
+            // If the relay fails to connect (stale DNS after sleep, etc.), retry with
+            // a fresh ephemeral connection.
+            var connected = false
+            for (attempt in 0..2) {
+                if (relayFeedGeneration != currentGen) return@launch
+                if (attempt > 0) {
+                    relayPool.disconnectRelay(url)
+                    delay(1500L)
+                }
+                val msg = ClientMessage.req(subId, filter)
+                relayPool.sendToRelayOrEphemeral(url, msg, skipBadCheck = true)
+
+                // Wait for relay to connect — pending messages drain on WebSocket open
+                val deadline = System.currentTimeMillis() + 5_000
+                while (System.currentTimeMillis() < deadline) {
+                    if (relayFeedGeneration != currentGen) return@launch
+                    if (relayPool.isRelayConnected(url)) {
+                        connected = true
+                        break
+                    }
+                    delay(200)
+                }
+                if (connected) break
+            }
+            if (!connected) {
+                _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Failed to connect to trending relay")
+                return@launch
+            }
+
+            subManager.awaitEoseCount(subId, 1)
             onRelayFeedEose()
             subscribeEngagementForFeed()
             withContext(processingContext) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -175,6 +175,14 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         context = app,
         relayPool = relayPool,
         scope = viewModelScope,
+        onPreReconnect = {
+            // Start the trending relay connection early so it connects in parallel
+            // with persistent relays, not sequentially after them.
+            if (feedSub.feedType.value == FeedType.TRENDING) {
+                val url = buildTrendingRelayUrl(feedSub.trendingMetric.value, feedSub.trendingTimeframe.value)
+                relayPool.preConnectEphemeral(url)
+            }
+        },
         onReconnected = { force ->
             Log.d("RLC", "[FeedVM] onReconnected(force=$force) feedType=${feedSub.feedType.value} selectedRelay=${feedSub.selectedRelay.value} feedSize=${eventRepo.feed.value.size}")
             feedSub.subscribeFeed()


### PR DESCRIPTION
## Summary
- Trending feed failed to reconnect after app resume because its ephemeral relay was evicted during reconnect and only re-created sequentially after persistent relays connected
- Added `onPreReconnect` hook to start the trending relay connection in parallel with persistent relays, eliminating the sequential delay
- Added retry logic in `subscribeTrendingFeed()` to handle failed ephemeral connections (stale DNS, timeouts after sleep)

## Test plan
- [ ] Open trending feed, lock/minimize phone for 30+ seconds, resume — feed should reconnect quickly
- [ ] Open trending feed, lock briefly (<30s), resume — feed should reconnect
- [ ] Switch between trending metrics/timeframes after resume — should work normally
- [ ] Other feeds (following, relay) should still reconnect as before