### PR TITLE
Fix interest set fetch & compose improvements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 27
-        versionName = "0.8.0"
+        versionCode = 28
+        versionName = "0.8.1"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/ui/component/MentionVisualTransformation.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/MentionVisualTransformation.kt
@@ -1,33 +1,129 @@
 package com.wisp.app.ui.component
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.text.input.OutputTransformation
-import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
+private val HASHTAG_REGEX = Regex("""(?<!\w)#([a-zA-Z0-9_][a-zA-Z0-9_-]*)""")
 
-@OptIn(ExperimentalFoundationApi::class)
-class MentionOutputTransformation(
+private data class ReplacementRange(
+    val origStart: Int,
+    val origEnd: Int,
+    val transStart: Int,
+    val transEnd: Int
+)
+
+class ComposeHighlightTransformation(
+    private val linkColor: Color,
     private val resolveDisplayName: (String) -> String?
-) : OutputTransformation {
+) : VisualTransformation {
 
-    override fun TextFieldBuffer.transformOutput() {
-        val original = asCharSequence().toString()
-        val matches = NOSTR_URI_REGEX.findAll(original).toList()
-        if (matches.isEmpty()) return
+    override fun filter(text: AnnotatedString): TransformedText {
+        val raw = text.text
+        if (raw.isEmpty()) return TransformedText(text, OffsetMapping.Identity)
 
-        for (match in matches.asReversed()) {
+        data class Span(val start: Int, val end: Int, val replacement: String?)
+
+        val spans = mutableListOf<Span>()
+
+        for (match in NOSTR_URI_REGEX.findAll(raw)) {
             val bech32 = match.groupValues[1]
             val display = when {
                 bech32.startsWith("npub1") || bech32.startsWith("nprofile1") -> {
                     val name = resolveDisplayName(bech32) ?: bech32.take(12) + "..."
                     "@$name"
                 }
-                bech32.startsWith("note1") -> "\uD83D\uDD17${bech32.take(12)}..."  // 🔗
-                bech32.startsWith("nevent1") -> "\uD83D\uDD17${bech32.take(14)}..."  // 🔗
+                bech32.startsWith("note1") -> "\uD83D\uDD17${bech32.take(12)}..."
+                bech32.startsWith("nevent1") -> "\uD83D\uDD17${bech32.take(14)}..."
                 else -> bech32.take(12) + "..."
             }
-            replace(match.range.first, match.range.last + 1, display)
+            spans.add(Span(match.range.first, match.range.last + 1, display))
         }
+
+        for (match in HASHTAG_REGEX.findAll(raw)) {
+            val overlaps = spans.any { it.replacement != null && it.start <= match.range.first && it.end > match.range.first }
+            if (!overlaps) {
+                spans.add(Span(match.range.first, match.range.last + 1, null))
+            }
+        }
+
+        if (spans.isEmpty()) return TransformedText(text, OffsetMapping.Identity)
+
+        spans.sortBy { it.start }
+
+        val linkStyle = SpanStyle(color = linkColor)
+        val replacements = mutableListOf<ReplacementRange>()
+
+        val result = buildAnnotatedString {
+            var cursor = 0
+            for (span in spans) {
+                if (cursor < span.start) {
+                    append(raw.substring(cursor, span.start))
+                }
+
+                val transStart = length
+                if (span.replacement != null) {
+                    withStyle(linkStyle) {
+                        append(span.replacement)
+                    }
+                    replacements.add(ReplacementRange(span.start, span.end, transStart, transStart + span.replacement.length))
+                } else {
+                    withStyle(linkStyle) {
+                        append(raw.substring(span.start, span.end))
+                    }
+                }
+                cursor = span.end
+            }
+            if (cursor < raw.length) {
+                append(raw.substring(cursor))
+            }
+        }
+
+        val mapping = if (replacements.isEmpty()) {
+            OffsetMapping.Identity
+        } else {
+            ComposeOffsetMapping(raw.length, result.length, replacements)
+        }
+
+        return TransformedText(result, mapping)
+    }
+}
+
+private class ComposeOffsetMapping(
+    private val originalLength: Int,
+    private val transformedLength: Int,
+    private val replacements: List<ReplacementRange>
+) : OffsetMapping {
+
+    override fun originalToTransformed(offset: Int): Int {
+        var shift = 0
+        for (r in replacements) {
+            if (offset <= r.origStart) break
+            if (offset >= r.origEnd) {
+                shift += (r.transEnd - r.transStart) - (r.origEnd - r.origStart)
+            } else {
+                return r.transEnd
+            }
+        }
+        return (offset + shift).coerceIn(0, transformedLength)
+    }
+
+    override fun transformedToOriginal(offset: Int): Int {
+        var shift = 0
+        for (r in replacements) {
+            if (offset <= r.transStart) break
+            if (offset >= r.transEnd) {
+                shift += (r.origEnd - r.origStart) - (r.transEnd - r.transStart)
+            } else {
+                return r.origEnd
+            }
+        }
+        return (offset + shift).coerceIn(0, originalLength)
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -24,10 +24,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.foundation.text.input.TextFieldLineLimits
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -89,7 +85,7 @@ import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.MentionCandidate
 import com.wisp.app.repo.ProfileRepository
-import com.wisp.app.ui.component.MentionOutputTransformation
+import com.wisp.app.ui.component.ComposeHighlightTransformation
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.component.RichContent
 import com.wisp.app.viewmodel.ComposeViewModel
@@ -148,10 +144,12 @@ fun ComposeScreen(
         if (uris.isNotEmpty()) viewModel.uploadMedia(uris, context.contentResolver, signer)
     }
 
-    val outputTransformation = remember(profileRepo) {
-        MentionOutputTransformation(
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val highlightTransformation = remember(profileRepo, primaryColor) {
+        ComposeHighlightTransformation(
+            linkColor = primaryColor,
             resolveDisplayName = { bech32 ->
-                if (profileRepo == null) return@MentionOutputTransformation null
+                if (profileRepo == null) return@ComposeHighlightTransformation null
                 try {
                     val data = Nip19.decodeNostrUri("nostr:$bech32")
                     if (data is com.wisp.app.nostr.NostrUriData.ProfileRef) {
@@ -318,34 +316,13 @@ fun ComposeScreen(
                     }
                 }
 
-                // Text field with GIF keyboard support via BasicTextField(TextFieldState)
-                val textFieldState = remember { TextFieldState(content.text) }
+                // Text field with mention/hashtag highlighting
                 val interactionSource = remember { MutableInteractionSource() }
                 val enabled = !publishing && countdownSeconds == null
 
-                // Sync ViewModel → TextFieldState (for programmatic updates: upload URL, mention select, etc.)
-                LaunchedEffect(content) {
-                    if (textFieldState.text.toString() != content.text) {
-                        textFieldState.edit {
-                            replace(0, length, content.text)
-                            selection = content.selection
-                        }
-                    }
-                }
-
-                // Sync TextFieldState → ViewModel (for user typing)
-                LaunchedEffect(textFieldState) {
-                    snapshotFlow {
-                        textFieldState.text.toString() to textFieldState.selection
-                    }.collect { (text, selection) ->
-                        if (text != content.text) {
-                            viewModel.updateContent(TextFieldValue(text, selection))
-                        }
-                    }
-                }
-
                 BasicTextField(
-                    state = textFieldState,
+                    value = content,
+                    onValueChange = { viewModel.updateContent(it) },
                     cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                     modifier = Modifier
                         .fillMaxWidth()
@@ -368,14 +345,15 @@ fun ComposeScreen(
                         }),
                     enabled = enabled,
                     keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-                    lineLimits = TextFieldLineLimits.MultiLine(),
-                    outputTransformation = outputTransformation,
+                    maxLines = Int.MAX_VALUE,
+                    visualTransformation = highlightTransformation,
                     textStyle = MaterialTheme.typography.bodyLarge.copy(
                         color = MaterialTheme.colorScheme.onSurface
                     ),
-                    decorator = { innerTextField ->
+                    interactionSource = interactionSource,
+                    decorationBox = { innerTextField ->
                         OutlinedTextFieldDefaults.DecorationBox(
-                            value = textFieldState.text.toString(),
+                            value = content.text,
                             innerTextField = innerTextField,
                             enabled = enabled,
                             singleLine = false,


### PR DESCRIPTION
## Summary
- Fix interest sets not loading when not cached locally — fetch from outbox relays
- Improve compose mention search and display name resolution
- Highlight mentions and hashtags with primary color in compose text field
- Bump version to 0.8.1

## Test plan
- [ ] Open hashtag feed — interest sets load even on fresh install
- [ ] Compose a note with @mentions — display names resolve and show in primary color
- [ ] Compose a note with #hashtags — hashtags show in primary color while typing
- [ ] Verify GIF keyboard / image paste still works in compose