### PR TITLE
feat: drag-to-reorder media server priority

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/BlossomServersScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/BlossomServersScreen.kt
@@ -1,19 +1,22 @@
 package com.wisp.app.ui.screen
 
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -27,12 +30,21 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import com.wisp.app.nostr.Blossom
+import androidx.compose.ui.zIndex
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.viewmodel.BlossomServersViewModel
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +58,11 @@ fun BlossomServersScreen(
     val newServerUrl by viewModel.newServerUrl.collectAsState()
     val error by viewModel.error.collectAsState()
     val published by viewModel.published.collectAsState()
+
+    var draggedIndex by remember { mutableIntStateOf(-1) }
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    var itemHeightPx by remember { mutableFloatStateOf(0f) }
+    val density = LocalDensity.current
 
     Scaffold(
         topBar = {
@@ -67,6 +84,7 @@ fun BlossomServersScreen(
                 .fillMaxSize()
                 .padding(padding)
                 .padding(16.dp)
+                .verticalScroll(rememberScrollState())
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -103,37 +121,106 @@ fun BlossomServersScreen(
                 Text(if (published) "Broadcast Sent" else "Broadcast Server List")
             }
 
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(8.dp))
 
-            LazyColumn {
-                items(items = servers, key = { it }) { url ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = url,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            if (url == Blossom.DEFAULT_SERVER) {
-                                Text(
-                                    text = "(default)",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+            if (servers.size > 1) {
+                Text(
+                    text = "Drag to reorder priority",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            servers.forEachIndexed { index, url ->
+                val isDragged = draggedIndex == index
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp)
+                        .then(
+                            if (isDragged) Modifier
+                                .zIndex(1f)
+                                .offset { IntOffset(0, dragOffsetY.roundToInt()) }
+                            else Modifier
+                        )
+                        .onGloballyPositioned { coords ->
+                            if (itemHeightPx == 0f) {
+                                itemHeightPx = coords.size.height.toFloat()
                             }
                         }
-                        IconButton(onClick = { viewModel.removeServer(url) }) {
-                            Icon(
-                                Icons.Default.Delete,
-                                contentDescription = "Remove",
-                                tint = MaterialTheme.colorScheme.error
+                ) {
+                    if (servers.size > 1) {
+                        Icon(
+                            Icons.Default.DragHandle,
+                            contentDescription = "Drag to reorder",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .padding(end = 8.dp)
+                                .pointerInput(servers.size) {
+                                    detectVerticalDragGestures(
+                                        onDragStart = {
+                                            draggedIndex = index
+                                            dragOffsetY = 0f
+                                        },
+                                        onVerticalDrag = { change, dragAmount ->
+                                            change.consume()
+                                            dragOffsetY += dragAmount
+
+                                            if (itemHeightPx > 0f) {
+                                                val steps =
+                                                    (dragOffsetY / itemHeightPx).roundToInt()
+                                                val targetIndex =
+                                                    (draggedIndex + steps).coerceIn(
+                                                        0,
+                                                        servers.size - 1
+                                                    )
+                                                if (targetIndex != draggedIndex) {
+                                                    viewModel.moveServer(
+                                                        draggedIndex,
+                                                        targetIndex
+                                                    )
+                                                    dragOffsetY -= (targetIndex - draggedIndex) * itemHeightPx
+                                                    draggedIndex = targetIndex
+                                                }
+                                            }
+                                        },
+                                        onDragEnd = {
+                                            draggedIndex = -1
+                                            dragOffsetY = 0f
+                                        },
+                                        onDragCancel = {
+                                            draggedIndex = -1
+                                            dragOffsetY = 0f
+                                        }
+                                    )
+                                }
+                        )
+                    }
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = url,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        if (index == 0) {
+                            Text(
+                                text = "Primary",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary
                             )
                         }
+                    }
+
+                    IconButton(onClick = { viewModel.removeServer(url) }) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Remove",
+                            tint = MaterialTheme.colorScheme.error
+                        )
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/BlossomServersViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/BlossomServersViewModel.kt
@@ -69,6 +69,14 @@ class BlossomServersViewModel(app: Application) : AndroidViewModel(app) {
         blossomRepo.saveBlossomServers(current)
     }
 
+    fun moveServer(from: Int, to: Int) {
+        val current = servers.value.toMutableList()
+        if (from !in current.indices || to !in current.indices) return
+        val item = current.removeAt(from)
+        current.add(to, item)
+        blossomRepo.saveBlossomServers(current)
+    }
+
     fun publishServerList(relayPool: RelayPool, signer: NostrSigner? = null) {
         val s = signer ?: keyRepo.getKeypair()?.let { LocalSigner(it.privkey, it.pubkey) } ?: return
         val tags = Blossom.buildServerListTags(servers.value)


### PR DESCRIPTION
## Summary
- Add drag-to-reorder on the Media Servers settings screen so users can control which server is tried first for uploads
- Drag handle appears when multiple servers are configured, with a "Primary" label on the top server
- Adds `moveServer(from, to)` to the view model; upload order already respects list position

## Test plan
- [ ] Add 2+ media servers
- [ ] Drag handle appears on each row
- [ ] Drag a server up/down and verify new order persists
- [ ] First server shows "Primary" label
- [ ] Upload media and confirm the top server is attempted first
- [ ] Single server: no drag handle shown