### PR TITLE
fix: throw SignerRejectedException when signer rejects request

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/NostrSigner.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/NostrSigner.kt
@@ -104,7 +104,7 @@ class RemoteSigner(
 
         cursor.use {
             if (!it.moveToFirst()) return@withContext null
-            if (it.getColumnIndex("rejected") >= 0) return@withContext null
+            if (it.getColumnIndex("rejected") >= 0) throw SignerRejectedException("Signer rejected SIGN_EVENT kind=${unsigned.kind}")
 
             val eventIdx = it.getColumnIndex("event")
             if (eventIdx >= 0) {
@@ -134,7 +134,7 @@ class RemoteSigner(
 
         cursor.use {
             if (!it.moveToFirst()) return@withContext null
-            if (it.getColumnIndex("rejected") >= 0) return@withContext null
+            if (it.getColumnIndex("rejected") >= 0) throw SignerRejectedException("Signer rejected $method")
 
             val resIdx = it.getColumnIndex("result")
             if (resIdx >= 0) return@withContext it.getString(resIdx)


### PR DESCRIPTION
Update NostrSigner to throw a SignerRejectedException instead of returning null when the cursor contains a "rejected" column. This allows callers to explicitly handle cases where a signature or method request is denied by the signer.