### PR TITLE
fix: search and hashtag feeds return all results on repeat queries

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -885,15 +885,12 @@ fun WispNavHost(
             val searchSetListedIds by feedViewModel.bookmarkSetRepo.allListedEventIds.collectAsState()
             val searchBookmarkedIds by feedViewModel.bookmarkRepo.bookmarkedIds.collectAsState()
             val searchListedIds = remember(searchSetListedIds, searchBookmarkedIds) { searchSetListedIds + searchBookmarkedIds }
-            val extNetCache by feedViewModel.extendedNetworkRepo.cachedNetwork.collectAsState()
             SearchScreen(
                 viewModel = searchViewModel,
                 relayPool = feedViewModel.relayPool,
                 eventRepo = feedViewModel.eventRepo,
-                profileRepo = feedViewModel.profileRepo,
                 muteRepo = feedViewModel.muteRepo,
                 contactRepo = feedViewModel.contactRepo,
-                extendedNetworkCache = extNetCache,
                 onProfileClick = { pubkey ->
                     navController.navigate("profile/$pubkey")
                 },
@@ -911,9 +908,6 @@ fun WispNavHost(
                 },
                 onReact = { event, emoji ->
                     feedViewModel.toggleReaction(event, emoji)
-                },
-                onListClick = { list ->
-                    navController.navigate("list/${list.pubkey}/${list.dTag}")
                 },
                 onToggleFollow = { pubkey ->
                     feedViewModel.toggleFollow(pubkey)

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -135,7 +135,7 @@ class RelayPool {
 
     /** Subscription prefixes that bypass event deduplication. */
     private val dedupBypassPrefixes = java.util.concurrent.CopyOnWriteArrayList(
-        listOf("thread-", "user", "quote-", "editprofile", "notif", "dms")
+        listOf("thread-", "user", "quote-", "editprofile", "notif", "dms", "search-", "hashtag-")
     )
 
     /** Signing lambda for NIP-42 AUTH — set via [setAuthSigner]. */

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/HashtagFeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/HashtagFeedScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
@@ -18,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -85,7 +87,14 @@ fun HashtagFeedScreen(
                 CircularProgressIndicator(modifier = Modifier.size(32.dp))
             }
         } else {
+            val listState = remember(hashtag) { LazyListState() }
+            LaunchedEffect(isLoading) {
+                if (!isLoading) {
+                    listState.scrollToItem(0)
+                }
+            }
             LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
@@ -36,8 +36,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -53,21 +51,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.wisp.app.nostr.FollowSet
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.ProfileData
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.ContactRepository
 import com.wisp.app.repo.EventRepository
-import com.wisp.app.repo.ExtendedNetworkCache
 import com.wisp.app.repo.MuteRepository
-import com.wisp.app.repo.ProfileRepository
 import com.wisp.app.repo.TranslationRepository
 import com.wisp.app.ui.component.FollowButton
 import com.wisp.app.ui.component.PostCard
 import com.wisp.app.ui.component.ProfilePicture
-import com.wisp.app.viewmodel.LocalFilter
-import com.wisp.app.viewmodel.SearchTab
+import com.wisp.app.viewmodel.RelayOption
+import com.wisp.app.viewmodel.SearchFilter
 import com.wisp.app.viewmodel.SearchViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -76,16 +71,13 @@ fun SearchScreen(
     viewModel: SearchViewModel,
     relayPool: RelayPool,
     eventRepo: EventRepository,
-    profileRepo: ProfileRepository,
     muteRepo: MuteRepository? = null,
     contactRepo: ContactRepository? = null,
-    extendedNetworkCache: ExtendedNetworkCache? = null,
     onProfileClick: (String) -> Unit,
     onNoteClick: (NostrEvent) -> Unit,
     onQuotedNoteClick: ((String) -> Unit)? = null,
     onReply: (NostrEvent) -> Unit = {},
     onReact: (NostrEvent, String) -> Unit = { _, _ -> },
-    onListClick: (FollowSet) -> Unit = {},
     onToggleFollow: (String) -> Unit = {},
     onBlockUser: (String) -> Unit = {},
     userPubkey: String? = null,
@@ -95,18 +87,13 @@ fun SearchScreen(
     translationRepo: TranslationRepository? = null
 ) {
     val query by viewModel.query.collectAsState()
-    val selectedTab by viewModel.selectedTab.collectAsState()
-    val localFilter by viewModel.localFilter.collectAsState()
-    val localUsers by viewModel.localUsers.collectAsState()
-    val localNotes by viewModel.localNotes.collectAsState()
+    val filter by viewModel.filter.collectAsState()
     val users by viewModel.users.collectAsState()
     val notes by viewModel.notes.collectAsState()
-    val lists by viewModel.lists.collectAsState()
     val isSearching by viewModel.isSearching.collectAsState()
+    val selectedRelayOption by viewModel.selectedRelayOption.collectAsState()
+    val selectedRelayUrl by viewModel.selectedRelayUrl.collectAsState()
     val searchRelays by viewModel.searchRelays.collectAsState()
-    val selectedRelay by viewModel.selectedRelay.collectAsState()
-
-    val tabs = SearchTab.entries
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -124,414 +111,157 @@ fun SearchScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            // People / Notes filter
-            ResultFilterSelector(
-                localFilter = localFilter,
-                onSelectFilter = { viewModel.selectLocalFilter(it) }
+            // Filter chips
+            Row(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                FilterChip(
+                    selected = filter == SearchFilter.PEOPLE,
+                    onClick = { viewModel.selectFilter(SearchFilter.PEOPLE) },
+                    label = { Text("People") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primary,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                )
+                FilterChip(
+                    selected = filter == SearchFilter.NOTES,
+                    onClick = { viewModel.selectFilter(SearchFilter.NOTES) },
+                    label = { Text("Notes") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primary,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                )
+            }
+
+            // Relay selector
+            RelaySelector(
+                searchRelays = searchRelays,
+                selectedOption = selectedRelayOption,
+                selectedRelayUrl = selectedRelayUrl,
+                onSelectDefault = { viewModel.selectDefaultRelay() },
+                onSelectAllRelays = { viewModel.selectAllRelays() },
+                onSelectRelay = { viewModel.selectRelay(it) },
+                onAddRelay = { viewModel.addSearchRelay(it) },
+                onRemoveRelay = { viewModel.removeSearchRelay(it) }
             )
 
-            // Tabs
-            TabRow(selectedTabIndex = tabs.indexOf(selectedTab)) {
-                Tab(
-                    selected = selectedTab == SearchTab.MY_DEVICE,
-                    onClick = { viewModel.selectTab(SearchTab.MY_DEVICE) },
-                    text = { Text("My Device") }
+            // Search bar
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { viewModel.updateQuery(it) },
+                    placeholder = { Text("Search users and notes") },
+                    leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                    trailingIcon = {
+                        if (query.isNotEmpty()) {
+                            IconButton(onClick = { viewModel.clear() }) {
+                                Icon(Icons.Default.Clear, contentDescription = "Clear")
+                            }
+                        }
+                    },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(
+                        onSearch = { viewModel.search(query, relayPool, eventRepo, muteRepo) }
+                    ),
+                    modifier = Modifier.weight(1f)
                 )
-                Tab(
-                    selected = selectedTab == SearchTab.RELAYS,
-                    onClick = { viewModel.selectTab(SearchTab.RELAYS) },
-                    text = { Text("Relays") }
-                )
-            }
-
-            when (selectedTab) {
-                SearchTab.MY_DEVICE -> MyDeviceTab(
-                    query = query,
-                    localFilter = localFilter,
-                    localUsers = localUsers,
-                    localNotes = localNotes,
-                    eventRepo = eventRepo,
-                    contactRepo = contactRepo,
-                    onQueryChange = { viewModel.updateQuery(it, profileRepo, eventRepo) },
-                    onClear = { viewModel.clear() },
-                    onProfileClick = onProfileClick,
-                    onNoteClick = onNoteClick,
-                    onQuotedNoteClick = onQuotedNoteClick,
-                    onReply = onReply,
-                    onReact = onReact,
-                    onToggleFollow = onToggleFollow,
-                    onBlockUser = onBlockUser,
-                    userPubkey = userPubkey,
-                    listedIds = listedIds,
-                    onAddToList = onAddToList,
-                    onDeleteEvent = onDeleteEvent,
-                    translationRepo = translationRepo
-                )
-
-                SearchTab.RELAYS -> RelaysTab(
-                    query = query,
-                    users = users,
-                    notes = notes,
-                    lists = lists,
-                    isSearching = isSearching,
-                    localFilter = localFilter,
-                    searchRelays = searchRelays,
-                    selectedRelay = selectedRelay,
-                    onSelectRelay = { viewModel.selectRelay(it) },
-                    onAddRelay = { viewModel.addSearchRelay(it) },
-                    onRemoveRelay = { viewModel.removeSearchRelay(it) },
-                    onQueryChange = { viewModel.updateQuery(it, profileRepo, eventRepo) },
-                    onClear = { viewModel.clear() },
-                    onSearch = { viewModel.search(query, relayPool, eventRepo, muteRepo) },
-                    eventRepo = eventRepo,
-                    contactRepo = contactRepo,
-                    onProfileClick = onProfileClick,
-                    onNoteClick = onNoteClick,
-                    onQuotedNoteClick = onQuotedNoteClick,
-                    onReply = onReply,
-                    onReact = onReact,
-                    onListClick = onListClick,
-                    onToggleFollow = onToggleFollow,
-                    onBlockUser = onBlockUser,
-                    userPubkey = userPubkey,
-                    listedIds = listedIds,
-                    onAddToList = onAddToList,
-                    onDeleteEvent = onDeleteEvent,
-                    translationRepo = translationRepo
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun MyDeviceTab(
-    query: String,
-    localFilter: LocalFilter,
-    localUsers: List<ProfileData>,
-    localNotes: List<NostrEvent>,
-    eventRepo: EventRepository,
-    contactRepo: ContactRepository?,
-    onQueryChange: (String) -> Unit,
-    onClear: () -> Unit,
-    onProfileClick: (String) -> Unit,
-    onNoteClick: (NostrEvent) -> Unit,
-    onQuotedNoteClick: ((String) -> Unit)?,
-    onReply: (NostrEvent) -> Unit,
-    onReact: (NostrEvent, String) -> Unit,
-    onToggleFollow: (String) -> Unit,
-    onBlockUser: (String) -> Unit,
-    userPubkey: String?,
-    listedIds: Set<String>,
-    onAddToList: (String) -> Unit,
-    onDeleteEvent: (String, Int) -> Unit,
-    translationRepo: TranslationRepository? = null
-) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        // Search bar
-        SearchBar(
-            query = query,
-            onQueryChange = onQueryChange,
-            onClear = onClear
-        )
-
-        when {
-            query.isBlank() -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
+                IconButton(
+                    onClick = { viewModel.search(query, relayPool, eventRepo, muteRepo) }
                 ) {
-                    Text(
-                        "Search cached users and notes",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    Icon(Icons.Default.Search, contentDescription = "Search")
                 }
             }
 
-            localFilter == LocalFilter.PEOPLE && localUsers.isEmpty() ||
-            localFilter == LocalFilter.NOTES && localNotes.isEmpty() -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        "No results on your device",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+            // Results
+            when {
+                isSearching -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                    }
                 }
-            }
 
-            localFilter == LocalFilter.PEOPLE -> {
-                val sortedLocalUsers = localUsers.sortedByDescending {
-                    contactRepo?.isFollowing(it.pubkey) == true
-                }
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(sortedLocalUsers, key = { it.pubkey }, contentType = { "user" }) { profile ->
-                        UserResultItem(
-                            profile = profile,
-                            isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
-                            onClick = { onProfileClick(profile.pubkey) },
-                            onToggleFollow = { onToggleFollow(profile.pubkey) }
+                users.isEmpty() && notes.isEmpty() && query.isNotEmpty() && !isSearching -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            "No results found",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
-            }
 
-            localFilter == LocalFilter.NOTES -> {
-                val translationVersion by translationRepo?.version?.collectAsState() ?: remember { androidx.compose.runtime.mutableIntStateOf(0) }
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(localNotes, key = { it.id }, contentType = { "post" }) { event ->
-                        val profile = eventRepo.getProfileData(event.pubkey)
-                        val translationState = remember(translationVersion, event.id) {
-                            translationRepo?.getState(event.id) ?: com.wisp.app.repo.TranslationState()
-                        }
-                        PostCard(
-                            event = event,
-                            profile = profile,
-                            onReply = { onReply(event) },
-                            onProfileClick = { onProfileClick(event.pubkey) },
-                            onNavigateToProfile = onProfileClick,
-                            onNoteClick = { onNoteClick(event) },
-                            onQuotedNoteClick = onQuotedNoteClick,
-                            onReact = { emoji -> onReact(event, emoji) },
-                            eventRepo = eventRepo,
-                            onFollowAuthor = { onToggleFollow(event.pubkey) },
-                            onBlockAuthor = { onBlockUser(event.pubkey) },
-                            isOwnEvent = event.pubkey == userPubkey,
-                            onAddToList = { onAddToList(event.id) },
-                            isInList = event.id in listedIds,
-                            onDelete = { onDeleteEvent(event.id, event.kind) },
-                            translationState = translationState,
-                            onTranslate = { translationRepo?.translate(event.id, event.content) }
+                users.isEmpty() && notes.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            "Search for users and notes on relays",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
-            }
-        }
-    }
-}
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun RelaysTab(
-    query: String,
-    users: List<ProfileData>,
-    notes: List<NostrEvent>,
-    lists: List<FollowSet>,
-    isSearching: Boolean,
-    localFilter: LocalFilter,
-    searchRelays: List<String>,
-    selectedRelay: String?,
-    onSelectRelay: (String?) -> Unit,
-    onAddRelay: (String) -> Boolean,
-    onRemoveRelay: (String) -> Unit,
-    onQueryChange: (String) -> Unit,
-    onClear: () -> Unit,
-    onSearch: () -> Unit,
-    eventRepo: EventRepository,
-    contactRepo: ContactRepository?,
-    onProfileClick: (String) -> Unit,
-    onNoteClick: (NostrEvent) -> Unit,
-    onQuotedNoteClick: ((String) -> Unit)?,
-    onReply: (NostrEvent) -> Unit,
-    onReact: (NostrEvent, String) -> Unit,
-    onListClick: (FollowSet) -> Unit,
-    onToggleFollow: (String) -> Unit,
-    onBlockUser: (String) -> Unit,
-    userPubkey: String?,
-    listedIds: Set<String>,
-    onAddToList: (String) -> Unit,
-    onDeleteEvent: (String, Int) -> Unit,
-    translationRepo: TranslationRepository? = null
-) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        // Relay selector
-        RelaySelector(
-            searchRelays = searchRelays,
-            selectedRelay = selectedRelay,
-            onSelectRelay = onSelectRelay,
-            onAddRelay = onAddRelay,
-            onRemoveRelay = onRemoveRelay
-        )
-
-        // Search bar + Go
-        SearchBar(
-            query = query,
-            onQueryChange = onQueryChange,
-            onClear = onClear,
-            onSearch = onSearch
-        )
-
-    when {
-        isSearching -> {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
-            }
-        }
-
-        users.isEmpty() && notes.isEmpty() && lists.isEmpty() && query.isNotEmpty() && !isSearching -> {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    "No results found",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-
-        users.isEmpty() && notes.isEmpty() && lists.isEmpty() -> {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    "Press search to query relays",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-
-        else -> {
-            val relayTranslationVersion by translationRepo?.version?.collectAsState() ?: remember { androidx.compose.runtime.mutableIntStateOf(0) }
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                if (localFilter == LocalFilter.PEOPLE) {
-                    val sortedUsers = users.sortedByDescending {
-                        contactRepo?.isFollowing(it.pubkey) == true
-                    }
-                    items(sortedUsers, key = { it.pubkey }, contentType = { "user" }) { profile ->
-                        UserResultItem(
-                            profile = profile,
-                            isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
-                            onClick = { onProfileClick(profile.pubkey) },
-                            onToggleFollow = { onToggleFollow(profile.pubkey) }
-                        )
-                    }
-                } else {
-                    if (lists.isNotEmpty()) {
-                        item {
-                            Text(
-                                "Lists",
-                                style = MaterialTheme.typography.titleSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                            )
-                        }
-                        items(lists, key = { "${it.pubkey}:${it.dTag}" }, contentType = { "list" }) { list ->
-                            ListResultItem(
-                                followSet = list,
-                                eventRepo = eventRepo,
-                                onClick = { onListClick(list) }
-                            )
-                        }
-                        if (notes.isNotEmpty()) {
-                            item {
-                                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                else -> {
+                    val translationVersion by translationRepo?.version?.collectAsState()
+                        ?: remember { androidx.compose.runtime.mutableIntStateOf(0) }
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        if (filter == SearchFilter.PEOPLE) {
+                            val sortedUsers = users.sortedByDescending {
+                                contactRepo?.isFollowing(it.pubkey) == true
+                            }
+                            items(sortedUsers, key = { it.pubkey }, contentType = { "user" }) { profile ->
+                                UserResultItem(
+                                    profile = profile,
+                                    isFollowing = contactRepo?.isFollowing(profile.pubkey) == true,
+                                    onClick = { onProfileClick(profile.pubkey) },
+                                    onToggleFollow = { onToggleFollow(profile.pubkey) }
+                                )
+                            }
+                        } else {
+                            items(notes, key = { it.id }, contentType = { "post" }) { event ->
+                                val profile = eventRepo.getProfileData(event.pubkey)
+                                val translationState = remember(translationVersion, event.id) {
+                                    translationRepo?.getState(event.id)
+                                        ?: com.wisp.app.repo.TranslationState()
+                                }
+                                PostCard(
+                                    event = event,
+                                    profile = profile,
+                                    onReply = { onReply(event) },
+                                    onProfileClick = { onProfileClick(event.pubkey) },
+                                    onNavigateToProfile = onProfileClick,
+                                    onNoteClick = { onNoteClick(event) },
+                                    onQuotedNoteClick = onQuotedNoteClick,
+                                    onReact = { emoji -> onReact(event, emoji) },
+                                    eventRepo = eventRepo,
+                                    onFollowAuthor = { onToggleFollow(event.pubkey) },
+                                    onBlockAuthor = { onBlockUser(event.pubkey) },
+                                    isOwnEvent = event.pubkey == userPubkey,
+                                    onAddToList = { onAddToList(event.id) },
+                                    isInList = event.id in listedIds,
+                                    onDelete = { onDeleteEvent(event.id, event.kind) },
+                                    translationState = translationState,
+                                    onTranslate = { translationRepo?.translate(event.id, event.content) }
+                                )
                             }
                         }
                     }
-
-                    items(notes, key = { it.id }, contentType = { "post" }) { event ->
-                        val profile = eventRepo.getProfileData(event.pubkey)
-                        val translationState = remember(relayTranslationVersion, event.id) {
-                            translationRepo?.getState(event.id) ?: com.wisp.app.repo.TranslationState()
-                        }
-                        PostCard(
-                            event = event,
-                            profile = profile,
-                            onReply = { onReply(event) },
-                            onProfileClick = { onProfileClick(event.pubkey) },
-                            onNavigateToProfile = onProfileClick,
-                            onNoteClick = { onNoteClick(event) },
-                            onQuotedNoteClick = onQuotedNoteClick,
-                            onReact = { emoji -> onReact(event, emoji) },
-                            eventRepo = eventRepo,
-                            onFollowAuthor = { onToggleFollow(event.pubkey) },
-                            onBlockAuthor = { onBlockUser(event.pubkey) },
-                            isOwnEvent = event.pubkey == userPubkey,
-                            onAddToList = { onAddToList(event.id) },
-                            isInList = event.id in listedIds,
-                            onDelete = { onDeleteEvent(event.id, event.kind) },
-                            translationState = translationState,
-                            onTranslate = { translationRepo?.translate(event.id, event.content) }
-                        )
-                    }
                 }
-            }
-        }
-    }
-    } // Column
-}
-
-@Composable
-private fun ResultFilterSelector(
-    localFilter: LocalFilter,
-    onSelectFilter: (LocalFilter) -> Unit
-) {
-    Row(
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        FilterChip(
-            selected = localFilter == LocalFilter.PEOPLE,
-            onClick = { onSelectFilter(LocalFilter.PEOPLE) },
-            label = { Text("People") },
-            colors = FilterChipDefaults.filterChipColors(
-                selectedContainerColor = MaterialTheme.colorScheme.primary,
-                selectedLabelColor = MaterialTheme.colorScheme.onPrimary
-            )
-        )
-        FilterChip(
-            selected = localFilter == LocalFilter.NOTES,
-            onClick = { onSelectFilter(LocalFilter.NOTES) },
-            label = { Text("Notes") },
-            colors = FilterChipDefaults.filterChipColors(
-                selectedContainerColor = MaterialTheme.colorScheme.primary,
-                selectedLabelColor = MaterialTheme.colorScheme.onPrimary
-            )
-        )
-    }
-}
-
-@Composable
-private fun SearchBar(
-    query: String,
-    onQueryChange: (String) -> Unit,
-    onClear: () -> Unit,
-    onSearch: (() -> Unit)? = null
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        OutlinedTextField(
-            value = query,
-            onValueChange = onQueryChange,
-            placeholder = { Text("Search users and notes") },
-            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-            trailingIcon = {
-                if (query.isNotEmpty()) {
-                    IconButton(onClick = onClear) {
-                        Icon(Icons.Default.Clear, contentDescription = "Clear")
-                    }
-                }
-            },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = if (onSearch != null) ImeAction.Search else ImeAction.Done),
-            keyboardActions = KeyboardActions(
-                onSearch = { onSearch?.invoke() }
-            ),
-            modifier = Modifier.weight(1f)
-        )
-        if (onSearch != null) {
-            IconButton(onClick = onSearch) {
-                Icon(Icons.Default.Search, contentDescription = "Go")
             }
         }
     }
@@ -541,21 +271,30 @@ private fun SearchBar(
 @Composable
 private fun RelaySelector(
     searchRelays: List<String>,
-    selectedRelay: String?,
-    onSelectRelay: (String?) -> Unit,
+    selectedOption: RelayOption,
+    selectedRelayUrl: String?,
+    onSelectDefault: () -> Unit,
+    onSelectAllRelays: () -> Unit,
+    onSelectRelay: (String) -> Unit,
     onAddRelay: (String) -> Boolean,
     onRemoveRelay: (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
     var showAddDialog by remember { mutableStateOf(false) }
 
+    val displayText = when (selectedOption) {
+        RelayOption.DEFAULT -> SearchViewModel.DEFAULT_SEARCH_RELAY.removePrefix("wss://")
+        RelayOption.ALL_RELAYS -> "All relays"
+        RelayOption.INDIVIDUAL -> selectedRelayUrl?.removePrefix("wss://") ?: ""
+    }
+
     ExposedDropdownMenuBox(
         expanded = expanded,
         onExpandedChange = { expanded = it },
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        modifier = Modifier.padding(horizontal = 16.dp)
     ) {
         OutlinedTextField(
-            value = selectedRelay?.removePrefix("wss://") ?: "All relays",
+            value = displayText,
             onValueChange = {},
             readOnly = true,
             label = { Text("Search relay") },
@@ -569,13 +308,20 @@ private fun RelaySelector(
             expanded = expanded,
             onDismissRequest = { expanded = false }
         ) {
+            // Default search relay
             DropdownMenuItem(
-                text = { Text("All relays") },
+                text = { Text(SearchViewModel.DEFAULT_SEARCH_RELAY.removePrefix("wss://")) },
                 onClick = {
-                    onSelectRelay(null)
+                    onSelectDefault()
                     expanded = false
                 }
             )
+
+            if (searchRelays.isNotEmpty()) {
+                HorizontalDivider()
+            }
+
+            // User's search relays
             searchRelays.forEach { url ->
                 DropdownMenuItem(
                     text = {
@@ -603,7 +349,21 @@ private fun RelaySelector(
                     }
                 )
             }
+
             HorizontalDivider()
+
+            // All relays option
+            DropdownMenuItem(
+                text = { Text("All relays") },
+                onClick = {
+                    onSelectAllRelays()
+                    expanded = false
+                }
+            )
+
+            HorizontalDivider()
+
+            // Add new relay
             DropdownMenuItem(
                 text = { Text("Add new") },
                 leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
@@ -659,46 +419,6 @@ private fun AddRelayDialog(
             }
         }
     )
-}
-
-@Composable
-private fun ListResultItem(
-    followSet: FollowSet,
-    eventRepo: EventRepository,
-    onClick: () -> Unit
-) {
-    val authorProfile = eventRepo.getProfileData(followSet.pubkey)
-    val authorName = authorProfile?.displayString
-        ?: followSet.pubkey.take(8) + "..."
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = followSet.name,
-                style = MaterialTheme.typography.bodyLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = "by $authorName",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1
-            )
-        }
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = "${followSet.members.size} members",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/HashtagFeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/HashtagFeedViewModel.kt
@@ -9,7 +9,6 @@ import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.EventRepository
-import com.wisp.app.repo.KeyRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,8 +18,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
 class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
-    private val keyRepo = KeyRepository(app)
-
     private val _notes = MutableStateFlow<List<NostrEvent>>(emptyList())
     val notes: StateFlow<List<NostrEvent>> = _notes
 
@@ -35,10 +32,9 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
     private var loadJob: Job? = null
     private val activeSubIds = mutableListOf<String>()
     private var topRelayUrls: List<String> = emptyList()
-
-    companion object {
-        private const val NOTE_SUB = "hashtag-notes"
-    }
+    private var loadCounter = 0
+    private var noteSub = "hashtag-notes-0"
+    private var engagePrefix = "hashtag-engage-0"
 
     fun loadHashtag(
         tag: String,
@@ -46,8 +42,6 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
         eventRepo: EventRepository,
         topRelayUrls: List<String> = emptyList()
     ) {
-        if (tag == _hashtag.value && _notes.value.isNotEmpty()) return
-
         loadJob?.cancel()
         relayPoolRef?.let { closeAllSubs(it) }
 
@@ -58,25 +52,18 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
         eventRepoRef = eventRepo
         this.topRelayUrls = topRelayUrls
 
-        val noteFilter = Filter(kinds = listOf(1), tTags = listOf(tag), limit = 100)
-        val noteReq = ClientMessage.req(NOTE_SUB, noteFilter)
-        activeSubIds.add(NOTE_SUB)
+        loadCounter++
+        noteSub = "hashtag-notes-$loadCounter"
+        engagePrefix = "hashtag-engage-$loadCounter"
 
-        val searchRelays = keyRepo.getSearchRelays().ifEmpty { SearchViewModel.DEFAULT_SEARCH_RELAYS }
-        for (url in searchRelays) {
-            relayPool.sendToRelayOrEphemeral(url, noteReq)
-        }
-        // Also query top scored relays
-        for (url in topRelayUrls) {
-            relayPool.sendToRelayOrEphemeral(url, noteReq)
-        }
+        val currentNoteSub = noteSub
 
         val seenIds = mutableSetOf<String>()
 
         loadJob = viewModelScope.launch {
             val eventJob = launch {
                 relayPool.relayEvents.collect { relayEvent ->
-                    if (relayEvent.subscriptionId == NOTE_SUB) {
+                    if (relayEvent.subscriptionId == currentNoteSub) {
                         val event = relayEvent.event
                         if (event.kind == 1 && event.id !in seenIds) {
                             seenIds.add(event.id)
@@ -87,7 +74,7 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
                             _notes.value = current
                         }
                     }
-                    if (relayEvent.subscriptionId.startsWith("hashtag-engage")) {
+                    if (relayEvent.subscriptionId.startsWith(engagePrefix)) {
                         when (relayEvent.event.kind) {
                             7 -> eventRepo.addEvent(relayEvent.event)
                             9735 -> eventRepo.addEvent(relayEvent.event)
@@ -100,9 +87,19 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
                 }
             }
 
+            // Send REQs after collectors are active
+            val noteFilter = Filter(kinds = listOf(1), tTags = listOf(tag), limit = 100)
+            val noteReq = ClientMessage.req(currentNoteSub, noteFilter)
+            activeSubIds.add(currentNoteSub)
+
+            relayPool.sendToRelayOrEphemeral(SearchViewModel.DEFAULT_SEARCH_RELAY, noteReq)
+            for (url in topRelayUrls) {
+                relayPool.sendToRelayOrEphemeral(url, noteReq)
+            }
+
             // Wait for EOSE or timeout, then subscribe engagement
             withTimeoutOrNull(5_000) {
-                relayPool.eoseSignals.first { it == NOTE_SUB }
+                relayPool.eoseSignals.first { it == currentNoteSub }
             }
             _isLoading.value = false
             subscribeEngagement(relayPool, eventRepo)
@@ -119,7 +116,7 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
         if (eventIds.isEmpty()) return
 
         eventIds.chunked(50).forEachIndexed { index, batch ->
-            val subId = if (index == 0) "hashtag-engage" else "hashtag-engage-$index"
+            val subId = if (index == 0) engagePrefix else "$engagePrefix-$index"
             activeSubIds.add(subId)
             val filters = listOf(
                 Filter(kinds = listOf(7), eTags = batch),
@@ -129,11 +126,7 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
             for (url in topRelayUrls) {
                 relayPool.sendToRelayOrEphemeral(url, ClientMessage.req(subId, filters))
             }
-            // Also send to search relays
-            val searchRelays = keyRepo.getSearchRelays().ifEmpty { SearchViewModel.DEFAULT_SEARCH_RELAYS }
-            for (url in searchRelays) {
-                relayPool.sendToRelayOrEphemeral(url, ClientMessage.req(subId, filters))
-            }
+            relayPool.sendToRelayOrEphemeral(SearchViewModel.DEFAULT_SEARCH_RELAY, ClientMessage.req(subId, filters))
         }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
@@ -5,8 +5,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Filter
-import com.wisp.app.nostr.FollowSet
-import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.ProfileData
 import com.wisp.app.relay.RelayConfig
@@ -14,17 +12,19 @@ import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.KeyRepository
 import com.wisp.app.repo.MuteRepository
-import com.wisp.app.repo.ProfileRepository
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-enum class SearchTab { MY_DEVICE, RELAYS }
-enum class LocalFilter { PEOPLE, NOTES }
+enum class SearchFilter { PEOPLE, NOTES }
+
+enum class RelayOption {
+    DEFAULT,
+    ALL_RELAYS,
+    INDIVIDUAL
+}
 
 class SearchViewModel(app: Application) : AndroidViewModel(app) {
     private val keyRepo = KeyRepository(app)
@@ -32,60 +32,54 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
     private val _query = MutableStateFlow("")
     val query: StateFlow<String> = _query
 
-    // Tab and filter state
-    private val _selectedTab = MutableStateFlow(SearchTab.MY_DEVICE)
-    val selectedTab: StateFlow<SearchTab> = _selectedTab
+    private val _filter = MutableStateFlow(SearchFilter.PEOPLE)
+    val filter: StateFlow<SearchFilter> = _filter
 
-    private val _localFilter = MutableStateFlow(LocalFilter.PEOPLE)
-    val localFilter: StateFlow<LocalFilter> = _localFilter
+    // Relay selection
+    private val _selectedRelayOption = MutableStateFlow(RelayOption.DEFAULT)
+    val selectedRelayOption: StateFlow<RelayOption> = _selectedRelayOption
 
-    // Local search results
-    private val _localUsers = MutableStateFlow<List<ProfileData>>(emptyList())
-    val localUsers: StateFlow<List<ProfileData>> = _localUsers
+    private val _selectedRelayUrl = MutableStateFlow<String?>(null)
+    val selectedRelayUrl: StateFlow<String?> = _selectedRelayUrl
 
-    private val _localNotes = MutableStateFlow<List<NostrEvent>>(emptyList())
-    val localNotes: StateFlow<List<NostrEvent>> = _localNotes
+    // User's search relays
+    private val _searchRelays = MutableStateFlow(keyRepo.getSearchRelays())
+    val searchRelays: StateFlow<List<String>> = _searchRelays
 
-    // Relay search results
+    // Results
     private val _users = MutableStateFlow<List<ProfileData>>(emptyList())
     val users: StateFlow<List<ProfileData>> = _users
 
     private val _notes = MutableStateFlow<List<NostrEvent>>(emptyList())
     val notes: StateFlow<List<NostrEvent>> = _notes
 
-    private val _lists = MutableStateFlow<List<FollowSet>>(emptyList())
-    val lists: StateFlow<List<FollowSet>> = _lists
-
     private val _isSearching = MutableStateFlow(false)
     val isSearching: StateFlow<Boolean> = _isSearching
 
-    // Search relay selection
-    private val _searchRelays = MutableStateFlow(
-        keyRepo.getSearchRelays().ifEmpty { DEFAULT_SEARCH_RELAYS }
-    )
-    val searchRelays: StateFlow<List<String>> = _searchRelays
-
-    private val _selectedRelay = MutableStateFlow<String?>(null)
-    val selectedRelay: StateFlow<String?> = _selectedRelay
-
     private var searchJob: Job? = null
-    private var localSearchJob: Job? = null
     private var relayPool: RelayPool? = null
+    private var searchCounter = 0
 
-    private val userSubId = "search-users"
-    private val noteSubId = "search-notes"
-    private val listSubId = "search-lists"
+    private var userSubId = "search-users-0"
+    private var noteSubId = "search-notes-0"
 
-    fun selectTab(tab: SearchTab) {
-        _selectedTab.value = tab
+    fun selectFilter(filter: SearchFilter) {
+        _filter.value = filter
     }
 
-    fun selectLocalFilter(filter: LocalFilter) {
-        _localFilter.value = filter
+    fun selectDefaultRelay() {
+        _selectedRelayOption.value = RelayOption.DEFAULT
+        _selectedRelayUrl.value = null
     }
 
-    fun selectRelay(url: String?) {
-        _selectedRelay.value = url
+    fun selectAllRelays() {
+        _selectedRelayOption.value = RelayOption.ALL_RELAYS
+        _selectedRelayUrl.value = null
+    }
+
+    fun selectRelay(url: String) {
+        _selectedRelayOption.value = RelayOption.INDIVIDUAL
+        _selectedRelayUrl.value = url
     }
 
     fun addSearchRelay(url: String): Boolean {
@@ -102,34 +96,13 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
         val updated = _searchRelays.value - url
         keyRepo.saveSearchRelays(updated)
         _searchRelays.value = updated
-        if (_selectedRelay.value == url) {
-            _selectedRelay.value = null
+        if (_selectedRelayOption.value == RelayOption.INDIVIDUAL && _selectedRelayUrl.value == url) {
+            selectDefaultRelay()
         }
     }
 
-    fun updateQuery(newQuery: String, profileRepo: ProfileRepository? = null, eventRepo: EventRepository? = null) {
+    fun updateQuery(newQuery: String) {
         _query.value = newQuery
-        if (profileRepo != null && eventRepo != null) {
-            searchLocal(newQuery, profileRepo, eventRepo)
-        }
-    }
-
-    private fun searchLocal(query: String, profileRepo: ProfileRepository, eventRepo: EventRepository) {
-        localSearchJob?.cancel()
-        if (query.isBlank()) {
-            _localUsers.value = emptyList()
-            _localNotes.value = emptyList()
-            return
-        }
-        localSearchJob = viewModelScope.launch {
-            delay(150) // debounce
-            withContext(Dispatchers.Default) {
-                val users = profileRepo.search(query, limit = 50)
-                val notes = eventRepo.searchNotes(query, limit = 50)
-                _localUsers.value = users
-                _localNotes.value = notes
-            }
-        }
     }
 
     fun search(query: String, relayPool: RelayPool, eventRepo: EventRepository, muteRepo: MuteRepository? = null) {
@@ -142,41 +115,40 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
         searchJob?.cancel()
         this.relayPool = relayPool
 
-        // Close previous subscriptions
         closeSubscriptions(relayPool)
+
+        searchCounter++
+        userSubId = "search-users-$searchCounter"
+        noteSubId = "search-notes-$searchCounter"
 
         _query.value = trimmed
         _isSearching.value = true
         _users.value = emptyList()
         _notes.value = emptyList()
-        _lists.value = emptyList()
 
         val userFilter = Filter(kinds = listOf(0), search = trimmed, limit = 20)
         val noteFilter = Filter(kinds = listOf(1), search = trimmed, limit = 50)
-        val listFilter = Filter(kinds = listOf(Nip51.KIND_FOLLOW_SET), search = trimmed, limit = 20)
 
         val userReq = ClientMessage.req(userSubId, userFilter)
         val noteReq = ClientMessage.req(noteSubId, noteFilter)
-        val listReq = ClientMessage.req(listSubId, listFilter)
 
-        val selected = _selectedRelay.value
-        val relaysToQuery = if (selected != null) listOf(selected) else _searchRelays.value
+        val relaysToQuery = when (_selectedRelayOption.value) {
+            RelayOption.DEFAULT -> listOf(DEFAULT_SEARCH_RELAY)
+            RelayOption.ALL_RELAYS -> _searchRelays.value
+            RelayOption.INDIVIDUAL -> listOfNotNull(_selectedRelayUrl.value)
+        }
 
         for (url in relaysToQuery) {
             relayPool.sendToRelayOrEphemeral(url, userReq)
             relayPool.sendToRelayOrEphemeral(url, noteReq)
-            relayPool.sendToRelayOrEphemeral(url, listReq)
         }
 
         val seenUserPubkeys = mutableSetOf<String>()
         val seenNoteIds = mutableSetOf<String>()
-        val seenListKeys = mutableSetOf<String>()
         var userEose = false
         var noteEose = false
-        var listEose = false
 
         searchJob = viewModelScope.launch {
-            // Collect events
             val eventJob = launch {
                 relayPool.relayEvents.collect { relayEvent ->
                     when (relayEvent.subscriptionId) {
@@ -201,36 +173,22 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
                                 eventRepo.cacheEvent(event)
                             }
                         }
-                        listSubId -> {
-                            val event = relayEvent.event
-                            val key = "${event.pubkey}:${event.id}"
-                            if (event.kind == Nip51.KIND_FOLLOW_SET && key !in seenListKeys) {
-                                seenListKeys.add(key)
-                                val followSet = Nip51.parseFollowSet(event)
-                                if (followSet != null) {
-                                    _lists.value = _lists.value + followSet
-                                }
-                            }
-                        }
                     }
                 }
             }
 
-            // Collect EOSE signals
             val eoseJob = launch {
                 relayPool.eoseSignals.collect { subId ->
                     when (subId) {
                         userSubId -> userEose = true
                         noteSubId -> noteEose = true
-                        listSubId -> listEose = true
                     }
-                    if (userEose && noteEose && listEose) {
+                    if (userEose && noteEose) {
                         _isSearching.value = false
                     }
                 }
             }
 
-            // Timeout after 5 seconds
             delay(5000)
             _isSearching.value = false
             closeSubscriptions(relayPool)
@@ -241,30 +199,19 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
 
     fun clear() {
         searchJob?.cancel()
-        localSearchJob?.cancel()
         relayPool?.let { closeSubscriptions(it) }
         _query.value = ""
         _users.value = emptyList()
         _notes.value = emptyList()
-        _lists.value = emptyList()
-        _localUsers.value = emptyList()
-        _localNotes.value = emptyList()
         _isSearching.value = false
     }
 
     companion object {
-        val DEFAULT_SEARCH_RELAYS = listOf(
-            "wss://relay.nostr.band",
-            "wss://search.nos.today"
-        )
+        const val DEFAULT_SEARCH_RELAY = "wss://search.nostrarchives.com"
     }
 
     private fun closeSubscriptions(relayPool: RelayPool) {
-        val closeUsers = ClientMessage.close(userSubId)
-        val closeNotes = ClientMessage.close(noteSubId)
-        val closeLists = ClientMessage.close(listSubId)
-        relayPool.sendToAll(closeUsers)
-        relayPool.sendToAll(closeNotes)
-        relayPool.sendToAll(closeLists)
+        relayPool.closeOnAllRelays(userSubId)
+        relayPool.closeOnAllRelays(noteSubId)
     }
 }


### PR DESCRIPTION
## Summary
- Add `search-` and `hashtag-` to `RelayPool.dedupBypassPrefixes` so previously-seen events are not silently dropped on repeat queries
- Simplify SearchScreen by removing tabs and local filter in favor of relay-based search with filter options
- Add scroll-to-top behavior on hashtag feed reload

## Test plan
- [ ] Search for a term → see results → search same term again → same results should appear
- [ ] Click a hashtag → see notes → go back → click same hashtag → same notes should appear
- [ ] Verify search filter options (notes, profiles) work correctly
- [ ] Verify hashtag feed scrolls to top on reload