### PR TITLE
feat: improve compose mention search and display

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -307,7 +307,7 @@ fun WispNavHost(
 
     // Initialize compose viewmodel with shared repos
     LaunchedEffect(Unit) {
-        composeViewModel.init(feedViewModel.profileRepo, feedViewModel.contactRepo, feedViewModel.relayPool, feedViewModel.eventRepo)
+        composeViewModel.init(feedViewModel.profileRepo, feedViewModel.contactRepo, feedViewModel.relayPool, feedViewModel.eventRepo, feedViewModel.eventPersistence)
     }
 
     // Initialize DM list viewmodel with shared repo

--- a/app/src/main/kotlin/com/wisp/app/db/EventPersistence.kt
+++ b/app/src/main/kotlin/com/wisp/app/db/EventPersistence.kt
@@ -76,6 +76,23 @@ class EventPersistence(
         }
     }
 
+    fun searchProfiles(query: String, limit: Int = 500): List<NostrEvent> {
+        if (query.isBlank()) return emptyList()
+        return try {
+            val entities = box.query(
+                EventEntity_.kind.equal(0)
+                    .and(EventEntity_.content.contains(query, StringOrder.CASE_INSENSITIVE))
+            )
+                .order(EventEntity_.createdAt, io.objectbox.query.QueryBuilder.DESCENDING)
+                .build()
+                .use { it.find(0, limit.toLong()) }
+            entities.mapNotNull { it.toNostrEvent() }
+        } catch (e: Exception) {
+            Log.w("EventPersistence", "searchProfiles failed: ${e.message}")
+            emptyList()
+        }
+    }
+
     fun searchNotes(query: String, limit: Int = 50): List<NostrEvent> {
         if (query.isBlank()) return emptyList()
         return try {

--- a/app/src/main/kotlin/com/wisp/app/repo/MentionSearchRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/MentionSearchRepository.kt
@@ -1,15 +1,11 @@
 package com.wisp.app.repo
 
-import com.wisp.app.nostr.ClientMessage
-import com.wisp.app.nostr.Filter
+import com.wisp.app.db.EventPersistence
 import com.wisp.app.nostr.ProfileData
 import com.wisp.app.relay.RelayPool
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 data class MentionCandidate(
     val profile: ProfileData,
@@ -25,92 +21,57 @@ class MentionSearchRepository(
     private val _candidates = MutableStateFlow<List<MentionCandidate>>(emptyList())
     val candidates: StateFlow<List<MentionCandidate>> = _candidates
 
-    private var remoteJob: Job? = null
-    private val subId = "mention-search"
-
-    companion object {
-        private val DEFAULT_SEARCH_RELAYS = listOf(
-            "wss://relay.nostr.band",
-            "wss://search.nos.today"
-        )
-    }
+    var eventPersistence: EventPersistence? = null
 
     fun search(query: String, scope: CoroutineScope) {
-        remoteJob?.cancel()
-        closeSubscription()
-
         if (query.isBlank()) {
-            val contacts = contactRepo.getFollowList().take(8).mapNotNull { entry ->
+            val contacts = contactRepo.getFollowList().take(5).mapNotNull { entry ->
                 profileRepo.get(entry.pubkey)?.let { MentionCandidate(it, isContact = true) }
             }
             _candidates.value = contacts
             return
         }
 
-        // Local search — instant
-        val localResults = profileRepo.search(query, limit = 20)
-        val followSet = contactRepo.getFollowList().map { it.pubkey }.toSet()
+        val lowerQuery = query.lowercase()
+        val followPubkeys = contactRepo.getFollowList().map { it.pubkey }.toSet()
 
-        val (contacts, others) = localResults.partition { it.pubkey in followSet }
-        val localCandidates = contacts.map { MentionCandidate(it, isContact = true) } +
-            others.map { MentionCandidate(it, isContact = false) }
+        // First: search contacts only via ProfileRepository
+        val contactResults = followPubkeys.mapNotNull { pubkey ->
+            val profile = profileRepo.get(pubkey) ?: return@mapNotNull null
+            val nameMatch = profile.name?.lowercase()?.contains(lowerQuery) == true
+            val displayMatch = profile.displayName?.lowercase()?.contains(lowerQuery) == true
+            if (!nameMatch && !displayMatch) return@mapNotNull null
+            MentionCandidate(profile, isContact = true)
+        }.take(5)
 
-        _candidates.value = localCandidates.take(10)
-
-        // Remote search — debounced 300ms
-        remoteJob = scope.launch {
-            delay(300)
-
-            val filter = Filter(kinds = listOf(0), search = query, limit = 10)
-            val req = ClientMessage.req(subId, filter)
-            val searchRelays = keyRepo.getSearchRelays().ifEmpty { DEFAULT_SEARCH_RELAYS }
-
-            for (url in searchRelays) {
-                relayPool.sendToRelayOrEphemeral(url, req)
-            }
-
-            val seenPubkeys = _candidates.value.map { it.profile.pubkey }.toMutableSet()
-
-            // Collect events with 3s timeout
-            val collectJob = launch {
-                relayPool.relayEvents.collect { relayEvent ->
-                    if (relayEvent.subscriptionId != subId) return@collect
-                    val event = relayEvent.event
-                    if (event.kind == 0 && event.pubkey !in seenPubkeys) {
-                        seenPubkeys.add(event.pubkey)
-                        val profile = ProfileData.fromEvent(event) ?: return@collect
-                        profileRepo.updateFromEvent(event)
-                        val candidate = MentionCandidate(profile, event.pubkey in followSet)
-                        _candidates.value = _candidates.value + candidate
-                    }
-                }
-            }
-
-            // Also listen for EOSE to stop early
-            val eoseJob = launch {
-                relayPool.eoseSignals.collect { sid ->
-                    if (sid == subId) {
-                        collectJob.cancel()
-                    }
-                }
-            }
-
-            delay(3000)
-            collectJob.cancel()
-            eoseJob.cancel()
-            closeSubscription()
+        if (contactResults.size >= 5) {
+            _candidates.value = contactResults
+            return
         }
-    }
 
-    private fun closeSubscription() {
-        try {
-            relayPool.sendToAll(ClientMessage.close(subId))
-        } catch (_: Exception) {}
+        // Fill remaining slots from ObjectBox
+        val persistence = eventPersistence
+        if (persistence == null) {
+            _candidates.value = contactResults
+            return
+        }
+
+        val seenPubkeys = contactResults.map { it.profile.pubkey }.toMutableSet()
+        val remaining = 5 - contactResults.size
+        val events = persistence.searchProfiles(query, limit = 500)
+        val dbResults = events.mapNotNull { event ->
+            if (!seenPubkeys.add(event.pubkey)) return@mapNotNull null
+            val profile = ProfileData.fromEvent(event) ?: return@mapNotNull null
+            val nameMatch = profile.name?.lowercase()?.contains(lowerQuery) == true
+            val displayMatch = profile.displayName?.lowercase()?.contains(lowerQuery) == true
+            if (!nameMatch && !displayMatch) return@mapNotNull null
+            MentionCandidate(profile, isContact = false)
+        }.take(remaining)
+
+        _candidates.value = contactResults + dbResults
     }
 
     fun clear() {
-        remoteJob?.cancel()
-        closeSubscription()
         _candidates.value = emptyList()
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/MentionVisualTransformation.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/MentionVisualTransformation.kt
@@ -1,36 +1,22 @@
 package com.wisp.app.ui.component
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.OffsetMapping
-import androidx.compose.ui.text.input.TransformedText
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
 
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
 
-class MentionVisualTransformation(
-    private val accentColor: Color,
+@OptIn(ExperimentalFoundationApi::class)
+class MentionOutputTransformation(
     private val resolveDisplayName: (String) -> String?
-) : VisualTransformation {
+) : OutputTransformation {
 
-    override fun filter(text: AnnotatedString): TransformedText {
-        val original = text.text
+    override fun TextFieldBuffer.transformOutput() {
+        val original = asCharSequence().toString()
         val matches = NOSTR_URI_REGEX.findAll(original).toList()
+        if (matches.isEmpty()) return
 
-        if (matches.isEmpty()) {
-            return TransformedText(text, OffsetMapping.Identity)
-        }
-
-        val builder = AnnotatedString.Builder()
-        val mentionStyle = SpanStyle(color = accentColor, fontWeight = FontWeight.Medium)
-
-        data class Replacement(val origStart: Int, val origEnd: Int, val displayText: String)
-
-        val replacements = mutableListOf<Replacement>()
-
-        for (match in matches) {
+        for (match in matches.asReversed()) {
             val bech32 = match.groupValues[1]
             val display = when {
                 bech32.startsWith("npub1") || bech32.startsWith("nprofile1") -> {
@@ -41,66 +27,7 @@ class MentionVisualTransformation(
                 bech32.startsWith("nevent1") -> "\uD83D\uDD17${bech32.take(14)}..."  // 🔗
                 else -> bech32.take(12) + "..."
             }
-            replacements.add(Replacement(match.range.first, match.range.last + 1, display))
+            replace(match.range.first, match.range.last + 1, display)
         }
-
-        // Build transformed string
-        var lastEnd = 0
-        for (r in replacements) {
-            if (r.origStart > lastEnd) {
-                builder.append(original.substring(lastEnd, r.origStart))
-            }
-            builder.pushStyle(mentionStyle)
-            builder.append(r.displayText)
-            builder.pop()
-            lastEnd = r.origEnd
-        }
-        if (lastEnd < original.length) {
-            builder.append(original.substring(lastEnd))
-        }
-
-        val transformedText = builder.toAnnotatedString()
-
-        // Build offset mapping
-        val offsetMapping = MentionOffsetMapping(original.length, transformedText.length, replacements.map {
-            Triple(it.origStart, it.origEnd, it.displayText.length)
-        })
-
-        return TransformedText(transformedText, offsetMapping)
-    }
-}
-
-private class MentionOffsetMapping(
-    private val originalLength: Int,
-    private val transformedLength: Int,
-    private val replacements: List<Triple<Int, Int, Int>> // (origStart, origEnd, displayLen)
-) : OffsetMapping {
-
-    override fun originalToTransformed(offset: Int): Int {
-        var shift = 0
-        for ((origStart, origEnd, displayLen) in replacements) {
-            if (offset <= origStart) break
-            if (offset < origEnd) {
-                // Cursor is inside a mention — map to end of display text
-                return origStart + shift + displayLen
-            }
-            shift += displayLen - (origEnd - origStart)
-        }
-        return (offset + shift).coerceIn(0, transformedLength)
-    }
-
-    override fun transformedToOriginal(offset: Int): Int {
-        var shift = 0
-        for ((origStart, origEnd, displayLen) in replacements) {
-            val transStart = origStart + shift
-            val transEnd = transStart + displayLen
-            if (offset <= transStart) break
-            if (offset <= transEnd) {
-                // Cursor is inside a display mention — map to end of original mention
-                return origEnd
-            }
-            shift += displayLen - (origEnd - origStart)
-        }
-        return (offset - shift).coerceIn(0, originalLength)
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -37,8 +37,10 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -87,7 +89,7 @@ import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.MentionCandidate
 import com.wisp.app.repo.ProfileRepository
-import com.wisp.app.ui.component.MentionVisualTransformation
+import com.wisp.app.ui.component.MentionOutputTransformation
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.component.RichContent
 import com.wisp.app.viewmodel.ComposeViewModel
@@ -95,13 +97,17 @@ import com.wisp.app.viewmodel.PowManager
 import com.wisp.app.viewmodel.PowStatus
 import com.wisp.app.repo.PowPreferences
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.animation.animateContentSize
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.outlined.Tag
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
 @Composable
 fun ComposeScreen(
     viewModel: ComposeViewModel,
@@ -128,6 +134,7 @@ fun ComposeScreen(
     val mentionCandidates by viewModel.mentionCandidates.collectAsState()
     val mentionQuery by viewModel.mentionQuery.collectAsState()
     val explicit by viewModel.explicit.collectAsState()
+    val hashtags by viewModel.hashtags.collectAsState()
     val powEnabled by viewModel.powEnabled.collectAsState()
     val powStatus = powManager?.status?.collectAsState()?.value ?: PowStatus.Idle
     val isMiningBusy = powStatus is PowStatus.Mining
@@ -141,12 +148,10 @@ fun ComposeScreen(
         if (uris.isNotEmpty()) viewModel.uploadMedia(uris, context.contentResolver, signer)
     }
 
-    val accentColor = MaterialTheme.colorScheme.primary
-    val visualTransformation = remember(accentColor, profileRepo) {
-        MentionVisualTransformation(
-            accentColor = accentColor,
+    val outputTransformation = remember(profileRepo) {
+        MentionOutputTransformation(
             resolveDisplayName = { bech32 ->
-                if (profileRepo == null) return@MentionVisualTransformation null
+                if (profileRepo == null) return@MentionOutputTransformation null
                 try {
                     val data = Nip19.decodeNostrUri("nostr:$bech32")
                     if (data is com.wisp.app.nostr.NostrUriData.ProfileRef) {
@@ -181,13 +186,13 @@ fun ComposeScreen(
             )
         }
     ) { padding ->
-        // Outer non-scrollable Column handles IME padding
         Column(
             modifier = Modifier
                 .padding(padding)
+                .consumeWindowInsets(WindowInsets.navigationBars)
                 .imePadding()
         ) {
-            // Inner scrollable content takes remaining space
+            // Scrollable content takes remaining space
             Column(
                 modifier = Modifier
                     .weight(1f)
@@ -364,6 +369,7 @@ fun ComposeScreen(
                     enabled = enabled,
                     keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
                     lineLimits = TextFieldLineLimits.MultiLine(),
+                    outputTransformation = outputTransformation,
                     textStyle = MaterialTheme.typography.bodyLarge.copy(
                         color = MaterialTheme.colorScheme.onSurface
                     ),
@@ -373,40 +379,12 @@ fun ComposeScreen(
                             innerTextField = innerTextField,
                             enabled = enabled,
                             singleLine = false,
-                            visualTransformation = visualTransformation,
+                            visualTransformation = androidx.compose.ui.text.input.VisualTransformation.None,
                             interactionSource = interactionSource,
                             label = { Text("What's on your mind?") }
                         )
                     }
                 )
-
-                // Media previews
-                if (uploadedUrls.isNotEmpty()) {
-                    Spacer(Modifier.height(8.dp))
-                    uploadedUrls.forEach { url ->
-                        Box(modifier = Modifier.padding(bottom = 8.dp)) {
-                            AsyncImage(
-                                model = url,
-                                contentDescription = "Attached media",
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(200.dp)
-                                    .clip(RoundedCornerShape(8.dp)),
-                                contentScale = ContentScale.Crop
-                            )
-                            IconButton(
-                                onClick = { viewModel.removeMediaUrl(url) },
-                                modifier = Modifier.align(Alignment.TopEnd)
-                            ) {
-                                Icon(
-                                    Icons.Default.Close,
-                                    contentDescription = "Remove",
-                                    tint = MaterialTheme.colorScheme.onSurface
-                                )
-                            }
-                        }
-                    }
-                }
 
                 // Attach row with preview toggle
                 Spacer(Modifier.height(4.dp))
@@ -469,6 +447,48 @@ fun ComposeScreen(
                     }
                 }
 
+                // Hashtag chips
+                AnimatedVisibility(
+                    visible = hashtags.isNotEmpty(),
+                    enter = expandVertically() + fadeIn(),
+                    exit = shrinkVertically() + fadeOut()
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.Top,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp, horizontal = 4.dp)
+                    ) {
+                        Icon(
+                            Icons.Outlined.Tag,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f),
+                            modifier = Modifier
+                                .size(16.dp)
+                                .padding(top = 2.dp)
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            hashtags.forEach { tag ->
+                                Surface(
+                                    shape = RoundedCornerShape(12.dp),
+                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                                ) {
+                                    Text(
+                                        text = "#$tag",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // NSFW feedback banner
                 AnimatedVisibility(
                     visible = explicit,
@@ -497,41 +517,6 @@ fun ComposeScreen(
                                 text = "Marked as NSFW",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onErrorContainer
-                            )
-                        }
-                    }
-                }
-
-                // PoW enabled banner
-                AnimatedVisibility(
-                    visible = powEnabled,
-                    enter = expandVertically() + fadeIn(),
-                    exit = shrinkVertically() + fadeOut()
-                ) {
-                    val difficulty = powPrefs?.getNoteDifficulty() ?: 16
-                    Surface(
-                        shape = RoundedCornerShape(8.dp),
-                        color = Color(0xFFFF9800).copy(alpha = 0.12f),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 4.dp)
-                    ) {
-                        val orange = Color(0xFFFF9800)
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
-                        ) {
-                            Icon(
-                                Icons.Outlined.Shield,
-                                contentDescription = null,
-                                tint = orange,
-                                modifier = Modifier.size(18.dp)
-                            )
-                            Spacer(Modifier.width(8.dp))
-                            Text(
-                                text = "PoW: $difficulty bits (mined in background)",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = orange
                             )
                         }
                     }
@@ -594,7 +579,7 @@ fun ComposeScreen(
             }
 
             // Bottom bar — always visible above keyboard
-            Column(modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 8.dp, top = 4.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp)) {
                 if (countdownSeconds != null) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.launch
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
 // Matches bare bech32 IDs not already preceded by "nostr:" or embedded in a URL
 private val BARE_BECH32_REGEX = Regex("(?<!nostr:)(?<![a-z0-9/.:#])((note1|nevent1|npub1|nprofile1)[a-z0-9]{10,})")
+private val HASHTAG_REGEX = Regex("(?:^|(?<=\\s))#([a-zA-Z0-9_]+)")
 
 class ComposeViewModel(app: Application, private val savedStateHandle: SavedStateHandle) : AndroidViewModel(app) {
     private val keyRepo = KeyRepository(app)
@@ -74,6 +75,9 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
     private val _mentionCandidates = MutableStateFlow<List<MentionCandidate>>(emptyList())
     val mentionCandidates: StateFlow<List<MentionCandidate>> = _mentionCandidates
 
+    private val _hashtags = MutableStateFlow<List<String>>(emptyList())
+    val hashtags: StateFlow<List<String>> = _hashtags
+
     private val _explicit = MutableStateFlow(false)
     val explicit: StateFlow<Boolean> = _explicit
 
@@ -104,11 +108,13 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
     var currentDraftId: String? = null
         private set
 
-    fun init(profileRepo: ProfileRepository, contactRepo: ContactRepository, relayPool: RelayPool, eventRepo: EventRepository? = null) {
+    fun init(profileRepo: ProfileRepository, contactRepo: ContactRepository, relayPool: RelayPool, eventRepo: EventRepository? = null, eventPersistence: com.wisp.app.db.EventPersistence? = null) {
         if (initialized) return
         initialized = true
         this.eventRepo = eventRepo
-        mentionSearchRepo = MentionSearchRepository(profileRepo, contactRepo, relayPool, keyRepo)
+        mentionSearchRepo = MentionSearchRepository(profileRepo, contactRepo, relayPool, keyRepo).also {
+            it.eventPersistence = eventPersistence
+        }
         // Forward candidates from search repo
         viewModelScope.launch {
             mentionSearchRepo!!.candidates.collect { _mentionCandidates.value = it }
@@ -170,6 +176,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         _content.value = prefixed
         savedStateHandle["draft_content"] = prefixed.text
         detectMentionQuery(prefixed)
+        detectHashtags(prefixed.text)
     }
 
     private fun prefixBareBech32(value: TextFieldValue): TextFieldValue {
@@ -219,6 +226,13 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         val query = text.substring(atIndex + 1, cursor)
         _mentionQuery.value = query
         mentionSearchRepo?.search(query, viewModelScope)
+    }
+
+    private fun detectHashtags(text: String) {
+        _hashtags.value = HASHTAG_REGEX.findAll(text)
+            .map { it.groupValues[1].lowercase() }
+            .distinct()
+            .toList()
     }
 
     private fun clearMentionState() {
@@ -361,6 +375,10 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             Nip18.appendNoteUri(content, quoteTo.id, relayHints, quoteTo.pubkey)
         } else {
             content
+        }
+
+        for (hashtag in _hashtags.value) {
+            tags.add(listOf("t", hashtag))
         }
 
         if (interfacePrefs.isClientTagEnabled()) {
@@ -540,6 +558,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         _uploadedUrls.value = emptyList()
         _uploadProgress.value = null
         _explicit.value = false
+        _hashtags.value = emptyList()
         _powEnabled.value = false
         clearMentionState()
     }


### PR DESCRIPTION
## Summary
- Display `@name` instead of raw `nostr:nprofile1...` in compose text field using `OutputTransformation`
- Search mentions from ObjectBox (persisted kind 0 events) instead of in-memory LruCache — contacts are searched first via ProfileRepository, remaining slots filled from DB
- Filter mention results by name/displayName only, cap at 5 results
- Remove duplicate media previews below text field (already visible in live preview)

## Test plan
- [ ] Type `@` followed by a name of someone you follow — should appear at top of results
- [ ] Select a mention — should display as `@name` in the text field, publish as `nostr:nprofile1...`
- [ ] Backspace into a mention — should delete the entire mention
- [ ] Upload media — no duplicate preview below text field, visible in live preview only
- [ ] Search for a name you don't follow — should show results from ObjectBox after contact results