### PR TITLE
fix: handle poll events in user profile notes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 34
-        versionName = "0.9.3"
+        versionCode = 35
+        versionName = "0.9.4"
 
         ndk {
             abiFilters += "arm64-v8a"


### PR DESCRIPTION
## Summary
- Filter out poll response events (kind 1018) from user profile notes to prevent crashes when rendering non-standard event types
- Bump version to 0.9.4

## Test plan
- [ ] Open a user profile that has interacted with polls
- [ ] Verify their notes tab loads without errors
- [ ] Confirm poll response events are not displayed in the notes list