### PR TITLE
feat: add interest set feed and improve hashtag picker

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1245,6 +1245,10 @@ fun WispNavHost(
                 },
                 nip05Repo = feedViewModel.nip05Repo,
                 translationRepo = feedViewModel.translationRepo,
+                onHashtagPicker = {
+                    feedViewModel.requestHashtagPicker()
+                    navController.popBackStack()
+                },
                 onBack = { navController.popBackStack() },
                 onPollVote = { pollId, optionIds -> feedViewModel.publishPollVote(pollId, optionIds) }
             )
@@ -1332,6 +1336,10 @@ fun WispNavHost(
                 },
                 nip05Repo = feedViewModel.nip05Repo,
                 translationRepo = feedViewModel.translationRepo,
+                onHashtagPicker = {
+                    feedViewModel.requestHashtagPicker()
+                    navController.popBackStack()
+                },
                 onBack = { navController.popBackStack() },
                 onPollVote = { pollId, optionIds -> feedViewModel.publishPollVote(pollId, optionIds) }
             )

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -242,7 +243,14 @@ fun FeedScreen(
     var showRelayPicker by remember { mutableStateOf(false) }
     var showListPicker by remember { mutableStateOf(false) }
     val interestSets by viewModel.interestRepo.sets.collectAsState()
+    val hashtagPickerRequested by viewModel.hashtagPickerRequested.collectAsState()
     var showHashtagPicker by remember { mutableStateOf(false) }
+    LaunchedEffect(hashtagPickerRequested) {
+        if (hashtagPickerRequested) {
+            showHashtagPicker = true
+            viewModel.clearHashtagPickerRequest()
+        }
+    }
     var showRelayDropdown by remember { mutableStateOf(false) }
     var showFeedTypeDropdown by remember { mutableStateOf(false) }
     var showSocialGraphDialog by remember { mutableStateOf(false) }
@@ -366,6 +374,7 @@ fun FeedScreen(
                 onViewSetFeed?.invoke(set)
             },
             onAddHashtag = { tag, dTag -> viewModel.followHashtag(tag, dTag) },
+            onRemoveHashtag = { tag, dTag -> viewModel.unfollowHashtag(tag, dTag) },
             onCreateSet = { name -> viewModel.createInterestSet(name) },
             onRenameSet = { dTag, name -> viewModel.renameInterestSet(dTag, name) },
             onDeleteSet = { dTag -> viewModel.deleteInterestSet(dTag) },
@@ -1707,6 +1716,7 @@ private fun HashtagPickerDialog(
     onSelectHashtag: (String) -> Unit,
     onViewSetFeed: (com.wisp.app.nostr.InterestSet) -> Unit,
     onAddHashtag: (tag: String, dTag: String) -> Unit,
+    onRemoveHashtag: (tag: String, dTag: String) -> Unit,
     onCreateSet: (String) -> Unit,
     onRenameSet: (String, String) -> Unit,
     onDeleteSet: (String) -> Unit,
@@ -1720,6 +1730,10 @@ private fun HashtagPickerDialog(
     var confirmDeleteDTag by remember { mutableStateOf<String?>(null) }
     var showNewSetField by remember { mutableStateOf(false) }
     val newSetFocusRequester = remember { FocusRequester() }
+    // First set always expanded by default
+    var expandedDTags by remember(sets.size) {
+        mutableStateOf(sets.firstOrNull()?.let { setOf(it.dTag) } ?: emptySet())
+    }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -1800,24 +1814,34 @@ private fun HashtagPickerDialog(
                                 }
                             }
                         } else {
+                            val isExpanded = set.dTag in expandedDTags
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,
                                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
                             ) {
+                                Icon(
+                                    if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                                    contentDescription = if (isExpanded) "Collapse" else "Expand",
+                                    modifier = Modifier.size(20.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Spacer(Modifier.width(6.dp))
                                 Text(
                                     set.name,
-                                    style = MaterialTheme.typography.titleSmall,
+                                    style = MaterialTheme.typography.titleMedium,
                                     modifier = Modifier
                                         .weight(1f)
                                         .combinedClickable(
-                                            onClick = {},
+                                            onClick = {
+                                                expandedDTags = if (isExpanded) expandedDTags - set.dTag else expandedDTags + set.dTag
+                                            },
                                             onLongClick = {
                                                 renamingDTag = set.dTag
                                                 renameText = set.name
                                             }
                                         )
                                 )
-                                if (set.hashtags.isNotEmpty()) {
+                                if (isExpanded && set.hashtags.isNotEmpty()) {
                                     TextButton(
                                         onClick = { onViewSetFeed(set) },
                                         modifier = Modifier.heightIn(min = 32.dp),
@@ -1826,76 +1850,84 @@ private fun HashtagPickerDialog(
                                         Text("Feed", style = MaterialTheme.typography.labelSmall)
                                     }
                                 }
-                                IconButton(
-                                    onClick = {
-                                        addingToDTag = if (addingToDTag == set.dTag) null else set.dTag
-                                        newHashtagText = ""
-                                    },
-                                    modifier = Modifier.size(32.dp)
-                                ) {
-                                    Icon(
-                                        Icons.Default.Add,
-                                        contentDescription = "Add hashtag",
-                                        modifier = Modifier.size(16.dp)
-                                    )
+                                if (isExpanded) {
+                                    IconButton(
+                                        onClick = {
+                                            addingToDTag = if (addingToDTag == set.dTag) null else set.dTag
+                                            newHashtagText = ""
+                                        },
+                                        modifier = Modifier.size(32.dp)
+                                    ) {
+                                        Icon(
+                                            Icons.Default.Add,
+                                            contentDescription = "Add hashtag",
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    }
                                 }
                             }
                         }
-                        // Add hashtag input for this set
-                        if (addingToDTag == set.dTag) {
-                            val focusRequester = remember { FocusRequester() }
-                            LaunchedEffect(Unit) { focusRequester.requestFocus() }
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.fillMaxWidth().padding(start = 8.dp, bottom = 4.dp)
-                            ) {
-                                androidx.compose.material3.OutlinedTextField(
-                                    value = newHashtagText,
-                                    onValueChange = { newHashtagText = it },
-                                    placeholder = { Text("hashtag") },
-                                    singleLine = true,
-                                    modifier = Modifier.weight(1f).focusRequester(focusRequester)
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                TextButton(
-                                    onClick = {
-                                        val cleaned = newHashtagText.trim().removePrefix("#").lowercase()
-                                        if (cleaned.isNotBlank()) {
-                                            onAddHashtag(cleaned, set.dTag)
-                                            newHashtagText = ""
-                                            addingToDTag = null
-                                        }
-                                    },
-                                    enabled = newHashtagText.trim().removePrefix("#").isNotBlank()
-                                ) { Text("Add") }
+                        val isExpanded = renamingDTag == set.dTag || set.dTag in expandedDTags
+                        if (isExpanded) {
+                            // Add hashtag input for this set
+                            if (addingToDTag == set.dTag) {
+                                val focusRequester = remember { FocusRequester() }
+                                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.fillMaxWidth().padding(start = 8.dp, bottom = 4.dp)
+                                ) {
+                                    androidx.compose.material3.OutlinedTextField(
+                                        value = newHashtagText,
+                                        onValueChange = { newHashtagText = it },
+                                        placeholder = { Text("hashtag") },
+                                        singleLine = true,
+                                        modifier = Modifier.weight(1f).focusRequester(focusRequester)
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    TextButton(
+                                        onClick = {
+                                            val cleaned = newHashtagText.trim().removePrefix("#").lowercase()
+                                            if (cleaned.isNotBlank()) {
+                                                onAddHashtag(cleaned, set.dTag)
+                                                newHashtagText = ""
+                                                addingToDTag = null
+                                            }
+                                        },
+                                        enabled = newHashtagText.trim().removePrefix("#").isNotBlank()
+                                    ) { Text("Add") }
+                                }
                             }
-                        }
-                        // Hashtags in this set
-                        if (set.hashtags.isEmpty()) {
-                            Text(
-                                "No hashtags yet",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(start = 12.dp, bottom = 4.dp)
-                            )
-                        } else {
-                            FlowRow(
-                                modifier = Modifier.padding(start = 8.dp),
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                verticalArrangement = Arrangement.spacedBy(3.dp)
-                            ) {
-                                set.hashtags.sorted().forEach { tag ->
-                                    Surface(
-                                        onClick = { onSelectHashtag(tag) },
-                                        shape = RoundedCornerShape(16.dp),
-                                        color = MaterialTheme.colorScheme.surfaceVariant
-                                    ) {
-                                        Text(
-                                            "#$tag",
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
-                                        )
+                            // Hashtags in this set
+                            if (set.hashtags.isEmpty()) {
+                                Text(
+                                    "No hashtags yet",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(start = 12.dp, bottom = 4.dp)
+                                )
+                            } else {
+                                FlowRow(
+                                    modifier = Modifier.padding(start = 8.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalArrangement = Arrangement.spacedBy(3.dp)
+                                ) {
+                                    set.hashtags.sorted().forEach { tag ->
+                                        Surface(
+                                            shape = RoundedCornerShape(16.dp),
+                                            color = MaterialTheme.colorScheme.surfaceVariant,
+                                            modifier = Modifier.combinedClickable(
+                                                onClick = { onSelectHashtag(tag) },
+                                                onLongClick = { onRemoveHashtag(tag, set.dTag) }
+                                            )
+                                        ) {
+                                            Text(
+                                                "#$tag",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/HashtagFeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/HashtagFeedScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.outlined.Tag
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -62,6 +63,7 @@ fun HashtagFeedScreen(
     onCreateDefaultSet: () -> Unit = {},
     nip05Repo: Nip05Repository? = null,
     translationRepo: TranslationRepository? = null,
+    onHashtagPicker: () -> Unit = {},
     onBack: () -> Unit,
     onPollVote: (String, List<String>) -> Unit = { _, _ -> }
 ) {
@@ -98,6 +100,12 @@ fun HashtagFeedScreen(
                     }
                 },
                 actions = {
+                    IconButton(onClick = onHashtagPicker) {
+                        Icon(
+                            Icons.Outlined.Tag,
+                            contentDescription = "Hashtag picker"
+                        )
+                    }
                     if (userPubkey != null) {
                         if (!interestSetsLoaded && interestSets.isEmpty()) {
                             CircularProgressIndicator(
@@ -120,7 +128,8 @@ fun HashtagFeedScreen(
                             }) {
                                 Icon(
                                     if (isFollowing) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
-                                    contentDescription = if (isFollowing) "Unfollow hashtag" else "Follow hashtag"
+                                    contentDescription = if (isFollowing) "Unfollow hashtag" else "Follow hashtag",
+                                    tint = MaterialTheme.colorScheme.primary
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -515,6 +515,11 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     private val _interestSetsFetched = MutableStateFlow(false)
     val interestSetsFetched: StateFlow<Boolean> = _interestSetsFetched
 
+    private val _hashtagPickerRequested = MutableStateFlow(false)
+    val hashtagPickerRequested: StateFlow<Boolean> = _hashtagPickerRequested
+    fun requestHashtagPicker() { _hashtagPickerRequested.value = true }
+    fun clearHashtagPickerRequest() { _hashtagPickerRequested.value = false }
+
     /**
      * Fetch interest sets (kind 30015) from relays if none are cached locally.
      * Called when entering hashtag feed to ensure we have up-to-date data.

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/HashtagFeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/HashtagFeedViewModel.kt
@@ -95,6 +95,7 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
                         if (event.kind == 1 && event.id !in seenIds) {
                             seenIds.add(event.id)
                             eventRepo.cacheEvent(event)
+                            eventRepo.requestProfileIfMissing(event.pubkey)
                             val current = _notes.value.toMutableList()
                             current.add(event)
                             current.sortByDescending { it.created_at }
@@ -129,6 +130,12 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
                 relayPool.eoseSignals.first { it == currentNoteSub }
             }
             _isLoading.value = false
+
+            // Fetch profiles for all note authors
+            for (note in _notes.value) {
+                eventRepo.requestProfileIfMissing(note.pubkey)
+            }
+
             subscribeEngagement(relayPool, eventRepo)
 
             // Keep collecting for another 10s then clean up


### PR DESCRIPTION
## Summary
- Add "Feed" button to each interest set in the hashtag picker, opening a combined feed of all hashtags in the set using `#t` filter on `search.nostrarchives.com`
- Replace bottom cancel button with an X close button in the title bar to maximize dialog content space
- Move "New Set" button next to the "Hashtags" title for better layout

## Test plan
- [ ] Open hashtag picker, verify "Feed" button appears on sets with hashtags
- [ ] Tap "Feed" on a set — should open a feed showing notes matching any of the set's hashtags, with the set name as the title
- [ ] Verify the X button in the top-right closes the dialog
- [ ] Verify "New Set" button still works next to the title
- [ ] Verify tapping individual hashtag chips still navigates to single-hashtag feed