### PR TITLE
Fix custom emojis missing from profile screen emoji picker

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -842,6 +842,9 @@ fun WispNavHost(
             val profileListedIds = remember(profileSetListedIds, profileBookmarkedIds) { profileSetListedIds + profileBookmarkedIds }
             val profilePinnedIds by if (isOwnProfile) feedViewModel.pinRepo.pinnedIds.collectAsState() else userProfileViewModel.pinnedNoteIds.collectAsState()
             val profileZapInProgress by feedViewModel.zapInProgress.collectAsState()
+            val profileResolvedEmojis by feedViewModel.customEmojiRepo.resolvedEmojis.collectAsState()
+            val profileUnicodeEmojis by feedViewModel.customEmojiRepo.unicodeEmojis.collectAsState()
+            var showProfileEmojiLibrary by remember { mutableStateOf(false) }
             UserProfileScreen(
                 viewModel = userProfileViewModel,
                 contactRepo = feedViewModel.contactRepo,
@@ -906,8 +909,20 @@ fun WispNavHost(
                 onArticleClick = { kind, articleAuthor, articleDTag ->
                     navController.navigate("article/$kind/$articleAuthor/${java.net.URLEncoder.encode(articleDTag, "UTF-8")}")
                 },
-                onPollVote = { pollId, optionIds -> feedViewModel.publishPollVote(pollId, optionIds) }
+                onPollVote = { pollId, optionIds -> feedViewModel.publishPollVote(pollId, optionIds) },
+                resolvedEmojis = profileResolvedEmojis,
+                unicodeEmojis = profileUnicodeEmojis,
+                onOpenEmojiLibrary = { showProfileEmojiLibrary = true }
             )
+            if (showProfileEmojiLibrary) {
+                com.wisp.app.ui.component.EmojiLibrarySheet(
+                    currentEmojis = profileUnicodeEmojis,
+                    onAddEmojis = { emojis ->
+                        emojis.forEach { feedViewModel.customEmojiRepo.addUnicodeEmoji(it) }
+                    },
+                    onDismiss = { showProfileEmojiLibrary = false }
+                )
+            }
         }
 
         composable(Routes.SEARCH) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -145,7 +145,10 @@ fun UserProfileScreen(
     signer: com.wisp.app.nostr.NostrSigner? = null,
     translationRepo: TranslationRepository? = null,
     onArticleClick: ((Int, String, String) -> Unit)? = null,
-    onPollVote: (String, List<String>) -> Unit = { _, _ -> }
+    onPollVote: (String, List<String>) -> Unit = { _, _ -> },
+    resolvedEmojis: Map<String, String> = emptyMap(),
+    unicodeEmojis: List<String> = emptyList(),
+    onOpenEmojiLibrary: (() -> Unit)? = null
 ) {
     val profile by viewModel.profile.collectAsState()
     val isFollowing by viewModel.isFollowing.collectAsState()
@@ -472,7 +475,10 @@ fun UserProfileScreen(
                                 pollVoteCounts = pinnedPollVoteCounts,
                                 pollTotalVotes = pinnedPollTotalVotes,
                                 userPollVotes = pinnedUserPollVotes,
-                                onPollVote = { optionIds -> onPollVote(event.id, optionIds) }
+                                onPollVote = { optionIds -> onPollVote(event.id, optionIds) },
+                                resolvedEmojis = resolvedEmojis,
+                                unicodeEmojis = unicodeEmojis,
+                                onOpenEmojiLibrary = onOpenEmojiLibrary
                             )
                         }
                     }
@@ -568,7 +574,10 @@ fun UserProfileScreen(
                                 pollVoteCounts = rootPollVoteCounts,
                                 pollTotalVotes = rootPollTotalVotes,
                                 userPollVotes = rootUserPollVotes,
-                                onPollVote = { optionIds -> onPollVote(event.id, optionIds) }
+                                onPollVote = { optionIds -> onPollVote(event.id, optionIds) },
+                                resolvedEmojis = resolvedEmojis,
+                                unicodeEmojis = unicodeEmojis,
+                                onOpenEmojiLibrary = onOpenEmojiLibrary
                             )
                         }
                         if (rootNotes.isNotEmpty()) {
@@ -657,7 +666,10 @@ fun UserProfileScreen(
                                 pollVoteCounts = replyPollVoteCounts,
                                 pollTotalVotes = replyPollTotalVotes,
                                 userPollVotes = replyUserPollVotes,
-                                onPollVote = { optionIds -> onPollVote(event.id, optionIds) }
+                                onPollVote = { optionIds -> onPollVote(event.id, optionIds) },
+                                resolvedEmojis = resolvedEmojis,
+                                unicodeEmojis = unicodeEmojis,
+                                onOpenEmojiLibrary = onOpenEmojiLibrary
                             )
                         }
                         item {


### PR DESCRIPTION
## Summary
- UserProfileScreen was missing `resolvedEmojis`, `unicodeEmojis`, and `onOpenEmojiLibrary` parameters
- Added these params to UserProfileScreen and passed them through to all three PostCard call sites (pinned notes, root notes, replies)
- Added EmojiLibrarySheet to the profile route in Navigation.kt, matching the pattern used by feed, thread, article, and notifications screens

## Test plan
- [ ] Open a user profile page and long-press a note to react
- [ ] Verify custom image emojis appear in the emoji picker
- [ ] Verify the "+" button opens the emoji library sheet
- [ ] Confirm emoji reactions still work correctly on feed and thread screens