### PR TITLE
fix: handle poll events in user profile notes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
@@ -238,7 +238,7 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
                                 }
                             }
                         }
-                        30023 -> {
+                        30023, 1068 -> {
                             eventRepo.cacheEvent(event)
                             if (event.created_at < oldestNoteTimestamp) oldestNoteTimestamp = event.created_at
                             val current = _rootNotes.value.toMutableList()


### PR DESCRIPTION
## Summary
- Poll events (kind 1068) were included in the subscription filter but had no handler in the ViewModel's event processing, so they were silently dropped
- Added kind 1068 to the existing long-form article (kind 30023) handler so polls now appear in the user's root notes tab
- The UI already fully supported rendering polls with vote counts — only the ViewModel routing was missing

## Test plan
- [ ] View a user's profile who has published polls
- [ ] Verify poll notes appear in the Notes tab alongside regular posts
- [ ] Verify poll vote counts display correctly
- [ ] Load more notes and confirm older polls also appear