### PR TITLE
feat: add proof of work option for DMs

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/CrashHandler.kt
+++ b/app/src/main/kotlin/com/wisp/app/CrashHandler.kt
@@ -70,7 +70,7 @@ object CrashHandler {
         "wss://relay.damus.io"
     )
 
-    fun sendCrashDm(keyRepo: KeyRepository, relayPool: RelayPool, crashLog: String) {
+    suspend fun sendCrashDm(keyRepo: KeyRepository, relayPool: RelayPool, crashLog: String) {
         val keypair = keyRepo.getKeypair() ?: return
 
         val recipientPubkey = DEVELOPER_PUBKEY.chunked(2).map { it.toInt(16).toByte() }.toByteArray()

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -983,7 +983,7 @@ fun WispNavHost(
             val dmConvoViewModel: DmConversationViewModel = viewModel()
             LaunchedEffect(pubkey) {
                 feedViewModel.refreshDmsAndNotifications()
-                dmConvoViewModel.init(pubkey, feedViewModel.dmRepo, feedViewModel.relayListRepo, feedViewModel.relayPool)
+                dmConvoViewModel.init(pubkey, feedViewModel.dmRepo, feedViewModel.relayListRepo, feedViewModel.relayPool, feedViewModel.powPrefs)
                 activeSigner?.let { dmConvoViewModel.decryptPending(it, feedViewModel.muteRepo) }
             }
             val peerProfile = feedViewModel.eventRepo.getProfileData(pubkey)

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip17.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip17.kt
@@ -24,13 +24,15 @@ object Nip17 {
      * Create a gift-wrapped DM (kind 1059) from sender to recipient.
      * Implements the 3-layer NIP-17 scheme: rumor(14) -> seal(13) -> gift wrap(1059).
      */
-    fun createGiftWrap(
+    suspend fun createGiftWrap(
         senderPrivkey: ByteArray,
         senderPubkey: ByteArray,
         recipientPubkey: ByteArray,
         message: String,
         replyTags: List<List<String>> = emptyList(),
-        rumorPTag: String? = null
+        rumorPTag: String? = null,
+        targetDifficulty: Int = 0,
+        onProgress: ((Long) -> Unit)? = null
     ): NostrEvent {
         val senderPubkeyHex = senderPubkey.toHex()
         val recipientPubkeyHex = recipientPubkey.toHex()
@@ -72,13 +74,34 @@ object Nip17 {
         val throwawayRecipientKey = Nip44.getConversationKey(throwaway.privkey, recipientPubkey)
         val encryptedSeal = Nip44.encrypt(seal.toJson(), throwawayRecipientKey)
         val wrapTimestamp = randomizeTimestamp(now)
+        val baseTags = listOf(listOf("p", recipientPubkeyHex))
+
+        val finalTags: List<List<String>>
+        val finalCreatedAt: Long
+        if (targetDifficulty > 0) {
+            val result = Nip13.mine(
+                pubkeyHex = throwaway.pubkey.toHex(),
+                kind = 1059,
+                content = encryptedSeal,
+                tags = baseTags,
+                targetDifficulty = targetDifficulty,
+                createdAt = wrapTimestamp,
+                onProgress = onProgress
+            )
+            finalTags = result.tags
+            finalCreatedAt = result.createdAt
+        } else {
+            finalTags = baseTags
+            finalCreatedAt = wrapTimestamp
+        }
+
         val giftWrap = NostrEvent.create(
             privkey = throwaway.privkey,
             pubkey = throwaway.pubkey,
             kind = 1059,
             content = encryptedSeal,
-            tags = listOf(listOf("p", recipientPubkeyHex)),
-            createdAt = wrapTimestamp
+            tags = finalTags,
+            createdAt = finalCreatedAt
         )
 
         // Wipe throwaway private key — no reason for it to persist
@@ -140,7 +163,9 @@ object Nip17 {
         recipientPubkeyHex: String,
         message: String,
         replyTags: List<List<String>> = emptyList(),
-        rumorPTag: String? = null
+        rumorPTag: String? = null,
+        targetDifficulty: Int = 0,
+        onProgress: ((Long) -> Unit)? = null
     ): NostrEvent {
         val senderPubkeyHex = signer.pubkeyHex
 
@@ -177,13 +202,34 @@ object Nip17 {
         val throwawayRecipientKey = Nip44.getConversationKey(throwaway.privkey, recipientPubkeyHex.hexToByteArray())
         val encryptedSeal = Nip44.encrypt(seal.toJson(), throwawayRecipientKey)
         val wrapTimestamp = randomizeTimestamp(now)
+        val baseTags = listOf(listOf("p", recipientPubkeyHex))
+
+        val finalTags: List<List<String>>
+        val finalCreatedAt: Long
+        if (targetDifficulty > 0) {
+            val result = Nip13.mine(
+                pubkeyHex = throwaway.pubkey.toHex(),
+                kind = 1059,
+                content = encryptedSeal,
+                tags = baseTags,
+                targetDifficulty = targetDifficulty,
+                createdAt = wrapTimestamp,
+                onProgress = onProgress
+            )
+            finalTags = result.tags
+            finalCreatedAt = result.createdAt
+        } else {
+            finalTags = baseTags
+            finalCreatedAt = wrapTimestamp
+        }
+
         val giftWrap = NostrEvent.create(
             privkey = throwaway.privkey,
             pubkey = throwaway.pubkey,
             kind = 1059,
             content = encryptedSeal,
-            tags = listOf(listOf("p", recipientPubkeyHex)),
-            createdAt = wrapTimestamp
+            tags = finalTags,
+            createdAt = finalCreatedAt
         )
 
         throwaway.wipe()

--- a/app/src/main/kotlin/com/wisp/app/repo/PowPreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/PowPreferences.kt
@@ -16,4 +16,10 @@ class PowPreferences(context: Context) {
 
     fun getReactionDifficulty(): Int = prefs.getInt("pow_reaction_difficulty", 12)
     fun setReactionDifficulty(bits: Int) = prefs.edit().putInt("pow_reaction_difficulty", bits.coerceIn(8, 32)).apply()
+
+    fun isDmPowEnabled(): Boolean = prefs.getBoolean("pow_dm_enabled", true)
+    fun setDmPowEnabled(enabled: Boolean) = prefs.edit().putBoolean("pow_dm_enabled", enabled).apply()
+
+    fun getDmDifficulty(): Int = prefs.getInt("pow_dm_difficulty", 12)
+    fun setDmDifficulty(bits: Int) = prefs.edit().putInt("pow_dm_difficulty", bits.coerceIn(8, 32)).apply()
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
@@ -66,6 +66,7 @@ import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.nostr.NostrSigner
 import com.wisp.app.viewmodel.DeliveryRelaySource
 import com.wisp.app.viewmodel.DmConversationViewModel
+import com.wisp.app.viewmodel.PowStatus
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -92,6 +93,7 @@ fun DmConversationScreen(
     val userDmRelays by viewModel.userDmRelays.collectAsState()
     val decrypting by viewModel.decrypting.collectAsState()
     val pendingDecryptCount by viewModel.pendingDecryptCount.collectAsState()
+    val miningStatus by viewModel.miningStatus.collectAsState()
     val listState = rememberLazyListState()
     var showRelayInfo by remember { mutableStateOf(false) }
     val totalRelayCount = (peerDelivery.urls.size + userDmRelays.size)
@@ -371,7 +373,20 @@ fun DmConversationScreen(
                     modifier = Modifier.weight(1f)
                 )
                 Spacer(Modifier.width(8.dp))
-                if (sending) {
+                if (sending && miningStatus is PowStatus.Mining) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            "Mining...",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else if (sending) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(24.dp),
                         strokeWidth = 2.dp,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/PowSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/PowSettingsScreen.kt
@@ -43,6 +43,8 @@ fun PowSettingsScreen(
     var noteDifficulty by remember { mutableIntStateOf(powPrefs.getNoteDifficulty()) }
     var reactionEnabled by remember { mutableStateOf(powPrefs.isReactionPowEnabled()) }
     var reactionDifficulty by remember { mutableIntStateOf(powPrefs.getReactionDifficulty()) }
+    var dmEnabled by remember { mutableStateOf(powPrefs.isDmPowEnabled()) }
+    var dmDifficulty by remember { mutableIntStateOf(powPrefs.getDmDifficulty()) }
 
     Scaffold(
         topBar = {
@@ -150,6 +152,47 @@ fun PowSettingsScreen(
                     onValueChange = {
                         reactionDifficulty = it
                         powPrefs.setReactionDifficulty(it)
+                    }
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // DMs section
+            Text(
+                text = "Direct Messages",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Enable PoW for DMs", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Mine proof of work on gift wraps before sending DMs",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = dmEnabled,
+                    onCheckedChange = {
+                        dmEnabled = it
+                        powPrefs.setDmPowEnabled(it)
+                    }
+                )
+            }
+            if (dmEnabled) {
+                Spacer(Modifier.height(12.dp))
+                DifficultySelector(
+                    label = "DM difficulty",
+                    value = dmDifficulty,
+                    onValueChange = {
+                        dmDifficulty = it
+                        powPrefs.setDmDifficulty(it)
                     }
                 )
             }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/DmConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/DmConversationViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.DmMessage
 import com.wisp.app.nostr.Filter
+import com.wisp.app.nostr.Nip13
 import com.wisp.app.nostr.Nip17
 import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.NostrSigner
@@ -22,6 +23,7 @@ import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.BlossomRepository
 import com.wisp.app.repo.DmRepository
 import com.wisp.app.repo.KeyRepository
+import com.wisp.app.repo.PowPreferences
 import com.wisp.app.repo.RelayListRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -69,14 +71,19 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
     private val _pendingDecryptCount = MutableStateFlow(0)
     val pendingDecryptCount: StateFlow<Int> = _pendingDecryptCount
 
+    private val _miningStatus = MutableStateFlow<PowStatus>(PowStatus.Idle)
+    val miningStatus: StateFlow<PowStatus> = _miningStatus
+
     private var peerPubkey: String = ""
     private var dmRepo: DmRepository? = null
     private var relayListRepo: RelayListRepository? = null
+    private var powPrefs: PowPreferences? = null
 
-    fun init(peerPubkeyHex: String, dmRepository: DmRepository, relayListRepository: RelayListRepository? = null, relayPool: RelayPool? = null) {
+    fun init(peerPubkeyHex: String, dmRepository: DmRepository, relayListRepository: RelayListRepository? = null, relayPool: RelayPool? = null, powPreferences: PowPreferences? = null) {
         peerPubkey = peerPubkeyHex
         dmRepo = dmRepository
         relayListRepo = relayListRepository
+        powPrefs = powPreferences
         _messages.value = dmRepository.getConversation(peerPubkeyHex)
 
         // Expose user's own DM relays
@@ -320,10 +327,20 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
                     val recipientDmRelays = fetchRecipientDmRelays(relayPool)
                     val deliveryRelays = resolveRecipientRelaysWithSource(recipientDmRelays, relayPool).urls
 
+                    val dmPowEnabled = powPrefs?.isDmPowEnabled() == true
+                    val dmDifficulty = if (dmPowEnabled) powPrefs?.getDmDifficulty() ?: 0 else 0
+                    if (dmDifficulty > 0) {
+                        _miningStatus.value = PowStatus.Mining(1059, 0, dmDifficulty)
+                    }
+
                     val recipientWrap = Nip17.createGiftWrapRemote(
                         signer = signer,
                         recipientPubkeyHex = peerPubkey,
-                        message = text
+                        message = text,
+                        targetDifficulty = dmDifficulty,
+                        onProgress = { attempts ->
+                            _miningStatus.value = PowStatus.Mining(1059, attempts, dmDifficulty)
+                        }
                     )
                     val recipientMsg = ClientMessage.event(recipientWrap)
                     val sentRelayUrls = sendToDeliveryRelays(relayPool, deliveryRelays, recipientMsg)
@@ -365,6 +382,7 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
                     Log.w("DmConversation", "Send failed (remote signer)", e)
                 } finally {
                     _sending.value = false
+                    _miningStatus.value = PowStatus.Idle
                 }
             }
             return
@@ -384,11 +402,21 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
                 val recipientDmRelays = fetchRecipientDmRelays(relayPool)
                 val deliveryRelays = resolveRecipientRelaysWithSource(recipientDmRelays, relayPool).urls
 
+                val dmPowEnabled = powPrefs?.isDmPowEnabled() == true
+                val dmDifficulty = if (dmPowEnabled) powPrefs?.getDmDifficulty() ?: 0 else 0
+                if (dmDifficulty > 0) {
+                    _miningStatus.value = PowStatus.Mining(1059, 0, dmDifficulty)
+                }
+
                 val recipientWrap = Nip17.createGiftWrap(
                     senderPrivkey = keypair.privkey,
                     senderPubkey = keypair.pubkey,
                     recipientPubkey = peerPubkey.hexToByteArray(),
-                    message = text
+                    message = text,
+                    targetDifficulty = dmDifficulty,
+                    onProgress = { attempts ->
+                        _miningStatus.value = PowStatus.Mining(1059, attempts, dmDifficulty)
+                    }
                 )
                 val recipientMsg = ClientMessage.event(recipientWrap)
                 val sentRelayUrls = sendToDeliveryRelays(relayPool, deliveryRelays, recipientMsg)
@@ -428,6 +456,7 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
                 Log.w("DmConversation", "Send failed (local signer)", e)
             } finally {
                 _sending.value = false
+                _miningStatus.value = PowStatus.Idle
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds NIP-13 proof of work mining to DM gift wraps (kind 1059) before sending
- Enabled by default at 12 bits difficulty (matching reactions default)
- Configurable via PoW settings screen (enable/disable + difficulty 8-32 bits)
- Shows "Mining..." indicator in DM conversation while PoW is being computed
- Supports both local and remote signer paths

## Test plan
- [ ] Send a DM with PoW enabled — verify "Mining..." appears briefly, message sends successfully
- [ ] Disable DM PoW in settings — verify DMs send without mining delay
- [ ] Adjust DM difficulty in settings — verify it persists and applies on next send
- [ ] Verify notes and reactions PoW still work as before