### PR TITLE
fix: restore GIF keyboard support in compose field

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 28
-        versionName = "0.8.1"
+        versionCode = 29
+        versionName = "0.8.2"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/ui/component/MentionVisualTransformation.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/MentionVisualTransformation.kt
@@ -1,38 +1,20 @@
 package com.wisp.app.ui.component
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.input.OffsetMapping
-import androidx.compose.ui.text.input.TransformedText
-import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
 
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
-private val HASHTAG_REGEX = Regex("""(?<!\w)#([a-zA-Z0-9_][a-zA-Z0-9_-]*)""")
 
-private data class ReplacementRange(
-    val origStart: Int,
-    val origEnd: Int,
-    val transStart: Int,
-    val transEnd: Int
-)
-
-class ComposeHighlightTransformation(
-    private val linkColor: Color,
+class MentionOutputTransformation(
     private val resolveDisplayName: (String) -> String?
-) : VisualTransformation {
+) : OutputTransformation {
 
-    override fun filter(text: AnnotatedString): TransformedText {
-        val raw = text.text
-        if (raw.isEmpty()) return TransformedText(text, OffsetMapping.Identity)
+    override fun TextFieldBuffer.transformOutput() {
+        val original = asCharSequence().toString()
+        val matches = NOSTR_URI_REGEX.findAll(original).toList()
+        if (matches.isEmpty()) return
 
-        data class Span(val start: Int, val end: Int, val replacement: String?)
-
-        val spans = mutableListOf<Span>()
-
-        for (match in NOSTR_URI_REGEX.findAll(raw)) {
+        for (match in matches.asReversed()) {
             val bech32 = match.groupValues[1]
             val display = when {
                 bech32.startsWith("npub1") || bech32.startsWith("nprofile1") -> {
@@ -43,87 +25,7 @@ class ComposeHighlightTransformation(
                 bech32.startsWith("nevent1") -> "\uD83D\uDD17${bech32.take(14)}..."
                 else -> bech32.take(12) + "..."
             }
-            spans.add(Span(match.range.first, match.range.last + 1, display))
+            replace(match.range.first, match.range.last + 1, display)
         }
-
-        for (match in HASHTAG_REGEX.findAll(raw)) {
-            val overlaps = spans.any { it.replacement != null && it.start <= match.range.first && it.end > match.range.first }
-            if (!overlaps) {
-                spans.add(Span(match.range.first, match.range.last + 1, null))
-            }
-        }
-
-        if (spans.isEmpty()) return TransformedText(text, OffsetMapping.Identity)
-
-        spans.sortBy { it.start }
-
-        val linkStyle = SpanStyle(color = linkColor)
-        val replacements = mutableListOf<ReplacementRange>()
-
-        val result = buildAnnotatedString {
-            var cursor = 0
-            for (span in spans) {
-                if (cursor < span.start) {
-                    append(raw.substring(cursor, span.start))
-                }
-
-                val transStart = length
-                if (span.replacement != null) {
-                    withStyle(linkStyle) {
-                        append(span.replacement)
-                    }
-                    replacements.add(ReplacementRange(span.start, span.end, transStart, transStart + span.replacement.length))
-                } else {
-                    withStyle(linkStyle) {
-                        append(raw.substring(span.start, span.end))
-                    }
-                }
-                cursor = span.end
-            }
-            if (cursor < raw.length) {
-                append(raw.substring(cursor))
-            }
-        }
-
-        val mapping = if (replacements.isEmpty()) {
-            OffsetMapping.Identity
-        } else {
-            ComposeOffsetMapping(raw.length, result.length, replacements)
-        }
-
-        return TransformedText(result, mapping)
-    }
-}
-
-private class ComposeOffsetMapping(
-    private val originalLength: Int,
-    private val transformedLength: Int,
-    private val replacements: List<ReplacementRange>
-) : OffsetMapping {
-
-    override fun originalToTransformed(offset: Int): Int {
-        var shift = 0
-        for (r in replacements) {
-            if (offset <= r.origStart) break
-            if (offset >= r.origEnd) {
-                shift += (r.transEnd - r.transStart) - (r.origEnd - r.origStart)
-            } else {
-                return r.transEnd
-            }
-        }
-        return (offset + shift).coerceIn(0, transformedLength)
-    }
-
-    override fun transformedToOriginal(offset: Int): Int {
-        var shift = 0
-        for (r in replacements) {
-            if (offset <= r.transStart) break
-            if (offset >= r.transEnd) {
-                shift += (r.origEnd - r.origStart) - (r.transEnd - r.transStart)
-            } else {
-                return r.origEnd
-            }
-        }
-        return (offset + shift).coerceIn(0, originalLength)
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -21,6 +21,10 @@ import androidx.compose.foundation.content.hasMediaType
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -85,7 +89,7 @@ import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.MentionCandidate
 import com.wisp.app.repo.ProfileRepository
-import com.wisp.app.ui.component.ComposeHighlightTransformation
+import com.wisp.app.ui.component.MentionOutputTransformation
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.component.RichContent
 import com.wisp.app.viewmodel.ComposeViewModel
@@ -144,12 +148,10 @@ fun ComposeScreen(
         if (uris.isNotEmpty()) viewModel.uploadMedia(uris, context.contentResolver, signer)
     }
 
-    val primaryColor = MaterialTheme.colorScheme.primary
-    val highlightTransformation = remember(profileRepo, primaryColor) {
-        ComposeHighlightTransformation(
-            linkColor = primaryColor,
+    val outputTransformation = remember(profileRepo) {
+        MentionOutputTransformation(
             resolveDisplayName = { bech32 ->
-                if (profileRepo == null) return@ComposeHighlightTransformation null
+                if (profileRepo == null) return@MentionOutputTransformation null
                 try {
                     val data = Nip19.decodeNostrUri("nostr:$bech32")
                     if (data is com.wisp.app.nostr.NostrUriData.ProfileRef) {
@@ -316,13 +318,34 @@ fun ComposeScreen(
                     }
                 }
 
-                // Text field with mention/hashtag highlighting
+                // Text field with GIF keyboard support via BasicTextField(TextFieldState)
+                val textFieldState = remember { TextFieldState(content.text) }
                 val interactionSource = remember { MutableInteractionSource() }
                 val enabled = !publishing && countdownSeconds == null
 
+                // Sync ViewModel → TextFieldState (for programmatic updates: upload URL, mention select, etc.)
+                LaunchedEffect(content) {
+                    if (textFieldState.text.toString() != content.text) {
+                        textFieldState.edit {
+                            replace(0, length, content.text)
+                            selection = content.selection
+                        }
+                    }
+                }
+
+                // Sync TextFieldState → ViewModel (for user typing)
+                LaunchedEffect(textFieldState) {
+                    snapshotFlow {
+                        textFieldState.text.toString() to textFieldState.selection
+                    }.collect { (text, selection) ->
+                        if (text != content.text) {
+                            viewModel.updateContent(TextFieldValue(text, selection))
+                        }
+                    }
+                }
+
                 BasicTextField(
-                    value = content,
-                    onValueChange = { viewModel.updateContent(it) },
+                    state = textFieldState,
                     cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                     modifier = Modifier
                         .fillMaxWidth()
@@ -345,15 +368,14 @@ fun ComposeScreen(
                         }),
                     enabled = enabled,
                     keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-                    maxLines = Int.MAX_VALUE,
-                    visualTransformation = highlightTransformation,
+                    lineLimits = TextFieldLineLimits.MultiLine(),
+                    outputTransformation = outputTransformation,
                     textStyle = MaterialTheme.typography.bodyLarge.copy(
                         color = MaterialTheme.colorScheme.onSurface
                     ),
-                    interactionSource = interactionSource,
-                    decorationBox = { innerTextField ->
+                    decorator = { innerTextField ->
                         OutlinedTextFieldDefaults.DecorationBox(
-                            value = content.text,
+                            value = textFieldState.text.toString(),
                             innerTextField = innerTextField,
                             enabled = enabled,
                             singleLine = false,


### PR DESCRIPTION
## Summary
- Switches compose text field back to `BasicTextField(TextFieldState)` (BTF2) which properly declares content MIME types to the IME, restoring GIF keyboard support
- Reverts to `OutputTransformation` for mention display name replacement — inline color highlighting for mentions/hashtags is removed as BTF2 doesn't support `SpanStyle` annotations in Compose BOM 2024.12.01
- Bumps version to 0.8.2

## Test plan
- [ ] Verify GIF keyboard works in compose field
- [ ] Verify mention insertion still shows `@displayName` in the text field
- [ ] Verify image paste/drop still works via `contentReceiver`