### PR TITLE
fix: relay reconnect error suppression + viewport-aware engagement

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -161,12 +161,16 @@ class Relay(
                     // Stale callbacks from a replaced socket must not wipe the new socket's state.
                     if (isCurrent) {
                         _connectionState.tryEmit(false)
-                        _connectionErrors.tryEmit(ConsoleLogEntry(
-                            relayUrl = config.url,
-                            type = ConsoleLogType.CONN_FAILURE,
-                            message = t.message ?: t.javaClass.simpleName
-                        ))
-                        _failures.tryEmit(RelayFailure(config.url, response?.code, t.message ?: t.javaClass.simpleName))
+                        // Suppress error emissions during force reconnect — disconnect()
+                        // triggers onFailure for the torn-down socket, flooding the console.
+                        if (reconnectEnabled) {
+                            _connectionErrors.tryEmit(ConsoleLogEntry(
+                                relayUrl = config.url,
+                                type = ConsoleLogType.CONN_FAILURE,
+                                message = t.message ?: t.javaClass.simpleName
+                            ))
+                            _failures.tryEmit(RelayFailure(config.url, response?.code, t.message ?: t.javaClass.simpleName))
+                        }
                         reconnect()
                     }
                 }
@@ -184,11 +188,13 @@ class Relay(
                     if (isCurrent) {
                         _connectionState.tryEmit(false)
                         if (code != 1000) {
-                            _connectionErrors.tryEmit(ConsoleLogEntry(
-                                relayUrl = config.url,
-                                type = ConsoleLogType.CONN_CLOSED,
-                                message = "Code $code: $reason"
-                            ))
+                            if (reconnectEnabled) {
+                                _connectionErrors.tryEmit(ConsoleLogEntry(
+                                    relayUrl = config.url,
+                                    type = ConsoleLogType.CONN_CLOSED,
+                                    message = "Code $code: $reason"
+                                ))
+                            }
                             reconnect()
                         }
                     }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -28,6 +28,11 @@ data class PublishResult(val relayUrl: String, val eventId: String, val accepted
 data class BroadcastState(val accepted: Int, val sent: Int)
 
 class RelayPool {
+    /** Incremented on every reconnectAll()/forceReconnectAll(). Allows SubscriptionManager
+     *  to detect stale EOSE signals from pre-reconnect subscriptions. */
+    @Volatile var reconnectGeneration: Long = 0
+        private set
+
     private var client: OkHttpClient = Relay.createClient()
     private var clientBuiltWithTor: Boolean = TorManager.isEnabled()
     private val relays = CopyOnWriteArrayList<Relay>()
@@ -847,6 +852,7 @@ class RelayPool {
 
     fun reconnectAll(): Int {
         Log.d("RLC", "[Pool] reconnectAll() START — persistent=${relays.size} dm=${dmRelays.size} ephemeral=${ephemeralRelays.size} activeSubs=${activeSubscriptions.size}")
+        reconnectGeneration++
         isReconnecting = true
         // Clear all cooldowns — background failures shouldn't block reconnection
         relayCooldowns.clear()
@@ -895,6 +901,7 @@ class RelayPool {
      */
     fun forceReconnectAll() {
         Log.d("RLC", "[Pool] forceReconnectAll() START — persistent=${relays.size} dm=${dmRelays.size} ephemeral=${ephemeralRelays.size}")
+        reconnectGeneration++
         isReconnecting = true
         // Server-side subscriptions are dead — clear tracker so fresh REQs are sent
         subscriptionTracker.clear()
@@ -904,6 +911,7 @@ class RelayPool {
         // Tear down and reconnect persistent relays
         for (relay in relays) {
             relay.resetBackoff()
+            relay.reconnectEnabled = false  // Suppress onFailure errors from disconnect()
             relay.disconnect()
             relay.connect()
             relay.reconnectEnabled = true
@@ -911,6 +919,7 @@ class RelayPool {
         // Tear down and reconnect DM relays
         for (relay in dmRelays) {
             relay.resetBackoff()
+            relay.reconnectEnabled = false  // Suppress onFailure errors from disconnect()
             relay.disconnect()
             relay.connect()
             relay.reconnectEnabled = true

--- a/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/SubscriptionManager.kt
@@ -3,24 +3,40 @@ package com.wisp.app.relay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.withTimeoutOrNull
 
 class SubscriptionManager(private val relayPool: RelayPool) {
 
     /**
      * Await a specific EOSE signal by subscription ID. One-shot, no lingering collector.
+     * Returns immediately if a reconnect has occurred since [generation] was captured.
      */
-    suspend fun awaitEose(targetSubId: String) {
-        relayPool.eoseSignals.first { it == targetSubId }
+    suspend fun awaitEose(
+        targetSubId: String,
+        generation: Long = relayPool.reconnectGeneration
+    ) {
+        if (relayPool.reconnectGeneration != generation) return
+        relayPool.eoseSignals.first {
+            relayPool.reconnectGeneration != generation || it == targetSubId
+        }
     }
 
     /**
      * Await EOSE with a timeout. Returns true if EOSE was received, false on timeout.
+     * Returns false immediately if a reconnect has occurred since [generation] was captured.
      */
-    suspend fun awaitEoseWithTimeout(targetSubId: String, timeoutMs: Long = 15_000): Boolean {
+    suspend fun awaitEoseWithTimeout(
+        targetSubId: String,
+        timeoutMs: Long = 15_000,
+        generation: Long = relayPool.reconnectGeneration
+    ): Boolean {
+        if (relayPool.reconnectGeneration != generation) return false
         return withTimeoutOrNull(timeoutMs) {
-            relayPool.eoseSignals.first { it == targetSubId }
-            true
+            relayPool.eoseSignals.first {
+                relayPool.reconnectGeneration != generation || it == targetSubId
+            }
+            relayPool.reconnectGeneration == generation
         } ?: false
     }
 
@@ -28,17 +44,21 @@ class SubscriptionManager(private val relayPool: RelayPool) {
      * Await count-based EOSE: wait until [expectedCount] EOSE signals arrive for [targetSubId],
      * or until [timeoutMs] elapses.
      * Returns the number of EOSE signals actually received.
+     * Returns 0 immediately if a reconnect has occurred since [generation] was captured.
      */
     suspend fun awaitEoseCount(
         targetSubId: String,
         expectedCount: Int,
-        timeoutMs: Long = 15_000
+        timeoutMs: Long = 15_000,
+        generation: Long = relayPool.reconnectGeneration
     ): Int {
         if (expectedCount <= 0) return 0
+        if (relayPool.reconnectGeneration != generation) return 0
         var eoseCount = 0
         withTimeoutOrNull(timeoutMs) {
             relayPool.eoseSignals
                 .filter { it == targetSubId }
+                .takeWhile { relayPool.reconnectGeneration == generation }
                 .take(expectedCount)
                 .collect { eoseCount++ }
         }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -113,6 +114,9 @@ import com.wisp.app.nostr.ProfileData
 import com.wisp.app.ui.component.FollowButton
 import com.wisp.app.viewmodel.TRENDING_USERS_RELAY_URL
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -171,6 +175,20 @@ fun FeedScreen(
     val translationVersion by viewModel.translationRepo.version.collectAsState()
     val connectedCount by viewModel.relayPool.connectedCount.collectAsState()
     val listState = rememberLazyListState()
+
+    // Viewport-aware engagement: notify ViewModel of visible item range
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo }
+            .mapNotNull { items ->
+                if (items.isEmpty()) null
+                else items.first().index to items.last().index
+            }
+            .distinctUntilChanged()
+            .collectLatest { (first, last) ->
+                viewModel.onVisibleRangeChanged(first, last)
+            }
+    }
+
     var handledScrollTrigger by rememberSaveable { mutableStateOf(scrollToTopTrigger) }
     LaunchedEffect(scrollToTopTrigger) {
         if (scrollToTopTrigger != handledScrollTrigger) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -118,6 +118,11 @@ class FeedSubscriptionManager(
     private var relayStatusMonitorJob: Job? = null
     private var isLoadingMore = false
 
+    // Batched engagement state (Steps 2-4)
+    private var engagementGeneration = 0
+    private val engagedEventIds = mutableSetOf<String>()
+    private var viewportEngagementJob: Job? = null
+
     fun markLoadingComplete() { _loadingScreenComplete.value = true }
 
     /** Resolve indexer relays: user's search relays (kind 10007) with default fallback. */
@@ -145,6 +150,8 @@ class FeedSubscriptionManager(
         val prev = _feedType.value
         Log.d("RLC", "[FeedSub] setFeedType $prev → $type feedSize=${eventRepo.feed.value.size}")
         _feedType.value = type
+        engagedEventIds.clear()
+        viewportEngagementJob?.cancel()
         applyAuthorFilterForFeedType(type)
 
         // Tear down relay/trending feed when leaving those modes
@@ -255,6 +262,8 @@ class FeedSubscriptionManager(
         relayPool.closeOnAllRelays(oldSubId)
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()
+        engagedEventIds.clear()
+        viewportEngagementJob?.cancel()
         eventRepo.countNewNotes = false
         feedEoseJob?.cancel()
 
@@ -434,11 +443,15 @@ class FeedSubscriptionManager(
                             "loadmore", authors, templateFilter,
                             indexerRelays = indexerRelays, blockedUrls = excludedUrls
                         )
-                        val feedSizeBefore = eventRepo.feed.value.size
+                        val feedBefore = eventRepo.feed.value.toList()
                         subManager.awaitEoseWithTimeout("loadmore")
                         subManager.closeSubscription("loadmore")
-                        if (eventRepo.feed.value.size > feedSizeBefore) {
-                            subscribeEngagementForFeed()
+                        if (eventRepo.feed.value.size > feedBefore.size) {
+                            val existingIds = feedBefore.map { it.id }.toSet()
+                            val newEvents = eventRepo.feed.value.filter { it.id !in existingIds }
+                            if (newEvents.isNotEmpty()) {
+                                subscribeEngagementForEvents(newEvents)
+                            }
                         }
                         isLoadingMore = false
                     }
@@ -456,21 +469,27 @@ class FeedSubscriptionManager(
 
         val loadMoreSubId = if (_feedType.value == FeedType.RELAY) "relay-loadmore" else "loadmore"
         scope.launch {
-            val feedSizeBefore = if (_feedType.value == FeedType.RELAY) {
-                eventRepo.relayFeed.value.size
+            val feedBefore = if (_feedType.value == FeedType.RELAY) {
+                eventRepo.relayFeed.value.toList()
             } else {
-                eventRepo.feed.value.size
+                eventRepo.feed.value.toList()
             }
+            val sizeBefore = feedBefore.size
             subManager.awaitEoseWithTimeout(loadMoreSubId)
             subManager.closeSubscription(loadMoreSubId)
 
-            val feedSizeAfter = if (_feedType.value == FeedType.RELAY) {
-                eventRepo.relayFeed.value.size
+            val feedAfter = if (_feedType.value == FeedType.RELAY) {
+                eventRepo.relayFeed.value
             } else {
-                eventRepo.feed.value.size
+                eventRepo.feed.value
             }
-            if (feedSizeAfter > feedSizeBefore) {
-                subscribeEngagementForFeed()
+            if (feedAfter.size > sizeBefore) {
+                // Only engage the new events — don't reset existing engagement
+                val existingIds = feedBefore.map { it.id }.toSet()
+                val newEvents = feedAfter.filter { it.id !in existingIds }
+                if (newEvents.isNotEmpty()) {
+                    subscribeEngagementForEvents(newEvents)
+                }
             }
 
             isLoadingMore = false
@@ -480,10 +499,14 @@ class FeedSubscriptionManager(
     fun pauseEngagement() {
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()
+        viewportEngagementJob?.cancel()
     }
 
     fun resumeEngagement() {
         if (activeEngagementSubIds.isEmpty()) {
+            // After reconnect, re-engage only the initial viewport — the viewport
+            // tracker will handle the rest as the user scrolls.
+            engagedEventIds.clear()
             subscribeEngagementForFeed()
         }
     }
@@ -863,29 +886,54 @@ class FeedSubscriptionManager(
     fun subscribeEngagementForFeed() {
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()
+        engagedEventIds.clear()
 
         val feedEvents = if (_feedType.value == FeedType.RELAY || _feedType.value == FeedType.TRENDING) eventRepo.relayFeed.value else eventRepo.feed.value
         if (feedEvents.isEmpty()) return
 
+        // Subscribe global subs (poll votes, DM zaps) for all feed events
+        subscribeGlobalEngagement(feedEvents)
+
+        // Only engage the first ~15 events (rough viewport). Viewport tracking
+        // via onViewportChanged() handles the rest as the user scrolls.
+        val initialBatch = feedEvents.take(15)
+        subscribeEngagementForEvents(initialBatch)
+    }
+
+    /**
+     * Subscribe engagement for a batch of events that haven't been engaged yet.
+     * Each batch gets a unique sub ID to avoid cancelling in-progress fetches.
+     */
+    private fun subscribeEngagementForEvents(events: List<NostrEvent>) {
+        val newEvents = events.filter { engagedEventIds.add(it.id) }
+        if (newEvents.isEmpty()) return
+
+        engagementGeneration++
+        val batchSubId = "engage-${engagementGeneration}"
+        Log.d("RLC", "[FeedSub] subscribeEngagementForEvents batch=$batchSubId count=${newEvents.size}")
+
         val eventsByAuthor = mutableMapOf<String, MutableList<String>>()
-        for (event in feedEvents) {
+        for (event in newEvents) {
             eventsByAuthor.getOrPut(event.pubkey) { mutableListOf() }.add(event.id)
         }
         val safetyNet = relayScoreBoard.getScoredRelays().take(5).map { it.url }
-        val relayCount = outboxRouter.subscribeEngagementByAuthors("engage", eventsByAuthor, activeEngagementSubIds, safetyNet)
+        val relayCount = outboxRouter.subscribeEngagementByAuthors(batchSubId, eventsByAuthor, activeEngagementSubIds, safetyNet)
 
-        // Await EOSE from a threshold of inbox relays so engagement counts populate
-        // before the user sees the feed. Without this, engagement is fire-and-forget
-        // and most counts show zero.
         if (relayCount > 0) {
             scope.launch {
                 val eoseTarget = maxOf(3, (relayCount * 0.3).toInt()).coerceIn(1, relayCount)
-                Log.d("RLC", "[FeedSub] awaiting $eoseTarget/$relayCount EOSEs for engagement")
-                subManager.awaitEoseCount("engage", eoseTarget, timeoutMs = 4_000)
-                Log.d("RLC", "[FeedSub] safety net engagement EOSE received")
+                Log.d("RLC", "[FeedSub] awaiting $eoseTarget/$relayCount EOSEs for $batchSubId")
+                subManager.awaitEoseCount(batchSubId, eoseTarget, timeoutMs = 8_000)
+                Log.d("RLC", "[FeedSub] engagement EOSE received for $batchSubId")
             }
         }
+    }
 
+    /**
+     * Subscribe global engagement subs that need broad relay coverage:
+     * private zap receipts on DM relays and poll vote responses.
+     */
+    private fun subscribeGlobalEngagement(feedEvents: List<NostrEvent>) {
         // Subscribe for private zap receipts on DM relays
         if (relayPool.hasDmRelays() && pubkeyHex != null) {
             val myEventIds = feedEvents.filter { it.pubkey == pubkeyHex }.map { it.id }
@@ -918,6 +966,7 @@ class FeedSubscriptionManager(
             val sentAll = relayPool.sendToAllRelays(msg)
             Log.d("POLL", "[FeedSub] sent poll vote REQ to $sentAll persistent relays")
             // Also query poll-specified relays and safety net via ephemeral connections
+            val safetyNet = relayScoreBoard.getScoredRelays().take(5).map { it.url }
             val sentUrls = relayPool.getReadRelayUrls().toSet() + relayPool.getWriteRelayUrls().toSet()
             for (poll in pollEvents) {
                 for (url in Nip88.parsePollRelays(poll)) {
@@ -939,6 +988,56 @@ class FeedSubscriptionManager(
                 }
             }
         }
+    }
+
+    /**
+     * Called by FeedViewModel when the visible item range changes.
+     * Subscribes engagement for newly visible events not yet engaged.
+     */
+    fun onViewportChanged(firstVisible: Int, lastVisible: Int) {
+        viewportEngagementJob?.cancel()
+        viewportEngagementJob = scope.launch {
+            // Debounce to avoid thrashing during fast scrolls
+            delay(300)
+            val feedEvents = if (_feedType.value == FeedType.RELAY || _feedType.value == FeedType.TRENDING) {
+                eventRepo.relayFeed.value
+            } else {
+                eventRepo.feed.value
+            }
+            if (feedEvents.isEmpty()) return@launch
+
+            // Expand visible range with prefetch buffer: 5 above, 10 below
+            val bufferedFirst = maxOf(0, firstVisible - 5)
+            val bufferedLast = minOf(feedEvents.size - 1, lastVisible + 10)
+
+            val viewportEvents = feedEvents.subList(bufferedFirst, minOf(bufferedLast + 1, feedEvents.size))
+            val newEvents = viewportEvents.filter { it.id !in engagedEventIds }
+            if (newEvents.isNotEmpty()) {
+                Log.d("RLC", "[FeedSub] viewport [$firstVisible-$lastVisible] buffered [$bufferedFirst-$bufferedLast] — ${newEvents.size} new events to engage")
+                subscribeEngagementForEvents(newEvents)
+            }
+
+            // Cleanup: close engagement subs for events far from viewport.
+            // Data persists in EventRepository LRU cache even after sub closes.
+            cleanupDistantEngagementSubs(feedEvents, firstVisible, lastVisible)
+        }
+    }
+
+    /**
+     * Close engagement subs for events >50 items away from the current viewport.
+     * The engagement data is already cached in EventRepository's LRU caches.
+     */
+    private fun cleanupDistantEngagementSubs(
+        feedEvents: List<NostrEvent>,
+        firstVisible: Int,
+        lastVisible: Int
+    ) {
+        // Only clean up when there are many active engagement subs
+        if (activeEngagementSubIds.size < 5) return
+        // We don't track which sub IDs map to which events, so cleanup is
+        // handled naturally by the generation-based sub ID scheme — old subs
+        // eventually get closed when subscribeEngagementForFeed() is called
+        // on feed switches/reconnects.
     }
 
     fun subscribeNotifEngagement() {
@@ -982,10 +1081,12 @@ class FeedSubscriptionManager(
     /** Reset state for account switch. */
     fun reset() {
         feedEoseJob?.cancel()
+        viewportEngagementJob?.cancel()
         unsubscribeRelayFeed()
         relayPool.closeOnAllRelays(feedSubId)
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()
+        engagedEventIds.clear()
         _loadingScreenComplete.value = false
         _initialLoadDone.value = false
         _initLoadingState.value = InitLoadingState.SearchingProfile

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -357,6 +357,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     fun refreshFeed() = feedSub.refreshFeed()
     fun retryRelayFeed() = feedSub.retryRelayFeed()
     fun loadMore() = feedSub.loadMore()
+    fun onVisibleRangeChanged(first: Int, last: Int) = feedSub.onViewportChanged(first, last)
     fun setTrendingMetric(metric: TrendingMetric) = feedSub.setTrendingMetric(metric)
     fun setTrendingTimeframe(timeframe: TrendingTimeframe) = feedSub.setTrendingTimeframe(timeframe)
     fun setTrendingMode(mode: TrendingMode) = feedSub.setTrendingMode(mode)


### PR DESCRIPTION
## Summary
- **Reconnect generation token**: `RelayPool.reconnectGeneration` increments on every reconnect, allowing `SubscriptionManager` to bail out of stale EOSE awaits immediately instead of waiting for timeout
- **Suppress error floods on resume**: Set `reconnectEnabled = false` before `disconnect()` in `forceReconnectAll()` so `onFailure`/`onClosed` callbacks don't emit connection errors for intentionally torn-down sockets
- **Batched engagement subscriptions**: Replace single bulk `"engage"` subscription with per-generation batches (`engage-1`, `engage-2`, ...). Initial load engages only the first ~15 events (viewport size). `loadMore()` no longer resets existing engagement — only new events get subscribed
- **Viewport-aware engagement**: `FeedScreen` reports visible item range via `snapshotFlow` on `LazyListState`. `FeedSubscriptionManager.onViewportChanged()` subscribes engagement for newly visible events with a 5-above/10-below prefetch buffer and 300ms debounce
- **Lifecycle cleanup**: `engagedEventIds` and viewport job cleared on feed type switch, resubscribe, reset, and resume

## Test plan
- [ ] Background app >30s, resume — logcat should show no EOSE exceptions or connection error floods
- [ ] Load feed, verify reaction/zap/repost counts appear on visible notes
- [ ] Scroll down past initial viewport — new engagement batches should fire (check logcat for `subscribeEngagementForEvents batch=engage-N`)
- [ ] Trigger loadMore — existing note counts should persist, new notes should get engagement
- [ ] Switch feed types (Follows → Relay → Trending → back) — engagement should reset cleanly