### PR TITLE
fix: update signer when switching between LOCAL accounts

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -194,7 +194,8 @@ fun WispNavHost(
     // Reactive: recomposes on login, logout, and account switch
     val context = LocalContext.current
     val signingMode by authViewModel.signingModeFlow.collectAsState()
-    val activeSigner = remember(signingMode) {
+    val npub by authViewModel.npub.collectAsState()
+    val activeSigner = remember(signingMode, npub) {
         when (signingMode) {
             SigningMode.REMOTE -> {
                 val pubkey = authViewModel.keyRepo.getPubkeyHex() ?: ""
@@ -244,6 +245,7 @@ fun WispNavHost(
     val accounts by authViewModel.accountsFlow.collectAsState()
 
     val onSwitchAccount: (String) -> Unit = { pubkeyHex ->
+        feedViewModel.clearSigner()
         feedViewModel.resetForAccountSwitch()
         walletViewModel.suspendForAccountSwitch()  // disconnect only, preserve credentials
         authViewModel.switchAccount(pubkeyHex)
@@ -731,6 +733,7 @@ fun WispNavHost(
                 onSwitchAccount = onSwitchAccount,
                 onAddAccount = onAddAccount,
                 onLogout = {
+                    feedViewModel.clearSigner()
                     feedViewModel.resetForAccountSwitch()
                     walletViewModel.disconnectWallet()  // full clear — intentional logout
                     val hasRemaining = authViewModel.logOut()

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -137,6 +137,10 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         registerAuthSigner()
     }
 
+    fun clearSigner() {
+        signer = null
+    }
+
     private fun registerAuthSigner() {
         val s = signer ?: return
         relayPool.setAuthSigner { relayUrl, challenge ->


### PR DESCRIPTION
## Summary
- When switching between two LOCAL (nsec) accounts, `signingMode` stays `LOCAL` so `StateFlow` conflation prevents recomposition — the old signer is reused, causing posts signed by the wrong key
- Added `npub` as a `remember` key in `Navigation.kt` so the signer is always recreated on account switch
- Added `clearSigner()` to `FeedViewModel` and call it during account switch and logout to prevent stale signing during the transition window

## Test plan
- [ ] Switch between two LOCAL accounts → verify posts are signed by the active account's pubkey
- [ ] Check feed shows the correct follow list after switching
- [ ] Switch back → verify signing identity follows
- [ ] Test LOCAL → REMOTE and REMOTE → LOCAL switches still work
- [ ] Test logout with remaining accounts → verify correct signer is active