### PR TITLE
fix: auto-prepend https:// for bare domain in media server input

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/BlossomServersViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/BlossomServersViewModel.kt
@@ -45,11 +45,13 @@ class BlossomServersViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun addServer() {
-        val url = _newServerUrl.value.trim().trimEnd('/')
-        if (!url.startsWith("https://")) {
-            _error.value = "URL must start with https://"
+        val raw = _newServerUrl.value.trim().trimEnd('/')
+        if (raw.isBlank()) return
+        if (raw.startsWith("http://")) {
+            _error.value = "Only HTTPS servers are supported"
             return
         }
+        val url = if (raw.startsWith("https://")) raw else "https://$raw"
         val current = servers.value.toMutableList()
         if (current.contains(url)) {
             _error.value = "Server already added"


### PR DESCRIPTION
When adding a media server, typing a bare domain like `haven.dergigi.com` triggers a validation error instead of just adding it. This normalizes the input by auto-prepending `https://` for bare domains, while still rejecting explicit `http://` URLs with a clear message.

- Bare domains and `https://` URLs are accepted as before
- `http://` is rejected with "Only HTTPS servers are supported"
- Blank input is silently ignored

Closes #249