### PR TITLE
feat: handle nostr: deep links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="nostr" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/app/src/main/kotlin/com/wisp/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/wisp/app/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.wisp.app
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.SystemBarStyle
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -21,10 +22,14 @@ import com.wisp.app.ui.component.MediaSettings
 import com.wisp.app.ui.theme.WispTheme
 
 class MainActivity : FragmentActivity() {
+    var deepLinkUri = mutableStateOf<String?>(null)
+        private set
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        deepLinkUri.value = intent?.data?.toString()
         setContent {
             val prefs = remember { getSharedPreferences("wisp_settings", Context.MODE_PRIVATE) }
             val interfacePrefs = remember { InterfacePreferences(this@MainActivity) }
@@ -57,6 +62,8 @@ class MainActivity : FragmentActivity() {
             WispTheme(isDarkTheme = isDarkTheme, accentColor = accentColor, isLargeText = isLargeText, themeName = themeName) {
                 CompositionLocalProvider(LocalMediaSettings provides mediaSettings) {
                     WispNavHost(
+                        deepLinkUri = deepLinkUri.value,
+                        onDeepLinkConsumed = { deepLinkUri.value = null },
                         isDarkTheme = isDarkTheme,
                         onToggleTheme = {
                             isDarkTheme = !isDarkTheme
@@ -77,5 +84,10 @@ class MainActivity : FragmentActivity() {
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        deepLinkUri.value = intent.data?.toString()
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -34,6 +34,8 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.collectAsState
 import com.wisp.app.nostr.Nip10
+import com.wisp.app.nostr.Nip19
+import com.wisp.app.nostr.NostrUriData
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.LocalSigner
 import com.wisp.app.nostr.RemoteSigner
@@ -145,6 +147,8 @@ object Routes {
 
 @Composable
 fun WispNavHost(
+    deepLinkUri: String? = null,
+    onDeepLinkConsumed: () -> Unit = {},
     isDarkTheme: Boolean = true,
     onToggleTheme: () -> Unit = {},
     accentColor: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color(0xFFFF9800),
@@ -329,6 +333,33 @@ fun WispNavHost(
     // Initialize notifications viewmodel with shared repos
     LaunchedEffect(Unit) {
         notificationsViewModel.init(feedViewModel.notifRepo, feedViewModel.eventRepo, feedViewModel.contactRepo)
+    }
+
+    // Resolve deep link URI to a navigation route
+    val deepLinkRoute = remember(deepLinkUri) {
+        val uri = deepLinkUri ?: return@remember null
+        val parsed = Nip19.decodeNostrUri(uri) ?: return@remember null
+        when (parsed) {
+            is NostrUriData.ProfileRef -> "profile/${parsed.pubkey}"
+            is NostrUriData.NoteRef -> "thread/${parsed.eventId}"
+            is NostrUriData.AddressRef -> {
+                if (parsed.kind == 30023 && parsed.author != null) {
+                    "article/${parsed.kind}/${parsed.author}/${parsed.dTag}"
+                } else null
+            }
+        }
+    }
+
+    // Handle deep links when app is already past loading (onNewIntent)
+    LaunchedEffect(deepLinkUri) {
+        val route = deepLinkRoute ?: return@LaunchedEffect
+        if (!authViewModel.isLoggedIn) return@LaunchedEffect
+        val currentDest = navController.currentDestination?.route
+        // Only navigate directly if we're past the loading/auth screens
+        if (currentDest != null && currentDest !in setOf(Routes.LOADING, Routes.AUTH, Routes.ONBOARDING_PROFILE)) {
+            onDeepLinkConsumed()
+            navController.navigate(route)
+        }
     }
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -564,8 +595,18 @@ fun WispNavHost(
             LoadingScreen(
                 viewModel = feedViewModel,
                 onReady = {
-                    navController.navigate(Routes.FEED) {
-                        popUpTo(Routes.LOADING) { inclusive = true }
+                    val target = deepLinkRoute
+                    if (target != null) {
+                        onDeepLinkConsumed()
+                        // Navigate to Feed first (as backstack root), then to the deep link target
+                        navController.navigate(Routes.FEED) {
+                            popUpTo(Routes.LOADING) { inclusive = true }
+                        }
+                        navController.navigate(target)
+                    } else {
+                        navController.navigate(Routes.FEED) {
+                            popUpTo(Routes.LOADING) { inclusive = true }
+                        }
                     }
                 }
             )


### PR DESCRIPTION
## Summary
- Registers Wisp as a handler for the `nostr:` URI scheme (npub, nprofile, nevent, note, naddr)
- Tapping a nostr link on the web or in another app opens Wisp to the correct screen (profile, thread, or article)
- Cold start: waits for relay initialization, then navigates to the deep link target with Feed as the backstack root
- Warm start (app already open): navigates immediately via `onNewIntent`

## Test plan
- [ ] Tap a `nostr:npub1...` link in a browser — should open the user's profile
- [ ] Tap a `nostr:nprofile1...` link — should open the user's profile
- [ ] Tap a `nostr:nevent1...` or `nostr:note1...` link — should open the thread
- [ ] Tap a `nostr:naddr1...` link (kind 30023) — should open the article
- [ ] Verify back button from deep link target goes to Feed
- [ ] Verify deep links while app is already open navigate correctly
- [ ] Verify normal app launch (no deep link) is unaffected