### PR TITLE
feat: add trending users sub-tab

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -93,14 +93,25 @@ import com.wisp.app.viewmodel.InitLoadingState
 import com.wisp.app.viewmodel.PowStatus
 import com.wisp.app.viewmodel.RelayFeedStatus
 import com.wisp.app.viewmodel.TrendingMetric
+import com.wisp.app.viewmodel.TrendingMode
 import com.wisp.app.viewmodel.TrendingTimeframe
 import com.wisp.app.viewmodel.buildTrendingRelayUrl
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.automirrored.outlined.Reply
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Repeat
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import com.wisp.app.nostr.ProfileData
+import com.wisp.app.ui.component.FollowButton
+import com.wisp.app.viewmodel.TRENDING_USERS_RELAY_URL
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -170,6 +181,9 @@ fun FeedScreen(
     val selectedList by viewModel.selectedList.collectAsState()
     val trendingMetric by viewModel.trendingMetric.collectAsState()
     val trendingTimeframe by viewModel.trendingTimeframe.collectAsState()
+    val trendingMode by viewModel.trendingMode.collectAsState()
+    val trendingUsers by viewModel.trendingUsers.collectAsState()
+    val trendingUsersLoading by viewModel.trendingUsersLoading.collectAsState()
     // Jump to top only when feed type, selected list, selected relay, or trending filters actually change
     // (not on recomposition after back-navigation from thread/compose)
     var prevFeedType by rememberSaveable { mutableStateOf(feedType.name) }
@@ -178,22 +192,25 @@ fun FeedScreen(
     var prevSelectedRelaySet by rememberSaveable { mutableStateOf(selectedRelaySet?.name) }
     var prevTrendingMetric by rememberSaveable { mutableStateOf(trendingMetric.name) }
     var prevTrendingTimeframe by rememberSaveable { mutableStateOf(trendingTimeframe.name) }
+    var prevTrendingMode by rememberSaveable { mutableStateOf(trendingMode.name) }
 
-    LaunchedEffect(feedType, selectedList, selectedRelay, selectedRelaySet, trendingMetric, trendingTimeframe) {
+    LaunchedEffect(feedType, selectedList, selectedRelay, selectedRelaySet, trendingMetric, trendingTimeframe, trendingMode) {
         val feedTypeChanged = feedType.name != prevFeedType
         val listChanged = selectedList?.dTag != prevSelectedListId
         val relayChanged = selectedRelay != prevSelectedRelay
         val relaySetChanged = selectedRelaySet?.name != prevSelectedRelaySet
         val metricChanged = trendingMetric.name != prevTrendingMetric
         val timeframeChanged = trendingTimeframe.name != prevTrendingTimeframe
+        val modeChanged = trendingMode.name != prevTrendingMode
 
-        if (feedTypeChanged || listChanged || relayChanged || relaySetChanged || metricChanged || timeframeChanged) {
+        if (feedTypeChanged || listChanged || relayChanged || relaySetChanged || metricChanged || timeframeChanged || modeChanged) {
             prevFeedType = feedType.name
             prevSelectedListId = selectedList?.dTag
             prevSelectedRelay = selectedRelay
             prevSelectedRelaySet = selectedRelaySet?.name
             prevTrendingMetric = trendingMetric.name
             prevTrendingTimeframe = trendingTimeframe.name
+            prevTrendingMode = trendingMode.name
             listState.scrollToItem(0)
         }
     }
@@ -727,14 +744,27 @@ fun FeedScreen(
                 TrendingFilterBar(
                     metric = trendingMetric,
                     timeframe = trendingTimeframe,
+                    mode = trendingMode,
                     onMetricChange = { viewModel.setTrendingMetric(it) },
-                    onTimeframeChange = { viewModel.setTrendingTimeframe(it) }
+                    onTimeframeChange = { viewModel.setTrendingTimeframe(it) },
+                    onModeChange = { viewModel.setTrendingMode(it) }
                 )
             }
             Box(
                 modifier = Modifier.fillMaxSize()
             ) {
-                if (feed.isEmpty()) {
+                if (feedType == FeedType.TRENDING && trendingMode == TrendingMode.USERS) {
+                    TrendingUsersContent(
+                        users = trendingUsers,
+                        isLoading = trendingUsersLoading,
+                        relayFeedStatus = relayFeedStatus,
+                        contactRepo = viewModel.contactRepo,
+                        onProfileClick = onProfileClick,
+                        onToggleFollow = { viewModel.toggleFollow(it) },
+                        onFollowAll = { viewModel.followAll(it) },
+                        onRetry = { viewModel.setTrendingMode(TrendingMode.USERS) }
+                    )
+                } else if (feed.isEmpty()) {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
@@ -1879,8 +1909,10 @@ private fun NewNotesButton(
 private fun TrendingFilterBar(
     metric: TrendingMetric,
     timeframe: TrendingTimeframe,
+    mode: TrendingMode,
     onMetricChange: (TrendingMetric) -> Unit,
-    onTimeframeChange: (TrendingTimeframe) -> Unit
+    onTimeframeChange: (TrendingTimeframe) -> Unit,
+    onModeChange: (TrendingMode) -> Unit
 ) {
     val metricIcon = @Composable { m: TrendingMetric ->
         when (m) {
@@ -1902,9 +1934,31 @@ private fun TrendingFilterBar(
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                FilterChip(
+                    selected = mode == TrendingMode.USERS,
+                    onClick = { onModeChange(TrendingMode.USERS) },
+                    label = { Icon(Icons.Outlined.Person, contentDescription = "People", modifier = Modifier.size(16.dp)) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primary,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                        selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                )
+                // Vertical divider
+                Box(
+                    modifier = Modifier
+                        .width(1.dp)
+                        .height(20.dp)
+                        .padding(vertical = 2.dp)
+                ) {
+                    Surface(
+                        modifier = Modifier.fillMaxSize(),
+                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+                    ) {}
+                }
                 TrendingMetric.entries.forEach { m ->
                     FilterChip(
-                        selected = m == metric,
+                        selected = mode == TrendingMode.NOTES && m == metric,
                         onClick = { onMetricChange(m) },
                         label = { metricIcon(m) },
                         colors = FilterChipDefaults.filterChipColors(
@@ -1915,50 +1969,191 @@ private fun TrendingFilterBar(
                     )
                 }
                 Spacer(Modifier.weight(1f))
-                Box {
-                    Surface(
-                        onClick = { showTimeframeDropdown = true },
-                        shape = RoundedCornerShape(20.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                AnimatedVisibility(visible = mode == TrendingMode.NOTES) {
+                    Box {
+                        Surface(
+                            onClick = { showTimeframeDropdown = true },
+                            shape = RoundedCornerShape(20.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant
                         ) {
-                            Text(
-                                timeframe.label,
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Spacer(Modifier.width(2.dp))
-                            Icon(
-                                Icons.Default.ArrowDropDown,
-                                contentDescription = "Change timeframe",
-                                modifier = Modifier.size(18.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                            Row(
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    timeframe.label,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Spacer(Modifier.width(2.dp))
+                                Icon(
+                                    Icons.Default.ArrowDropDown,
+                                    contentDescription = "Change timeframe",
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
-                    }
-                    DropdownMenu(
-                        expanded = showTimeframeDropdown,
-                        onDismissRequest = { showTimeframeDropdown = false }
-                    ) {
-                        TrendingTimeframe.entries.forEach { t ->
-                            DropdownMenuItem(
-                                text = { Text(t.label) },
-                                onClick = {
-                                    showTimeframeDropdown = false
-                                    onTimeframeChange(t)
-                                },
-                                trailingIcon = if (t == timeframe) {{
-                                    Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
-                                }} else null
-                            )
+                        DropdownMenu(
+                            expanded = showTimeframeDropdown,
+                            onDismissRequest = { showTimeframeDropdown = false }
+                        ) {
+                            TrendingTimeframe.entries.forEach { t ->
+                                DropdownMenuItem(
+                                    text = { Text(t.label) },
+                                    onClick = {
+                                        showTimeframeDropdown = false
+                                        onTimeframeChange(t)
+                                    },
+                                    trailingIcon = if (t == timeframe) {{
+                                        Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                                    }} else null
+                                )
+                            }
                         }
                     }
                 }
             }
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+        }
+    }
+}
+
+@Composable
+private fun TrendingUsersContent(
+    users: List<ProfileData>,
+    isLoading: Boolean,
+    relayFeedStatus: RelayFeedStatus,
+    contactRepo: com.wisp.app.repo.ContactRepository,
+    onProfileClick: (String) -> Unit,
+    onToggleFollow: (String) -> Unit,
+    onFollowAll: (Set<String>) -> Unit,
+    onRetry: () -> Unit
+) {
+    if (isLoading && users.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+        }
+        return
+    }
+
+    if (users.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            RelayFeedEmptyState(
+                status = relayFeedStatus,
+                relayUrl = TRENDING_USERS_RELAY_URL,
+                onRetry = onRetry
+            )
+        }
+        return
+    }
+
+    val followList by contactRepo.followList.collectAsState()
+    val followingPubkeys = remember(followList) {
+        followList.map { it.pubkey }.toSet()
+    }
+    val unfollowedPubkeys = remember(users, followingPubkeys) {
+        users.map { it.pubkey }.filter { it !in followingPubkeys }.toSet()
+    }
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Up & Coming",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                if (unfollowedPubkeys.isNotEmpty()) {
+                    FilledTonalButton(
+                        onClick = { onFollowAll(unfollowedPubkeys) }
+                    ) {
+                        Text("Follow All (${unfollowedPubkeys.size})")
+                    }
+                }
+            }
+        }
+
+        itemsIndexed(
+            items = users,
+            key = { _, profile -> profile.pubkey }
+        ) { index, profile ->
+            AnimatedVisibility(
+                visible = true,
+                enter = fadeIn(tween(300, delayMillis = index * 50)) +
+                        slideInVertically(tween(300, delayMillis = index * 50)) { it / 2 }
+            ) {
+                val isFollowing = profile.pubkey in followingPubkeys
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 6.dp)
+                        .clickable { onProfileClick(profile.pubkey) },
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        ProfilePicture(
+                            url = profile.picture,
+                            size = 56,
+                            onClick = { onProfileClick(profile.pubkey) }
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                profile.displayString,
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            if (!profile.nip05.isNullOrBlank()) {
+                                Text(
+                                    profile.nip05,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                            if (!profile.about.isNullOrBlank()) {
+                                Text(
+                                    profile.about,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.padding(top = 2.dp)
+                                )
+                            }
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        FollowButton(
+                            isFollowing = isFollowing,
+                            onClick = { onToggleFollow(profile.pubkey) }
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            Spacer(Modifier.height(80.dp).navigationBarsPadding())
         }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -346,6 +346,10 @@ class EventRouter(
                 subscriptionId == "feed-backfill"
             val isRelayFeedSub = subscriptionId == relayFeedSubId ||
                 subscriptionId == "relay-loadmore"
+            if (isRelayFeedSub && subscriptionId.startsWith("trending-users-")) {
+                // Kind 0 events collected directly by subscribeTrendingUsers() — skip feed routing
+                return
+            }
             if (isRelayFeedSub) {
                 eventRepo.cacheEvent(event)
                 if (getIsTrendingFeed()) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Filter
 import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.nostr.ProfileData
 import com.wisp.app.relay.ConsoleLogType
 import com.wisp.app.relay.OutboxRouter
 import com.wisp.app.relay.RelayConfig
@@ -60,6 +61,7 @@ class FeedSubscriptionManager(
         relayPool.registerDedupBypass("relay-feed-")
         relayPool.registerDedupBypass("relay-loadmore")
         relayPool.registerDedupBypass("trending-feed-")
+        relayPool.registerDedupBypass("trending-users-")
     }
 
     private val _feedType = MutableStateFlow(FeedType.FOLLOWS)
@@ -76,6 +78,15 @@ class FeedSubscriptionManager(
 
     private val _trendingTimeframe = MutableStateFlow(TrendingTimeframe.TODAY)
     val trendingTimeframe: StateFlow<TrendingTimeframe> = _trendingTimeframe
+
+    private val _trendingMode = MutableStateFlow(TrendingMode.NOTES)
+    val trendingMode: StateFlow<TrendingMode> = _trendingMode
+
+    private val _trendingUsers = MutableStateFlow<List<ProfileData>>(emptyList())
+    val trendingUsers: StateFlow<List<ProfileData>> = _trendingUsers
+
+    private val _trendingUsersLoading = MutableStateFlow(false)
+    val trendingUsersLoading: StateFlow<Boolean> = _trendingUsersLoading
 
     private val _relayFeedStatus = MutableStateFlow<RelayFeedStatus>(RelayFeedStatus.Idle)
     val relayFeedStatus: StateFlow<RelayFeedStatus> = _relayFeedStatus
@@ -174,7 +185,11 @@ class FeedSubscriptionManager(
             }
             FeedType.TRENDING -> {
                 eventRepo.clearRelayFeed()
-                subscribeTrendingFeed()
+                if (_trendingMode.value == TrendingMode.USERS) {
+                    subscribeTrendingUsers()
+                } else {
+                    subscribeTrendingFeed()
+                }
             }
         }
     }
@@ -213,7 +228,11 @@ class FeedSubscriptionManager(
             subscribeRelayFeed()
         } else if (_feedType.value == FeedType.TRENDING) {
             eventRepo.clearRelayFeed()
-            subscribeTrendingFeed()
+            if (_trendingMode.value == TrendingMode.USERS) {
+                subscribeTrendingUsers()
+            } else {
+                subscribeTrendingFeed()
+            }
         }
     }
 
@@ -470,6 +489,9 @@ class FeedSubscriptionManager(
     // -- Trending feed --
 
     fun setTrendingMetric(metric: TrendingMetric) {
+        if (_trendingMode.value == TrendingMode.USERS) {
+            _trendingMode.value = TrendingMode.NOTES
+        }
         _trendingMetric.value = metric
         if (_feedType.value == FeedType.TRENDING) {
             eventRepo.clearRelayFeed()
@@ -479,9 +501,25 @@ class FeedSubscriptionManager(
 
     fun setTrendingTimeframe(timeframe: TrendingTimeframe) {
         _trendingTimeframe.value = timeframe
-        if (_feedType.value == FeedType.TRENDING) {
+        if (_feedType.value == FeedType.TRENDING && _trendingMode.value == TrendingMode.NOTES) {
             eventRepo.clearRelayFeed()
             subscribeTrendingFeed()
+        }
+    }
+
+    fun setTrendingMode(mode: TrendingMode) {
+        if (_trendingMode.value == mode) return
+        _trendingMode.value = mode
+        if (_feedType.value == FeedType.TRENDING) {
+            if (mode == TrendingMode.USERS) {
+                unsubscribeRelayFeed()
+                subscribeTrendingUsers()
+            } else {
+                _trendingUsers.value = emptyList()
+                _trendingUsersLoading.value = false
+                eventRepo.clearRelayFeed()
+                subscribeTrendingFeed()
+            }
         }
     }
 
@@ -539,6 +577,87 @@ class FeedSubscriptionManager(
             withContext(processingContext) {
                 metadataFetcher.sweepMissingProfiles()
             }
+        }
+    }
+
+    private fun subscribeTrendingUsers() {
+        val oldSubId = relayFeedSubId
+        relayFeedGeneration++
+        relayFeedSubId = "trending-users-$relayFeedGeneration"
+        relayPool.closeOnAllRelays(oldSubId)
+        relayFeedEoseJob?.cancel()
+        relayStatusMonitorJob?.cancel()
+
+        val url = TRENDING_USERS_RELAY_URL
+        _trendingUsersLoading.value = true
+        _trendingUsers.value = emptyList()
+        _relayFeedStatus.value = RelayFeedStatus.Connecting
+
+        val filter = Filter(kinds = listOf(0), limit = 100)
+        val currentGen = relayFeedGeneration
+        val subId = relayFeedSubId
+
+        relayFeedEoseJob = scope.launch {
+            var connected = false
+            for (attempt in 0..2) {
+                if (relayFeedGeneration != currentGen) return@launch
+                if (attempt > 0) {
+                    relayPool.disconnectRelay(url)
+                    delay(1500L)
+                }
+                val msg = ClientMessage.req(subId, filter)
+                relayPool.sendToRelayOrEphemeral(url, msg, skipBadCheck = true)
+
+                val deadline = System.currentTimeMillis() + 5_000
+                while (System.currentTimeMillis() < deadline) {
+                    if (relayFeedGeneration != currentGen) return@launch
+                    if (relayPool.isRelayConnected(url)) {
+                        connected = true
+                        break
+                    }
+                    delay(200)
+                }
+                if (connected) break
+            }
+            if (!connected) {
+                _relayFeedStatus.value = RelayFeedStatus.ConnectionFailed("Failed to connect to trending users relay")
+                _trendingUsersLoading.value = false
+                return@launch
+            }
+
+            _relayFeedStatus.value = RelayFeedStatus.Subscribing
+
+            // Collect kind 0 events as they arrive
+            val collected = mutableListOf<ProfileData>()
+            val seenPubkeys = mutableSetOf<String>()
+            val collectJob = launch {
+                relayPool.relayEvents.collect { relayEvent ->
+                    if (relayEvent.subscriptionId != subId) return@collect
+                    if (relayFeedGeneration != currentGen) return@collect
+                    val event = relayEvent.event
+                    if (event.kind == 0 && seenPubkeys.add(event.pubkey)) {
+                        val profile = ProfileData.fromEvent(event)
+                        if (profile != null) {
+                            profileRepo.updateFromEvent(event)
+                            collected.add(profile)
+                            _trendingUsers.value = collected.toList()
+                            if (collected.size == 1) {
+                                _relayFeedStatus.value = RelayFeedStatus.Streaming
+                            }
+                        }
+                    }
+                }
+            }
+
+            subManager.awaitEoseCount(subId, 1)
+            collectJob.cancel()
+
+            if (collected.isEmpty()) {
+                _relayFeedStatus.value = RelayFeedStatus.NoEvents
+            } else {
+                _relayFeedStatus.value = RelayFeedStatus.Streaming
+            }
+            _trendingUsersLoading.value = false
         }
     }
 
@@ -829,6 +948,9 @@ class FeedSubscriptionManager(
         _selectedRelaySet.value = null
         _trendingMetric.value = TrendingMetric.REACTIONS
         _trendingTimeframe.value = TrendingTimeframe.TODAY
+        _trendingMode.value = TrendingMode.NOTES
+        _trendingUsers.value = emptyList()
+        _trendingUsersLoading.value = false
         isLoadingMore = false
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -70,6 +70,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 enum class FeedType { FOLLOWS, EXTENDED_FOLLOWS, RELAY, LIST, TRENDING }
 
+enum class TrendingMode { NOTES, USERS }
+
 enum class TrendingMetric(val slug: String, val label: String) {
     REACTIONS("reactions", "Reactions"),
     REPLIES("replies", "Replies"),
@@ -84,6 +86,8 @@ enum class TrendingTimeframe(val slug: String, val label: String) {
     YEAR("1y", "1y"),
     ALL("all", "All")
 }
+
+const val TRENDING_USERS_RELAY_URL = "wss://feeds.nostrarchives.com/users/upandcoming"
 
 fun buildTrendingRelayUrl(metric: TrendingMetric, timeframe: TrendingTimeframe): String =
     "wss://feeds.nostrarchives.com/notes/trending/${metric.slug}/${timeframe.slug}"
@@ -185,7 +189,11 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
             // Start the trending relay connection early so it connects in parallel
             // with persistent relays, not sequentially after them.
             if (feedSub.feedType.value == FeedType.TRENDING) {
-                val url = buildTrendingRelayUrl(feedSub.trendingMetric.value, feedSub.trendingTimeframe.value)
+                val url = if (feedSub.trendingMode.value == TrendingMode.USERS) {
+                    TRENDING_USERS_RELAY_URL
+                } else {
+                    buildTrendingRelayUrl(feedSub.trendingMetric.value, feedSub.trendingTimeframe.value)
+                }
                 relayPool.preConnectEphemeral(url)
             }
         },
@@ -316,6 +324,9 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val loadingScreenComplete: StateFlow<Boolean> = feedSub.loadingScreenComplete
     val trendingMetric: StateFlow<TrendingMetric> = feedSub.trendingMetric
     val trendingTimeframe: StateFlow<TrendingTimeframe> = feedSub.trendingTimeframe
+    val trendingMode: StateFlow<TrendingMode> = feedSub.trendingMode
+    val trendingUsers: StateFlow<List<com.wisp.app.nostr.ProfileData>> = feedSub.trendingUsers
+    val trendingUsersLoading: StateFlow<Boolean> = feedSub.trendingUsersLoading
     val selectedList: StateFlow<com.wisp.app.nostr.FollowSet?> = listRepo.selectedList
     val zapInProgress: StateFlow<Set<String>> = socialActions.zapInProgress
     val zapSuccess: SharedFlow<String> = socialActions.zapSuccess
@@ -348,6 +359,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun loadMore() = feedSub.loadMore()
     fun setTrendingMetric(metric: TrendingMetric) = feedSub.setTrendingMetric(metric)
     fun setTrendingTimeframe(timeframe: TrendingTimeframe) = feedSub.setTrendingTimeframe(timeframe)
+    fun setTrendingMode(mode: TrendingMode) = feedSub.setTrendingMode(mode)
     fun pauseEngagement() = feedSub.pauseEngagement()
     fun resumeEngagement() = feedSub.resumeEngagement()
 


### PR DESCRIPTION
## Summary
- Adds a **Trending Users** mode to the trending feed via a person icon chip in the filter bar
- Fetches up-and-coming profiles (kind 0) from `wss://feeds.nostrarchives.com/users/upandcoming`
- Renders profile cards with avatars, names, NIP-05, bios, and individual follow buttons
- Includes a "Follow All" bulk action that reactively updates count as users are followed
- Hides the timeframe dropdown when in users mode; metric chips switch back to notes mode

## Test plan
- [ ] Open Trending feed → verify metric chips still work as before
- [ ] Tap person icon → should switch to users view and fetch profiles
- [ ] Verify profiles render with avatars, names, bios, follow buttons
- [ ] Tap individual follow buttons → should immediately toggle to "Following"
- [ ] Tap "Follow All" → should follow all unfollowed users, count updates reactively
- [ ] Tap a profile card → should navigate to user profile screen
- [ ] Tap a metric chip from users view → should switch back to notes
- [ ] Test connection failure → should show error with retry