### PR TITLE
fix: fetch interest sets from outbox relays when not cached

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1174,12 +1174,17 @@ fun WispNavHost(
                 )
             }
             val interestSets by feedViewModel.interestRepo.sets.collectAsState()
+            val interestSetsFetched by feedViewModel.interestSetsFetched.collectAsState()
+            LaunchedEffect(Unit) {
+                feedViewModel.fetchInterestSetsIfMissing()
+            }
             HashtagFeedScreen(
                 viewModel = hashtagFeedViewModel,
                 eventRepo = feedViewModel.eventRepo,
                 userPubkey = feedViewModel.getUserPubkey(),
                 noteActions = hashtagNoteActions,
                 interestSets = interestSets,
+                interestSetsLoaded = interestSetsFetched,
                 onFollowHashtag = { dTag -> feedViewModel.followHashtag(tag, dTag) },
                 onUnfollowHashtag = { dTag -> feedViewModel.unfollowHashtag(tag, dTag) },
                 onCreateDefaultSet = {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -309,8 +309,13 @@ fun FeedScreen(
     }
 
     if (showHashtagPicker) {
+        val interestSetsLoaded by viewModel.interestSetsFetched.collectAsState()
+        LaunchedEffect(Unit) {
+            viewModel.fetchInterestSetsIfMissing()
+        }
         HashtagPickerDialog(
             sets = interestSets,
+            isLoading = !interestSetsLoaded && interestSets.isEmpty(),
             onSelectHashtag = { tag ->
                 showHashtagPicker = false
                 onHashtagClick?.invoke(tag)
@@ -1622,6 +1627,7 @@ private fun ListPickerDialog(
 @Composable
 private fun HashtagPickerDialog(
     sets: List<com.wisp.app.nostr.InterestSet>,
+    isLoading: Boolean = false,
     onSelectHashtag: (String) -> Unit,
     onCreateSet: (String) -> Unit,
     onRenameSet: (String, String) -> Unit,
@@ -1638,7 +1644,20 @@ private fun HashtagPickerDialog(
         title = { Text("Hashtags") },
         text = {
             Column(modifier = Modifier.fillMaxWidth()) {
-                if (sets.isEmpty()) {
+                if (isLoading) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                        Spacer(Modifier.size(12.dp))
+                        Text(
+                            "Loading interest sets\u2026",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else if (sets.isEmpty()) {
                     Text(
                         "No interest sets yet. Create one below, or follow hashtags from their feed pages.",
                         color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/HashtagFeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/HashtagFeedScreen.kt
@@ -56,6 +56,7 @@ fun HashtagFeedScreen(
     userPubkey: String?,
     noteActions: NoteActions,
     interestSets: List<InterestSet> = emptyList(),
+    interestSetsLoaded: Boolean = true,
     onFollowHashtag: (dTag: String) -> Unit = {},
     onUnfollowHashtag: (dTag: String) -> Unit = {},
     onCreateDefaultSet: () -> Unit = {},
@@ -95,22 +96,30 @@ fun HashtagFeedScreen(
                 },
                 actions = {
                     if (userPubkey != null) {
-                        IconButton(onClick = {
-                            val containingSets = interestSets.filter { hashtag.lowercase() in it.hashtags }
-                            if (containingSets.isNotEmpty()) {
-                                containingSets.forEach { onUnfollowHashtag(it.dTag) }
-                            } else if (interestSets.size == 1) {
-                                onFollowHashtag(interestSets.first().dTag)
-                            } else if (interestSets.isEmpty()) {
-                                onCreateDefaultSet()
-                            } else {
-                                showSetPicker = true
-                            }
-                        }) {
-                            Icon(
-                                if (isFollowing) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
-                                contentDescription = if (isFollowing) "Unfollow hashtag" else "Follow hashtag"
+                        if (!interestSetsLoaded && interestSets.isEmpty()) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp).padding(end = 4.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                        } else {
+                            IconButton(onClick = {
+                                val containingSets = interestSets.filter { hashtag.lowercase() in it.hashtags }
+                                if (containingSets.isNotEmpty()) {
+                                    containingSets.forEach { onUnfollowHashtag(it.dTag) }
+                                } else if (interestSets.size == 1) {
+                                    onFollowHashtag(interestSets.first().dTag)
+                                } else if (interestSets.isEmpty()) {
+                                    onCreateDefaultSet()
+                                } else {
+                                    showSetPicker = true
+                                }
+                            }) {
+                                Icon(
+                                    if (isFollowing) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
+                                    contentDescription = if (isFollowing) "Unfollow hashtag" else "Follow hashtag"
+                                )
+                            }
                         }
                     }
                 },

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -485,6 +485,51 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun renameInterestSet(dTag: String, newName: String) = listCrud.renameInterestSet(dTag, newName)
     fun deleteInterestSet(dTag: String) = listCrud.deleteInterestSet(dTag)
 
+    private val _interestSetsFetched = MutableStateFlow(false)
+    val interestSetsFetched: StateFlow<Boolean> = _interestSetsFetched
+
+    /**
+     * Fetch interest sets (kind 30015) from relays if none are cached locally.
+     * Called when entering hashtag feed to ensure we have up-to-date data.
+     */
+    suspend fun fetchInterestSetsIfMissing() {
+        if (interestRepo.sets.value.isNotEmpty()) {
+            _interestSetsFetched.value = true
+            return
+        }
+        val myPubkey = getUserPubkey() ?: run {
+            _interestSetsFetched.value = true
+            return
+        }
+
+        val subId = "interest_fetch_${myPubkey.take(8)}"
+        val filter = Filter(
+            kinds = listOf(Nip51.KIND_INTEREST_SET),
+            authors = listOf(myPubkey),
+            limit = 50
+        )
+
+        // Query own write (outbox) relays first, with fallback to all connected relays
+        outboxRouter.subscribeToUserWriteRelays(subId, myPubkey, filter)
+        // Also try indexer relays as safety net
+        val reqMsg = ClientMessage.req(subId, filter)
+        for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+            relayPool.sendToRelayOrEphemeral(url, reqMsg, skipBadCheck = true)
+        }
+
+        // Wait for events or timeout
+        withTimeoutOrNull(4000L) {
+            relayPool.relayEvents.first { it.subscriptionId == subId }
+        }
+
+        val closeMsg = ClientMessage.close(subId)
+        relayPool.closeOnAllRelays(subId)
+        for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+            relayPool.sendToRelay(url, closeMsg)
+        }
+        _interestSetsFetched.value = true
+    }
+
     fun setSelectedList(followSet: com.wisp.app.nostr.FollowSet) {
         listRepo.selectList(followSet)
     }


### PR DESCRIPTION
## Summary
- When opening the hashtag picker or hashtag feed screen, interest sets could appear empty if the startup relay fetch hadn't completed yet
- Added `fetchInterestSetsIfMissing()` that queries outbox relays + indexer relays with a 4s timeout
- Shows a loading spinner in both the hashtag picker dialog and the hashtag feed bookmark button while fetching

## Test plan
- [ ] Open hashtag picker from feed — should show loading spinner briefly, then display interest sets
- [ ] Navigate to a hashtag feed — bookmark button should show spinner while fetching, then the correct follow state
- [ ] If no interest sets exist, should show "No interest sets yet" message after loading completes