### PR TITLE
fix: apply PoW to DM self-copy and prevent future timestamps

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip17.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip17.kt
@@ -278,8 +278,8 @@ object Nip17 {
     }
 
     private fun randomizeTimestamp(base: Long): Long {
-        // +-2 days in seconds
+        // 0 to 2 days in the past — avoids future timestamps that relays reject
         val twoDays = 2 * 24 * 60 * 60
-        return base + random.nextInt(twoDays * 2) - twoDays
+        return base - random.nextInt(twoDays)
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/DmConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/DmConversationViewModel.kt
@@ -354,7 +354,8 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
                         signer = signer,
                         recipientPubkeyHex = signer.pubkeyHex,
                         message = text,
-                        rumorPTag = peerPubkey
+                        rumorPTag = peerPubkey,
+                        targetDifficulty = dmDifficulty
                     )
                     val selfMsg = ClientMessage.event(selfWrap)
                     if (relayPool.hasDmRelays()) {
@@ -431,7 +432,8 @@ class DmConversationViewModel(app: Application) : AndroidViewModel(app) {
                     senderPubkey = keypair.pubkey,
                     recipientPubkey = keypair.pubkey,
                     message = text,
-                    rumorPTag = peerPubkey
+                    rumorPTag = peerPubkey,
+                    targetDifficulty = dmDifficulty
                 )
                 val selfMsg = ClientMessage.event(selfWrap)
                 if (relayPool.hasDmRelays()) {


### PR DESCRIPTION
## Summary
- Apply PoW to self-copy gift wraps so relays that require PoW accept them (relays can't distinguish self-copy from recipient wrap since both are gift-wrapped with throwaway keys)
- Constrain timestamp randomization to 0–2 days in the past only, fixing relay rejections due to future timestamps

## Test plan
- [ ] Send a DM with PoW enabled and verify both recipient and self-copy are accepted by relays
- [ ] Verify gift wrap timestamps are never in the future