### PR TITLE
fix: prevent back button from closing the app

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1,5 +1,6 @@
 package com.wisp.app
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.ui.Alignment
@@ -458,6 +459,24 @@ fun WispNavHost(
             onAllow = { feedViewModel.relayPool.approveAuth(request) },
             onDeny = { feedViewModel.relayPool.denyAuth(request) }
         )
+    }
+
+    // Prevent the system back button from ever closing the app.
+    // On FEED: consume the press (nowhere to go).
+    // On any other app screen: pop the back stack, falling back to FEED if empty.
+    val isAppRoute = currentRoute != null && currentRoute !in nonAppRoutes
+    BackHandler(enabled = isAppRoute) {
+        if (currentRoute == Routes.FEED) {
+            // Already on home — do nothing
+        } else {
+            val popped = navController.popBackStack()
+            if (!popped) {
+                navController.navigate(Routes.FEED) {
+                    popUpTo(0) { inclusive = true }
+                    launchSingleTop = true
+                }
+            }
+        }
     }
 
     Scaffold(


### PR DESCRIPTION
## Summary
- Add a global `BackHandler` in `Navigation.kt` that prevents the system back button from ever exiting the app
- On the feed screen, back press is consumed (no-op since there's nowhere to go)
- On any other app screen, pops the back stack normally; if the stack is empty, navigates to the feed as a fallback

## Test plan
- [ ] On the feed screen, press the Android back button — app should stay on feed
- [ ] Navigate to a nested screen (e.g. thread, profile), press back — should pop back normally
- [ ] Deep-link or navigate to a screen where the back stack is empty, press back — should land on feed instead of closing