### PR TITLE
feat: zen mode notifications with inline reply

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 36
-        versionName = "0.9.5"
+        versionCode = 37
+        versionName = "0.10.0"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1995,6 +1995,8 @@ fun WispNavHost(
                 feedViewModel.refreshDmsAndNotifications()
                 notificationsViewModel.markRead()
             }
+
+            val notifReplyScope = rememberCoroutineScope()
             var notifZapTarget by remember { mutableStateOf<NostrEvent?>(null) }
             val notifZapInProgress by feedViewModel.zapInProgress.collectAsState()
             var notifZapAnimatingIds by remember { mutableStateOf(emptySet<String>()) }
@@ -2055,6 +2057,45 @@ fun WispNavHost(
                 onProfileClick = { pubkey ->
                     navController.navigate("profile/$pubkey")
                 },
+                onRefresh = { feedViewModel.refreshDmsAndNotifications() },
+                onSendReply = { replyToEvent, content ->
+                    val signer = activeSigner ?: return@NotificationsScreen
+                    notifReplyScope.launch {
+                        val hint = feedViewModel.outboxRouter?.getRelayHint(replyToEvent.pubkey) ?: ""
+                        val tags = com.wisp.app.nostr.Nip10.buildReplyTags(replyToEvent, hint)
+
+                        if (feedViewModel.powPrefs.isNotePowEnabled()) {
+                            feedViewModel.powManager.submitNote(
+                                signer = signer,
+                                content = content,
+                                tags = tags,
+                                kind = 1,
+                                replyToPubkey = replyToEvent.pubkey,
+                                onPublished = {
+                                    feedViewModel.eventRepo.addReplyCount(replyToEvent.id, "pow-pending")
+                                    val rootId = com.wisp.app.nostr.Nip10.getRootId(replyToEvent)
+                                    if (rootId != null && rootId != replyToEvent.id) {
+                                        feedViewModel.eventRepo.addReplyCount(rootId, "pow-pending")
+                                    }
+                                }
+                            )
+                        } else {
+                            val event = signer.signEvent(kind = 1, content = content, tags = tags)
+                            val msg = com.wisp.app.nostr.ClientMessage.event(event)
+                            if (feedViewModel.outboxRouter != null) {
+                                feedViewModel.outboxRouter!!.publishToInbox(msg, replyToEvent.pubkey)
+                            } else {
+                                feedViewModel.relayPool.sendToWriteRelays(msg)
+                            }
+                            feedViewModel.eventRepo.cacheEvent(event)
+                            feedViewModel.eventRepo.addReplyCount(replyToEvent.id, event.id)
+                            val rootId = com.wisp.app.nostr.Nip10.getRootId(replyToEvent)
+                            if (rootId != null && rootId != replyToEvent.id) {
+                                feedViewModel.eventRepo.addReplyCount(rootId, event.id)
+                            }
+                        }
+                    }
+                },
                 onReply = { event ->
                     replyTarget = event
                     quoteTarget = null
@@ -2086,9 +2127,22 @@ fun WispNavHost(
                 unicodeEmojis = notifUnicodeEmojis,
                 onOpenEmojiLibrary = { showNotifEmojiLibrary = true },
                 zapError = feedViewModel.zapError,
-                onRefresh = { feedViewModel.refreshDmsAndNotifications() },
                 translationRepo = feedViewModel.translationRepo,
-                onPollVote = { pollId, optionIds -> feedViewModel.publishPollVote(pollId, optionIds) }
+                onPollVote = { pollId, optionIds -> feedViewModel.publishPollVote(pollId, optionIds) },
+                onUploadMedia = { uris, onUrl ->
+                    notifReplyScope.launch {
+                        for (uri in uris) {
+                            try {
+                                val inputStream = context.contentResolver.openInputStream(uri)
+                                val bytes = inputStream?.use { it.readBytes() } ?: continue
+                                val mimeType = context.contentResolver.getType(uri) ?: "application/octet-stream"
+                                val ext = android.webkit.MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) ?: "bin"
+                                val url = feedViewModel.blossomRepo.uploadMedia(bytes, mimeType, ext, activeSigner)
+                                onUrl(url)
+                            } catch (_: Exception) {}
+                        }
+                    }
+                }
             )
 
             if (showNotifEmojiLibrary) {

--- a/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
@@ -1,5 +1,23 @@
 package com.wisp.app.nostr
 
+enum class NotificationType { REACTION, ZAP, REPOST, REPLY, QUOTE, MENTION, VOTE }
+
+data class FlatNotificationItem(
+    val id: String,
+    val type: NotificationType,
+    val actorPubkey: String,
+    val referencedEventId: String,
+    val timestamp: Long,
+    val emoji: String? = null,
+    val emojiUrl: String? = null,
+    val zapSats: Long = 0,
+    val zapMessage: String = "",
+    val isPrivateZap: Boolean = false,
+    val replyEventId: String? = null,
+    val quoteEventId: String? = null,
+    val voteOptionIds: List<String> = emptyList(),
+)
+
 data class NotificationSummary(
     val replyCount: Int = 0,
     val reactionCount: Int = 0,

--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -6,9 +6,12 @@ import android.util.LruCache
 import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.Nip30
 import com.wisp.app.nostr.Nip57
+import com.wisp.app.nostr.Nip88
 import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.nostr.FlatNotificationItem
 import com.wisp.app.nostr.NotificationGroup
 import com.wisp.app.nostr.NotificationSummary
+import com.wisp.app.nostr.NotificationType
 import com.wisp.app.nostr.ZapEntry
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,6 +35,11 @@ class NotificationRepository(
 
     private val _notifications = MutableStateFlow<List<NotificationGroup>>(emptyList())
     val notifications: StateFlow<List<NotificationGroup>> = _notifications
+
+    private val flatItems = mutableListOf<FlatNotificationItem>()
+    private val flatItemIds = mutableSetOf<String>()
+    private val _flatNotifications = MutableStateFlow<List<FlatNotificationItem>>(emptyList())
+    val flatNotifications: StateFlow<List<FlatNotificationItem>> = _flatNotifications
 
     private val _summary24h = MutableStateFlow(NotificationSummary())
     val summary24h: StateFlow<NotificationSummary> = _summary24h
@@ -62,7 +70,13 @@ class NotificationRepository(
         val hasPTag = event.tags.any { it.size >= 2 && it[0] == "p" && it[1] == myPubkey }
         // Kind 6 reposts may omit the p-tag; callers must pre-filter kind 6 ownership.
         // replyToMyEvent bypasses p-tag check for kind 1 replies found via e-tag subscription.
-        if (!hasPTag && event.kind != 6 && !(replyToMyEvent && event.kind == 1)) return
+        if (!hasPTag && event.kind != 6 && event.kind != Nip88.KIND_POLL_RESPONSE && !(replyToMyEvent && event.kind == 1)) return
+        // Kind 1018 poll votes: only notify if the poll is ours
+        if (event.kind == Nip88.KIND_POLL_RESPONSE) {
+            val pollId = Nip88.getPollEventId(event)
+            val pollEvent = pollId?.let { eventRepo?.getEvent(it) }
+            if (pollEvent == null || pollEvent.pubkey != myPubkey) return
+        }
 
         synchronized(lock) {
             // Atomic check-then-put inside lock to prevent race when the same
@@ -79,6 +93,7 @@ class NotificationRepository(
                 7 -> mergeReaction(event)
                 1 -> mergeKind1(event)
                 9735 -> mergeZap(event)
+                Nip88.KIND_POLL_RESPONSE -> mergeVote(event)
                 else -> false
             }
             if (!merged) return
@@ -121,7 +136,10 @@ class NotificationRepository(
             seenEvents.evictAll()
             groupMap.clear()
             zapEventIdsByGroup.clear()
+            flatItems.clear()
+            flatItemIds.clear()
             _notifications.value = emptyList()
+            _flatNotifications.value = emptyList()
             _summary24h.value = NotificationSummary()
             _hasUnread.value = false
             soundEligibleAfter = System.currentTimeMillis() / 1000
@@ -160,6 +178,9 @@ class NotificationRepository(
 
         toRemove.forEach { groupMap.remove(it) }
         toUpdate.forEach { (k, v) -> groupMap[k] = v }
+        flatItems.removeAll { item ->
+            if (item.actorPubkey == pubkey) { flatItemIds.remove(item.id); true } else false
+        }
         if (toRemove.isNotEmpty() || toUpdate.isNotEmpty()) {
             rebuildSortedList()
         }
@@ -231,6 +252,9 @@ class NotificationRepository(
 
         val sorted = result.sortedByDescending { it.latestTimestamp }
         _notifications.value = if (sorted.size > 200) sorted.take(200) else sorted
+
+        val sortedFlat = flatItems.sortedByDescending { it.timestamp }
+        _flatNotifications.value = if (sortedFlat.size > 500) sortedFlat.take(500) else sortedFlat
 
         // Compute 24h summary from raw groupMap (not the split result)
         val summaryCutoff = now - SUMMARY_WINDOW_SECONDS
@@ -326,6 +350,22 @@ class NotificationRepository(
                 latestTimestamp = event.created_at
             )
         }
+
+        val shortcode = Nip30.shortcodeRegex.matchEntire(emoji)?.groupValues?.get(1)
+        val flatEmojiUrl = eventEmojiUrls[shortcode ?: ""]
+        val flatId = "reaction:${referencedId}:${event.pubkey}:${emoji.hashCode()}"
+        if (flatItemIds.add(flatId)) {
+            flatItems.add(FlatNotificationItem(
+                id = flatId,
+                type = NotificationType.REACTION,
+                actorPubkey = event.pubkey,
+                referencedEventId = referencedId,
+                timestamp = event.created_at,
+                emoji = emoji,
+                emojiUrl = flatEmojiUrl
+            ))
+        }
+
         return true
     }
 
@@ -375,6 +415,21 @@ class NotificationRepository(
                 latestTimestamp = event.created_at
             )
         }
+
+        val flatZapId = "zap:${event.id}"
+        if (flatItemIds.add(flatZapId)) {
+            flatItems.add(FlatNotificationItem(
+                id = flatZapId,
+                type = NotificationType.ZAP,
+                actorPubkey = zapperPubkey,
+                referencedEventId = referencedId,
+                timestamp = event.created_at,
+                zapSats = amount,
+                zapMessage = message,
+                isPrivateZap = isPrivate
+            ))
+        }
+
         return true
     }
 
@@ -399,6 +454,19 @@ class NotificationRepository(
             referencedEventHints = hints,
             latestTimestamp = event.created_at
         )
+
+        val flatReplyId = "reply:${event.id}"
+        if (flatItemIds.add(flatReplyId)) {
+            flatItems.add(FlatNotificationItem(
+                id = flatReplyId,
+                type = NotificationType.REPLY,
+                actorPubkey = event.pubkey,
+                referencedEventId = replyTarget,
+                timestamp = event.created_at,
+                replyEventId = event.id
+            ))
+        }
+
         return true
     }
 
@@ -413,6 +481,19 @@ class NotificationRepository(
             relayHints = listOfNotNull(hint),
             latestTimestamp = event.created_at
         )
+
+        val flatQuoteId = "quote:${event.id}"
+        if (flatItemIds.add(flatQuoteId)) {
+            flatItems.add(FlatNotificationItem(
+                id = flatQuoteId,
+                type = NotificationType.QUOTE,
+                actorPubkey = event.pubkey,
+                referencedEventId = quotedEventId,
+                timestamp = event.created_at,
+                quoteEventId = event.id
+            ))
+        }
+
         return true
     }
 
@@ -424,6 +505,18 @@ class NotificationRepository(
             eventId = event.id,
             latestTimestamp = event.created_at
         )
+
+        val flatMentionId = "mention:${event.id}"
+        if (flatItemIds.add(flatMentionId)) {
+            flatItems.add(FlatNotificationItem(
+                id = flatMentionId,
+                type = NotificationType.MENTION,
+                actorPubkey = event.pubkey,
+                referencedEventId = event.id,
+                timestamp = event.created_at
+            ))
+        }
+
         return true
     }
 
@@ -457,6 +550,38 @@ class NotificationRepository(
                 latestTimestamp = event.created_at
             )
         }
+
+        val flatRepostId = "repost:${repostedId}:${event.pubkey}"
+        if (flatItemIds.add(flatRepostId)) {
+            flatItems.add(FlatNotificationItem(
+                id = flatRepostId,
+                type = NotificationType.REPOST,
+                actorPubkey = event.pubkey,
+                referencedEventId = repostedId,
+                timestamp = event.created_at
+            ))
+        }
+
+        return true
+    }
+
+    private fun mergeVote(event: NostrEvent): Boolean {
+        val pollEventId = Nip88.getPollEventId(event) ?: return false
+        val optionIds = Nip88.getResponseOptionIds(event)
+        if (optionIds.isEmpty()) return false
+
+        val flatVoteId = "vote:${event.id}"
+        if (flatItemIds.add(flatVoteId)) {
+            flatItems.add(FlatNotificationItem(
+                id = flatVoteId,
+                type = NotificationType.VOTE,
+                actorPubkey = event.pubkey,
+                referencedEventId = pollEventId,
+                timestamp = event.created_at,
+                voteOptionIds = optionIds
+            ))
+        }
+
         return true
     }
 
@@ -493,6 +618,9 @@ class NotificationRepository(
         }
         if (toRemove.isNotEmpty()) {
             toRemove.forEach { groupMap.remove(it) }
+            flatItems.removeAll { item ->
+                if (item.referencedEventId == rootEventId) { flatItemIds.remove(item.id); true } else false
+            }
             rebuildSortedList()
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -1,8 +1,11 @@
 package com.wisp.app.ui.screen
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,19 +22,22 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material.icons.outlined.AlternateEmail
+import androidx.compose.material.icons.outlined.BarChart
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Repeat
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -44,7 +50,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -54,35 +59,47 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.foundation.BorderStroke
 import coil3.compose.AsyncImage
+import com.wisp.app.nostr.FlatNotificationItem
 import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.Nip30
+import com.wisp.app.nostr.Nip88
 import com.wisp.app.nostr.NostrEvent
-import com.wisp.app.nostr.NotificationGroup
 import com.wisp.app.nostr.NotificationSummary
+import com.wisp.app.nostr.NotificationType
 import com.wisp.app.nostr.ProfileData
-import kotlinx.coroutines.flow.SharedFlow
-import com.wisp.app.nostr.ZapEntry
 import com.wisp.app.repo.EventRepository
-import com.wisp.app.repo.ZapDetail
-import com.wisp.app.ui.component.ZapInspectorDialog
 import com.wisp.app.repo.Nip05Repository
 import com.wisp.app.repo.TranslationRepository
 import com.wisp.app.ui.component.PostCard
+import android.net.Uri
+import androidx.compose.foundation.content.MediaType
+import androidx.compose.foundation.content.ReceiveContentListener
+import androidx.compose.foundation.content.TransferableContent
+import androidx.compose.foundation.content.consume
+import androidx.compose.foundation.content.contentReceiver
+import androidx.compose.foundation.content.hasMediaType
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.snapshotFlow
 import com.wisp.app.ui.component.ProfilePicture
-import com.wisp.app.ui.component.StackedAvatarRow
 import com.wisp.app.ui.theme.WispThemeColors
 import com.wisp.app.viewmodel.NotificationFilter
 import com.wisp.app.viewmodel.NotificationsViewModel
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -98,6 +115,8 @@ fun NotificationsScreen(
     onBack: () -> Unit = {},
     onNoteClick: (String) -> Unit,
     onProfileClick: (String) -> Unit,
+    onRefresh: () -> Unit = {},
+    onSendReply: (NostrEvent, String) -> Unit = { _, _ -> },
     onReply: (NostrEvent) -> Unit = {},
     onReact: (NostrEvent, String) -> Unit = { _, _ -> },
     onRepost: (NostrEvent) -> Unit = {},
@@ -115,32 +134,82 @@ fun NotificationsScreen(
     unicodeEmojis: List<String> = emptyList(),
     onOpenEmojiLibrary: (() -> Unit)? = null,
     zapError: SharedFlow<String>? = null,
-    onRefresh: () -> Unit = {},
     translationRepo: TranslationRepository? = null,
-    onPollVote: (String, List<String>) -> Unit = { _, _ -> }
+    onPollVote: (String, List<String>) -> Unit = { _, _ -> },
+    onUploadMedia: (List<Uri>, onUrl: (String) -> Unit) -> Unit = { _, _ -> },
 ) {
-    val notifications by viewModel.filteredNotifications.collectAsState()
+    val notifications by viewModel.filteredFlatNotifications.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
     val currentFilter by viewModel.filter.collectAsState()
     val summary by viewModel.summary24h.collectAsState()
     val eventRepo = viewModel.eventRepository
     val listState = rememberLazyListState()
     var showFilterDropdown by remember { mutableStateOf(false) }
-    var zapErrorMessage by remember { mutableStateOf<String?>(null) }
+    val profileVersion = eventRepo?.profileVersion?.collectAsState()?.value ?: 0
 
-    LaunchedEffect(Unit) {
-        zapError?.collect { error ->
-            zapErrorMessage = error
-        }
+    // Track which notification is expanded (only one at a time)
+    var expandedId by rememberSaveable { mutableStateOf<String?>(null) }
+
+    // Track inline replies sent by user: replyEventId -> list of sent content strings
+    var inlineReplies by remember { mutableStateOf(mapOf<String, List<String>>()) }
+
+    // Version flows for PostCard cache invalidation
+    val reactionVersion = eventRepo?.reactionVersion?.collectAsState()?.value ?: 0
+    val zapVersion = eventRepo?.zapVersion?.collectAsState()?.value ?: 0
+    val replyCountVersion = eventRepo?.replyCountVersion?.collectAsState()?.value ?: 0
+    val repostVersion = eventRepo?.repostVersion?.collectAsState()?.value ?: 0
+    val pollVoteVersion = eventRepo?.pollVoteVersion?.collectAsState()?.value ?: 0
+    val followListSize = viewModel.contactRepository?.followList?.collectAsState()?.value?.size ?: 0
+
+    val postCardParams = remember(
+        eventRepo, userPubkey, profileVersion, reactionVersion, zapVersion,
+        replyCountVersion, repostVersion, followListSize, resolvedEmojis, unicodeEmojis, pollVoteVersion
+    ) {
+        NotifPostCardParams(
+            eventRepo = eventRepo,
+            userPubkey = userPubkey,
+            profileVersion = profileVersion,
+            reactionVersion = reactionVersion,
+            replyCountVersion = replyCountVersion,
+            zapVersion = zapVersion,
+            repostVersion = repostVersion,
+            followListSize = followListSize,
+            resolvedEmojis = resolvedEmojis,
+            unicodeEmojis = unicodeEmojis,
+            onOpenEmojiLibrary = onOpenEmojiLibrary,
+            isFollowing = { viewModel.isFollowing(it) },
+            onNoteClick = onNoteClick,
+            onProfileClick = onProfileClick,
+            onReply = onReply,
+            onReact = onReact,
+            onRepost = onRepost,
+            onQuote = onQuote,
+            onZap = onZap,
+            onFollowToggle = onFollowToggle,
+            onBlockUser = onBlockUser,
+            onMuteThread = onMuteThread,
+            onAddToList = onAddToList,
+            nip05Repo = nip05Repo,
+            isZapAnimating = isZapAnimating,
+            isZapInProgress = isZapInProgress,
+            isInList = isInList,
+            translationRepo = translationRepo,
+            pollVoteVersion = pollVoteVersion,
+            onPollVote = onPollVote
+        )
     }
 
+    var zapErrorMessage by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(Unit) {
+        zapError?.collect { error -> zapErrorMessage = error }
+    }
     if (zapErrorMessage != null) {
-        AlertDialog(
+        androidx.compose.material3.AlertDialog(
             onDismissRequest = { zapErrorMessage = null },
             title = { Text("Zap Failed") },
             text = { Text(zapErrorMessage ?: "") },
             confirmButton = {
-                TextButton(onClick = { zapErrorMessage = null }) { Text("OK") }
+                androidx.compose.material3.TextButton(onClick = { zapErrorMessage = null }) { Text("OK") }
             }
         )
     }
@@ -152,15 +221,6 @@ fun NotificationsScreen(
             listState.scrollToItem(0)
         }
     }
-
-    // Version flows for cache invalidation on reply PostCards
-    val reactionVersion = eventRepo?.reactionVersion?.collectAsState()?.value ?: 0
-    val zapVersion = eventRepo?.zapVersion?.collectAsState()?.value ?: 0
-    val replyCountVersion = eventRepo?.replyCountVersion?.collectAsState()?.value ?: 0
-    val repostVersion = eventRepo?.repostVersion?.collectAsState()?.value ?: 0
-    val profileVersion = eventRepo?.profileVersion?.collectAsState()?.value ?: 0
-    val pollVoteVersion = eventRepo?.pollVoteVersion?.collectAsState()?.value ?: 0
-    val followListSize = viewModel.contactRepository?.followList?.collectAsState()?.value?.size ?: 0
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -183,7 +243,7 @@ fun NotificationsScreen(
                                 ) {
                                     Text(
                                         currentFilter.label,
-                                        style = MaterialTheme.typography.titleSmall,
+                                        style = MaterialTheme.typography.titleMedium,
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis,
                                         modifier = Modifier.widthIn(max = 160.dp)
@@ -257,15 +317,9 @@ fun NotificationsScreen(
                 )
             }
         } else {
-            val recentCutoff = System.currentTimeMillis() / 1000 - 600
-            val (recentNotifs, olderNotifs) = remember(notifications, recentCutoff / 60) {
-                notifications.partition { it.groupId.endsWith(":recent") || it.latestTimestamp >= recentCutoff }
-            }
-
             LazyColumn(
                 state = listState,
-                modifier = Modifier
-                    .fillMaxSize()
+                modifier = Modifier.fillMaxSize()
             ) {
                 item(key = "summary_24h", contentType = "summary") {
                     DailySummaryBar(
@@ -273,87 +327,48 @@ fun NotificationsScreen(
                         onFilterSelect = { viewModel.setFilter(it) }
                     )
                 }
-                if (recentNotifs.isNotEmpty()) {
-                    item(key = "header_recent", contentType = "header") {
-                        SectionHeader("Recent")
-                    }
-                    items(items = recentNotifs, key = { it.groupId }, contentType = { "notification" }) { group ->
-                        NotificationItem(
-                            group = group,
-                            viewModel = viewModel,
-                            eventRepo = eventRepo,
-                            userPubkey = userPubkey,
-                            profileVersion = profileVersion,
-                            reactionVersion = reactionVersion,
-                            replyCountVersion = replyCountVersion,
-                            zapVersion = zapVersion,
-                            repostVersion = repostVersion,
-                            followListSize = followListSize,
-                            onNoteClick = onNoteClick,
-                            onProfileClick = onProfileClick,
-                            onReply = onReply,
-                            onReact = onReact,
-                            onRepost = onRepost,
-                            onQuote = onQuote,
-                            onZap = onZap,
-                            onFollowToggle = onFollowToggle,
-                            onBlockUser = onBlockUser,
-                            onMuteThread = onMuteThread,
-                            onAddToList = onAddToList,
-                            nip05Repo = nip05Repo,
-                            isZapAnimating = isZapAnimating,
-                            isZapInProgress = isZapInProgress,
-                            isInList = isInList,
-                            resolvedEmojis = resolvedEmojis,
-                            unicodeEmojis = unicodeEmojis,
-                            onOpenEmojiLibrary = onOpenEmojiLibrary,
-                            translationRepo = translationRepo,
-                            pollVoteVersion = pollVoteVersion,
-                            onPollVote = onPollVote
-                        )
-                        HorizontalDivider(color = MaterialTheme.colorScheme.outline, thickness = 0.5.dp)
-                    }
-                }
-                if (olderNotifs.isNotEmpty()) {
-                    item(key = "header_earlier", contentType = "header") {
-                        SectionHeader("Earlier")
-                    }
-                    items(items = olderNotifs, key = { it.groupId }, contentType = { "notification" }) { group ->
-                        NotificationItem(
-                            group = group,
-                            viewModel = viewModel,
-                            eventRepo = eventRepo,
-                            userPubkey = userPubkey,
-                            profileVersion = profileVersion,
-                            reactionVersion = reactionVersion,
-                            replyCountVersion = replyCountVersion,
-                            zapVersion = zapVersion,
-                            repostVersion = repostVersion,
-                            followListSize = followListSize,
-                            onNoteClick = onNoteClick,
-                            onProfileClick = onProfileClick,
-                            onReply = onReply,
-                            onReact = onReact,
-                            onRepost = onRepost,
-                            onQuote = onQuote,
-                            onZap = onZap,
-                            onFollowToggle = onFollowToggle,
-                            onBlockUser = onBlockUser,
-                            onMuteThread = onMuteThread,
-                            onAddToList = onAddToList,
-                            nip05Repo = nip05Repo,
-                            isZapAnimating = isZapAnimating,
-                            isZapInProgress = isZapInProgress,
-                            isInList = isInList,
-                            resolvedEmojis = resolvedEmojis,
-                            unicodeEmojis = unicodeEmojis,
-                            onOpenEmojiLibrary = onOpenEmojiLibrary,
-                            translationRepo = translationRepo,
-                            pollVoteVersion = pollVoteVersion,
-                            onPollVote = onPollVote
-                        )
-                        HorizontalDivider(color = MaterialTheme.colorScheme.outline, thickness = 0.5.dp)
-                    }
+                items(items = notifications, key = { it.id }, contentType = { "notification" }) { item ->
+                    val isExpanded = expandedId == item.id
+                    val itemIndex = notifications.indexOf(item) + 1 // +1 for summary header
+                    val coroutineScope = rememberCoroutineScope()
+                    ZenNotificationRow(
+                        item = item,
+                        resolveProfile = { viewModel.getProfileData(it) },
+                        eventRepo = eventRepo,
+                        profileVersion = profileVersion,
+                        isExpanded = isExpanded,
+                        inlineReplies = inlineReplies[item.replyEventId ?: ""] ?: emptyList(),
+                        userPubkey = userPubkey,
+                        postCardParams = postCardParams,
+                        onClick = {
+                            expandedId = if (isExpanded) null else item.id
+                        },
+                        onProfileClick = onProfileClick,
+                        onSendReply = { replyToEvent, content ->
+                            onSendReply(replyToEvent, content)
+                            val key = item.replyEventId ?: ""
+                            val existing = inlineReplies[key] ?: emptyList()
+                            inlineReplies = inlineReplies + (key to (existing + content))
+                        },
+                        onUploadMedia = onUploadMedia,
+                        onReplyFocused = {
+                            coroutineScope.launch {
+                                // Wait for keyboard to appear and layout to settle
+                                kotlinx.coroutines.delay(300)
+                                // Find how tall this item is in the current layout
+                                val itemInfo = listState.layoutInfo.visibleItemsInfo
+                                    .firstOrNull { it.key == item.id }
+                                val itemHeight = itemInfo?.size ?: 0
+                                // Visible height after keyboard takes ~half the screen
+                                val visibleHeight = listState.layoutInfo.viewportSize.height
+                                // Offset so the bottom of the item (where composer is)
+                                // aligns with the bottom of the visible area
+                                val offset = (itemHeight - visibleHeight * 3 / 5).coerceAtLeast(0)
+                                listState.animateScrollToItem(index = itemIndex, scrollOffset = offset)
+                            }
+                        }
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outline, thickness = 0.5.dp)
                 }
             }
         }
@@ -361,622 +376,235 @@ fun NotificationsScreen(
     }
 }
 
-// ── Section Header ──────────────────────────────────────────────────────
+// ── Zen Notification Row ────────────────────────────────────────────────
 
 @Composable
-private fun SectionHeader(title: String) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 10.dp)
-    )
-}
+private fun ZenNotificationRow(
+    item: FlatNotificationItem,
+    resolveProfile: (String) -> ProfileData?,
+    eventRepo: EventRepository?,
+    profileVersion: Int,
+    isExpanded: Boolean = false,
+    inlineReplies: List<String> = emptyList(),
+    userPubkey: String? = null,
+    postCardParams: NotifPostCardParams? = null,
+    onClick: () -> Unit,
+    onProfileClick: (String) -> Unit,
+    onSendReply: (NostrEvent, String) -> Unit = { _, _ -> },
+    onUploadMedia: (List<Uri>, onUrl: (String) -> Unit) -> Unit = { _, _ -> },
+    onReplyFocused: () -> Unit = {}
+) {
+    val profile = remember(profileVersion, item.actorPubkey) { resolveProfile(item.actorPubkey) }
+    val displayName = profile?.displayString
+        ?: item.actorPubkey.take(8) + "..." + item.actorPubkey.takeLast(4)
 
-// ── Daily Summary Bar ──────────────────────────────────────────────────
-
-@Composable
-private fun DailySummaryBar(summary: NotificationSummary, onFilterSelect: (NotificationFilter) -> Unit) {
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        modifier = Modifier.fillMaxWidth()
-    ) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // Compact row — always visible
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly,
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = "24h",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+            // Type icon / emoji on the left (with sats below for zaps)
+            NotificationTypeIcon(item, showSats = true)
+            Spacer(Modifier.width(8.dp))
+            ProfilePicture(
+                url = profile?.picture,
+                size = 32,
+                modifier = Modifier.clickable { onProfileClick(item.actorPubkey) }
             )
-            SummaryStat(Icons.Outlined.ChatBubbleOutline, summary.replyCount.toString()) { onFilterSelect(NotificationFilter.REPLIES) }
-            SummaryStat(Icons.Outlined.FavoriteBorder, summary.reactionCount.toString()) { onFilterSelect(NotificationFilter.REACTIONS) }
-            SummaryStat(Icons.Outlined.CurrencyBitcoin, formatSatsCompact(summary.zapSats)) { onFilterSelect(NotificationFilter.ZAPS) }
-            SummaryStat(Icons.Outlined.Repeat, summary.repostCount.toString()) { onFilterSelect(NotificationFilter.REPOSTS) }
-            SummaryStat(Icons.Outlined.AlternateEmail, (summary.mentionCount + summary.quoteCount).toString()) { onFilterSelect(NotificationFilter.MENTIONS) }
-        }
-    }
-}
-
-@Composable
-private fun SummaryStat(icon: androidx.compose.ui.graphics.vector.ImageVector, value: String, onClick: () -> Unit) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
-            .clickable(onClick = onClick)
-            .padding(horizontal = 4.dp, vertical = 2.dp)
-    ) {
-        Icon(
-            icon,
-            contentDescription = null,
-            modifier = Modifier.size(20.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(Modifier.width(4.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
-
-private fun formatSatsCompact(sats: Long): String = when {
-    sats >= 1_000_000 -> "${sats / 1_000_000}M"
-    sats >= 1_000 -> "${sats / 1_000}K"
-    else -> sats.toString()
-}
-
-// ── Notification Item Router ────────────────────────────────────────────
-
-@Composable
-private fun NotificationItem(
-    group: NotificationGroup,
-    viewModel: NotificationsViewModel,
-    eventRepo: EventRepository?,
-    userPubkey: String?,
-    profileVersion: Int,
-    reactionVersion: Int,
-    replyCountVersion: Int,
-    zapVersion: Int,
-    repostVersion: Int,
-    followListSize: Int = 0,
-    onNoteClick: (String) -> Unit,
-    onProfileClick: (String) -> Unit,
-    onReply: (NostrEvent) -> Unit,
-    onReact: (NostrEvent, String) -> Unit,
-    onRepost: (NostrEvent) -> Unit,
-    onQuote: (NostrEvent) -> Unit,
-    onZap: (NostrEvent) -> Unit,
-    onFollowToggle: (String) -> Unit,
-    onBlockUser: (String) -> Unit,
-    onMuteThread: (String) -> Unit = {},
-    onAddToList: (String) -> Unit = {},
-    nip05Repo: Nip05Repository?,
-    isZapAnimating: (String) -> Boolean,
-    isZapInProgress: (String) -> Boolean,
-    isInList: (String) -> Boolean,
-    resolvedEmojis: Map<String, String> = emptyMap(),
-    unicodeEmojis: List<String> = emptyList(),
-    onOpenEmojiLibrary: (() -> Unit)? = null,
-    translationRepo: TranslationRepository? = null,
-    pollVoteVersion: Int = 0,
-    onPollVote: (String, List<String>) -> Unit = { _, _ -> }
-) {
-    // Shared PostCard params for rendering referenced notes with full action bar
-    val postCardParams = NotifPostCardParams(
-        eventRepo = eventRepo,
-        userPubkey = userPubkey,
-        profileVersion = profileVersion,
-        reactionVersion = reactionVersion,
-        replyCountVersion = replyCountVersion,
-        zapVersion = zapVersion,
-        repostVersion = repostVersion,
-        followListSize = followListSize,
-        resolvedEmojis = resolvedEmojis,
-        unicodeEmojis = unicodeEmojis,
-        onOpenEmojiLibrary = onOpenEmojiLibrary,
-        isFollowing = { viewModel.isFollowing(it) },
-        onNoteClick = onNoteClick,
-        onProfileClick = onProfileClick,
-        onReply = onReply,
-        onReact = onReact,
-        onRepost = onRepost,
-        onQuote = onQuote,
-        onZap = onZap,
-        onFollowToggle = onFollowToggle,
-        onBlockUser = onBlockUser,
-        onMuteThread = onMuteThread,
-        onAddToList = onAddToList,
-        nip05Repo = nip05Repo,
-        isZapAnimating = isZapAnimating,
-        isZapInProgress = isZapInProgress,
-        isInList = isInList,
-        translationRepo = translationRepo,
-        pollVoteVersion = pollVoteVersion,
-        onPollVote = onPollVote
-    )
-
-    when (group) {
-        is NotificationGroup.ReactionGroup -> ReactionGroupRow(
-            group = group,
-            resolveProfile = { viewModel.getProfileData(it) },
-            isFollowing = { viewModel.isFollowing(it) },
-            onProfileClick = onProfileClick,
-            onFollowToggle = postCardParams.onFollowToggle,
-            postCardParams = postCardParams,
-            eventRepo = postCardParams.eventRepo
-        )
-        is NotificationGroup.ReplyNotification -> ReplyPostCard(
-            item = group,
-            postCardParams = postCardParams
-        )
-        is NotificationGroup.QuoteNotification -> QuoteNotificationRow(
-            item = group,
-            resolveProfile = { viewModel.getProfileData(it) },
-            isFollowing = viewModel.isFollowing(group.senderPubkey),
-            onProfileClick = onProfileClick,
-            postCardParams = postCardParams
-        )
-        is NotificationGroup.MentionNotification -> MentionNotificationRow(
-            item = group,
-            resolveProfile = { viewModel.getProfileData(it) },
-            isFollowing = viewModel.isFollowing(group.senderPubkey),
-            onProfileClick = onProfileClick,
-            postCardParams = postCardParams
-        )
-    }
-}
-
-// ── Reaction Group ──────────────────────────────────────────────────────
-// Each emoji on its own row: <emoji> <stacked avatars of that emoji's reactors>
-// Then the referenced note rendered as a full PostCard with action bar.
-
-@Composable
-private fun ReactionGroupRow(
-    group: NotificationGroup.ReactionGroup,
-    resolveProfile: (String) -> ProfileData?,
-    isFollowing: (String) -> Boolean,
-    onProfileClick: (String) -> Unit,
-    onFollowToggle: ((String) -> Unit)? = null,
-    postCardParams: NotifPostCardParams,
-    eventRepo: EventRepository? = null
-) {
-    var inspectedZap by remember { mutableStateOf<ZapEntry?>(null) }
-
-    Column(modifier = Modifier.fillMaxWidth()) {
-        // Emoji summary header
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp)
-        ) {
-            // Timestamp on top-right
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+            Spacer(Modifier.width(8.dp))
+            Column(
+                modifier = Modifier.weight(1f)
             ) {
-                Spacer(Modifier.weight(1f))
-                Text(
-                    text = formatNotifTimestamp(group.latestTimestamp),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            // Zap rows (most recent first)
-            if (group.zapEntries.isNotEmpty()) {
-                val sortedZaps = remember(group.zapEntries) { group.zapEntries.sortedByDescending { it.createdAt } }
-                sortedZaps.forEachIndexed { index, zap ->
-                    ZapEntryRow(
-                        zap = zap,
-                        profile = resolveProfile(zap.pubkey),
-                        showFollowBadge = isFollowing(zap.pubkey),
-                        highlighted = index == 0 && sortedZaps.size > 1,
-                        onProfileClick = onProfileClick,
-                        onLongPress = if (zap.receiptEventId != null) {
-                            { inspectedZap = zap }
-                        } else null,
-                        isPrivate = zap.isPrivate
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = displayName,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        text = actionText(item),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1
                     )
                 }
-            }
-            // Repost row (from EventRepository for older splits, from reactions map for recent)
-            val isRecentSplit = group.groupId.endsWith(":recent")
-            val repostPubkeys = if (isRecentSplit) {
-                group.reactions[NotificationGroup.REPOST_EMOJI] ?: emptyList()
-            } else {
-                val eventRepo = postCardParams.eventRepo
-                remember(postCardParams.repostVersion, group.referencedEventId) {
-                    eventRepo?.getReposterPubkeys(group.referencedEventId) ?: emptyList()
-                }
-            }
-            if (repostPubkeys.isNotEmpty()) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 3.dp),
-                    verticalAlignment = Alignment.Top
-                ) {
-                    Icon(
-                        Icons.Outlined.Repeat,
-                        contentDescription = "reposted",
-                        modifier = Modifier
-                            .size(24.dp)
-                            .padding(top = 6.dp),
-                        tint = WispThemeColors.repostColor
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    StackedAvatarRow(
-                        pubkeys = repostPubkeys.reversed(),
-                        resolveProfile = resolveProfile,
-                        isFollowing = isFollowing,
-                        onProfileClick = onProfileClick,
-                        highlightFirst = repostPubkeys.size > 1,
-                        onProfileLongPress = onFollowToggle,
-                        showAll = true
-                    )
-                }
-            }
-            // Each emoji row: <emoji> <avatars> (newest reactor first)
-            group.reactions.forEach { (emoji, pubkeys) ->
-                if (emoji == NotificationGroup.REPOST_EMOJI || emoji == NotificationGroup.ZAP_EMOJI) return@forEach
-                val displayEmoji = if (emoji == "+") "\u2764\uFE0F" else emoji
-                val shortcode = Nip30.shortcodeRegex.matchEntire(displayEmoji)?.groupValues?.get(1)
-                val customEmojiUrl = group.emojiUrls[displayEmoji]
-                    ?: shortcode?.let { group.emojiUrls[":$it:"] }
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 3.dp),
-                    verticalAlignment = Alignment.Top
-                ) {
-                    if (customEmojiUrl != null) {
-                        AsyncImage(
-                            model = customEmojiUrl,
-                            contentDescription = shortcode ?: displayEmoji,
-                            modifier = Modifier
-                                .size(24.dp)
-                                .padding(top = 6.dp)
-                        )
-                    } else {
+                // Show voted option labels
+                if (item.type == NotificationType.VOTE && item.voteOptionIds.isNotEmpty()) {
+                    val optionLabels = remember(item.referencedEventId, item.voteOptionIds) {
+                        val pollEvent = eventRepo?.getEvent(item.referencedEventId)
+                        if (pollEvent != null) {
+                            val options = Nip88.parsePollOptions(pollEvent)
+                            item.voteOptionIds.mapNotNull { id -> options.firstOrNull { it.id == id }?.label }
+                        } else emptyList()
+                    }
+                    if (optionLabels.isNotEmpty()) {
                         Text(
-                            text = displayEmoji,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(top = 4.dp)
+                            text = optionLabels.joinToString(", "),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(top = 2.dp)
                         )
                     }
-                    Spacer(Modifier.width(8.dp))
-                    StackedAvatarRow(
-                        pubkeys = pubkeys.reversed(),
-                        resolveProfile = resolveProfile,
-                        isFollowing = isFollowing,
-                        onProfileClick = onProfileClick,
-                        highlightFirst = pubkeys.size > 1,
-                        onProfileLongPress = onFollowToggle,
-                        showAll = true
-                    )
                 }
             }
-        }
-        // Referenced note as full PostCard
-        ReferencedNotePostCard(
-            eventId = group.referencedEventId,
-            params = postCardParams,
-            relayHints = group.relayHints
-        )
-    }
-
-    if (inspectedZap != null && eventRepo != null) {
-        val zapDetail = remember(inspectedZap) {
-            val z = inspectedZap!!
-            ZapDetail(
-                pubkey = z.pubkey,
-                sats = z.sats,
-                message = z.message,
-                isPrivate = z.isPrivate,
-                receiptEventId = z.receiptEventId
-            )
-        }
-        ZapInspectorDialog(
-            zapDetail = zapDetail,
-            eventRepo = eventRepo,
-            onDismiss = { inspectedZap = null }
-        )
-    }
-}
-
-@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
-@Composable
-private fun ZapEntryRow(
-    zap: ZapEntry,
-    profile: ProfileData?,
-    showFollowBadge: Boolean,
-    highlighted: Boolean = false,
-    onProfileClick: (String) -> Unit,
-    onLongPress: (() -> Unit)? = null,
-    isPrivate: Boolean = false
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .then(
-                if (onLongPress != null) {
-                    Modifier.combinedClickable(
-                        onClick = { onProfileClick(zap.pubkey) },
-                        onLongClick = onLongPress
-                    )
-                } else {
-                    Modifier
-                }
-            )
-            .padding(vertical = 3.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = "\u26A1",
-            style = MaterialTheme.typography.bodyMedium
-        )
-        if (isPrivate) {
-            Spacer(Modifier.width(2.dp))
-            Icon(
-                painter = androidx.compose.ui.res.painterResource(com.wisp.app.R.drawable.ic_private_zap),
-                contentDescription = "Private zap",
-                modifier = Modifier.size(16.dp),
-                tint = Color(0xFFFF8C00)
-            )
-        }
-        Spacer(Modifier.width(4.dp))
-        Text(
-            text = formatSats(zap.sats),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.tertiary
-        )
-        Spacer(Modifier.width(8.dp))
-        ProfilePicture(
-            url = profile?.picture,
-            size = 24,
-            showFollowBadge = showFollowBadge,
-            highlighted = highlighted,
-            modifier = Modifier.clickable { onProfileClick(zap.pubkey) }
-        )
-        Spacer(Modifier.width(6.dp))
-        if (zap.message.isNotBlank()) {
-            Text(
-                text = zap.message,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-        } else {
-            val name = profile?.displayString
-                ?: zap.pubkey.take(8) + "..."
-            Text(
-                text = name,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-        }
-    }
-}
-
-// ── Reply ───────────────────────────────────────────────────────────────
-// Full PostCard for reply notifications — same rendering as feed items.
-
-@Composable
-private fun ReplyPostCard(
-    item: NotificationGroup.ReplyNotification,
-    postCardParams: NotifPostCardParams
-) {
-    val eventRepo = postCardParams.eventRepo ?: return
-
-    // Render the parent note inline above the reply
-    if (item.referencedEventId != null) {
-        Text(
-            text = "replying to",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 2.dp),
-            textAlign = androidx.compose.ui.text.style.TextAlign.End
-        )
-        Surface(
-            shape = RoundedCornerShape(12.dp),
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-            color = MaterialTheme.colorScheme.surface,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 4.dp)
-        ) {
-            ReferencedNotePostCard(
-                eventId = item.referencedEventId,
-                params = postCardParams,
-                relayHints = item.referencedEventHints
-            )
-        }
-    }
-
-    Column(modifier = Modifier.padding(start = 24.dp)) {
-        ReferencedNotePostCard(
-            eventId = item.replyEventId,
-            params = postCardParams
-        )
-    }
-}
-
-// ── Quote ───────────────────────────────────────────────────────────────
-
-@Composable
-private fun QuoteNotificationRow(
-    item: NotificationGroup.QuoteNotification,
-    resolveProfile: (String) -> ProfileData?,
-    isFollowing: Boolean,
-    onProfileClick: (String) -> Unit,
-    postCardParams: NotifPostCardParams
-) {
-    val profile = resolveProfile(item.senderPubkey)
-    val displayName = profile?.displayString
-        ?: item.senderPubkey.take(8) + "..." + item.senderPubkey.takeLast(4)
-
-    Column(modifier = Modifier.fillMaxWidth()) {
-        // Quote header
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            ProfilePicture(
-                url = profile?.picture,
-                size = 34,
-                showFollowBadge = isFollowing,
-                modifier = Modifier.clickable { onProfileClick(item.senderPubkey) }
-            )
-            Spacer(Modifier.width(10.dp))
-            Text(
-                text = displayName,
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-            Spacer(Modifier.width(4.dp))
-            Text(
-                text = "quoted your note",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
             Spacer(Modifier.width(8.dp))
             Text(
-                text = formatNotifTimestamp(item.latestTimestamp),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-        // Quote event as full PostCard
-        ReferencedNotePostCard(
-            eventId = item.quoteEventId,
-            params = postCardParams,
-            relayHints = item.relayHints
-        )
-    }
-}
-
-// ── Mention ─────────────────────────────────────────────────────────────
-
-@Composable
-private fun MentionNotificationRow(
-    item: NotificationGroup.MentionNotification,
-    resolveProfile: (String) -> ProfileData?,
-    isFollowing: Boolean,
-    onProfileClick: (String) -> Unit,
-    postCardParams: NotifPostCardParams
-) {
-    val profile = resolveProfile(item.senderPubkey)
-    val displayName = profile?.displayString
-        ?: item.senderPubkey.take(8) + "..." + item.senderPubkey.takeLast(4)
-
-    Column(modifier = Modifier.fillMaxWidth()) {
-        // Mention header
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            ProfilePicture(
-                url = profile?.picture,
-                size = 34,
-                showFollowBadge = isFollowing,
-                modifier = Modifier.clickable { onProfileClick(item.senderPubkey) }
-            )
-            Spacer(Modifier.width(10.dp))
-            Text(
-                text = displayName,
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-            Spacer(Modifier.width(4.dp))
-            Text(
-                text = "@",
+                text = formatNotifTimestamp(item.timestamp),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(Modifier.width(2.dp))
-            Text(
-                text = "mentioned you",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(Modifier.width(8.dp))
-            Text(
-                text = formatNotifTimestamp(item.latestTimestamp),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
         }
-        // Mention event as full PostCard
+
+        // Expanded section
+        AnimatedVisibility(
+            visible = isExpanded,
+            enter = expandVertically(),
+            exit = shrinkVertically()
+        ) {
+            if (item.type == NotificationType.REPLY) {
+                ReplyExpansion(
+                    item = item,
+                    eventRepo = eventRepo,
+                    resolveProfile = resolveProfile,
+                    profileVersion = profileVersion,
+                    inlineReplies = inlineReplies,
+                    userPubkey = userPubkey,
+                    postCardParams = postCardParams,
+                    onProfileClick = onProfileClick,
+                    onSendReply = onSendReply,
+                    onUploadMedia = onUploadMedia,
+                    onReplyFocused = onReplyFocused
+                )
+            } else if (postCardParams != null) {
+                NoteExpansion(
+                    item = item,
+                    params = postCardParams
+                )
+            }
+        }
+    }
+}
+
+// ── Note Expansion (non-reply types) ────────────────────────────────────
+
+@Composable
+private fun NoteExpansion(
+    item: FlatNotificationItem,
+    params: NotifPostCardParams
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp)
+    ) {
+        // For QUOTE: show the quote event (which embeds the quoted note via RichContent)
+        // For all others: show the referenced note
+        val eventId = when (item.type) {
+            NotificationType.QUOTE -> item.quoteEventId ?: item.referencedEventId
+            else -> item.referencedEventId
+        }
         ReferencedNotePostCard(
-            eventId = item.eventId,
-            params = postCardParams,
-            relayHints = item.relayHints
+            eventId = eventId,
+            params = params
         )
     }
 }
 
-// ── Shared PostCard params ───────────────────────────────────────────────
+// ── Reply Expansion ────────────────────────────────────────────────────
 
-private data class NotifPostCardParams(
-    val eventRepo: EventRepository?,
-    val userPubkey: String?,
-    val profileVersion: Int,
-    val reactionVersion: Int,
-    val replyCountVersion: Int,
-    val zapVersion: Int,
-    val repostVersion: Int,
-    val followListSize: Int = 0,
-    val resolvedEmojis: Map<String, String> = emptyMap(),
-    val unicodeEmojis: List<String> = emptyList(),
-    val onOpenEmojiLibrary: (() -> Unit)? = null,
-    val isFollowing: (String) -> Boolean,
-    val onNoteClick: (String) -> Unit,
-    val onProfileClick: (String) -> Unit,
-    val onReply: (NostrEvent) -> Unit,
-    val onReact: (NostrEvent, String) -> Unit,
-    val onRepost: (NostrEvent) -> Unit,
-    val onQuote: (NostrEvent) -> Unit,
-    val onZap: (NostrEvent) -> Unit,
-    val onFollowToggle: (String) -> Unit,
-    val onBlockUser: (String) -> Unit,
-    val onMuteThread: (String) -> Unit = {},
-    val onAddToList: (String) -> Unit,
-    val nip05Repo: Nip05Repository?,
-    val isZapAnimating: (String) -> Boolean,
-    val isZapInProgress: (String) -> Boolean,
-    val isInList: (String) -> Boolean,
-    val translationRepo: TranslationRepository? = null,
-    val pollVoteVersion: Int = 0,
-    val onPollVote: (String, List<String>) -> Unit = { _, _ -> }
-)
+@Composable
+private fun ReplyExpansion(
+    item: FlatNotificationItem,
+    eventRepo: EventRepository?,
+    resolveProfile: (String) -> ProfileData?,
+    profileVersion: Int,
+    inlineReplies: List<String>,
+    userPubkey: String?,
+    postCardParams: NotifPostCardParams?,
+    onProfileClick: (String) -> Unit,
+    onSendReply: (NostrEvent, String) -> Unit,
+    onUploadMedia: (List<Uri>, onUrl: (String) -> Unit) -> Unit = { _, _ -> },
+    onReplyFocused: () -> Unit = {}
+) {
+    val replyEvent = remember(item.replyEventId) { item.replyEventId?.let { eventRepo?.getEvent(it) } }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp)
+    ) {
+        // Original note (the note being replied to) — compact bordered card
+        if (item.referencedEventId.isNotBlank() && postCardParams != null) {
+            Text(
+                text = "replying to",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 2.dp),
+                textAlign = androidx.compose.ui.text.style.TextAlign.End
+            )
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                color = MaterialTheme.colorScheme.surface,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 4.dp)
+            ) {
+                ReferencedNotePostCard(
+                    eventId = item.referencedEventId,
+                    params = postCardParams
+                )
+            }
+        }
+
+        // The reply event — full PostCard with action bar
+        if (replyEvent != null && postCardParams != null) {
+            ReferencedNotePostCard(
+                eventId = replyEvent.id,
+                params = postCardParams
+            )
+        }
+
+        // User's inline replies
+        val userProfile = remember(profileVersion, userPubkey) {
+            userPubkey?.let { resolveProfile(it) }
+        }
+        inlineReplies.forEach { content ->
+            InlineSentReply(
+                content = content,
+                profile = userProfile,
+                eventRepo = postCardParams?.eventRepo,
+                onProfileClick = onProfileClick,
+                onNoteClick = postCardParams?.onNoteClick ?: {},
+                modifier = Modifier.padding(start = 48.dp, top = 4.dp, end = 16.dp)
+            )
+        }
+
+        // Inline reply composer
+        if (replyEvent != null) {
+            InlineReplyComposer(
+                onSend = { content -> onSendReply(replyEvent, content) },
+                onUploadMedia = onUploadMedia,
+                onFocused = onReplyFocused,
+                modifier = Modifier.padding(start = 48.dp, top = 8.dp, end = 16.dp, bottom = 4.dp)
+            )
+        }
+    }
+}
 
 // ── Referenced Note PostCard ────────────────────────────────────────────
-// Renders any event ID as a full PostCard with action bar (reactions, zaps, etc.)
 
 @Composable
 private fun ReferencedNotePostCard(
@@ -1038,7 +666,6 @@ private fun ReferencedNotePostCard(
     val followingAuthor = remember(params.followListSize, event.pubkey) {
         params.isFollowing(event.pubkey)
     }
-
     val eventReactionEmojiUrls = remember(params.reactionVersion, event.id) {
         eventRepo.getReactionEmojiUrls(event.id)
     }
@@ -1105,7 +732,334 @@ private fun ReferencedNotePostCard(
         onPollVote = { optionIds -> params.onPollVote(event.id, optionIds) },
         showDivider = false
     )
+}
 
+// ── PostCard params holder ─────────────────────────────────────────────
+
+private data class NotifPostCardParams(
+    val eventRepo: EventRepository?,
+    val userPubkey: String?,
+    val profileVersion: Int,
+    val reactionVersion: Int,
+    val replyCountVersion: Int,
+    val zapVersion: Int,
+    val repostVersion: Int,
+    val followListSize: Int = 0,
+    val resolvedEmojis: Map<String, String> = emptyMap(),
+    val unicodeEmojis: List<String> = emptyList(),
+    val onOpenEmojiLibrary: (() -> Unit)? = null,
+    val isFollowing: (String) -> Boolean,
+    val onNoteClick: (String) -> Unit,
+    val onProfileClick: (String) -> Unit,
+    val onReply: (NostrEvent) -> Unit,
+    val onReact: (NostrEvent, String) -> Unit,
+    val onRepost: (NostrEvent) -> Unit,
+    val onQuote: (NostrEvent) -> Unit,
+    val onZap: (NostrEvent) -> Unit,
+    val onFollowToggle: (String) -> Unit,
+    val onBlockUser: (String) -> Unit,
+    val onMuteThread: (String) -> Unit = {},
+    val onAddToList: (String) -> Unit,
+    val nip05Repo: Nip05Repository?,
+    val isZapAnimating: (String) -> Boolean,
+    val isZapInProgress: (String) -> Boolean,
+    val isInList: (String) -> Boolean,
+    val translationRepo: TranslationRepository? = null,
+    val pollVoteVersion: Int = 0,
+    val onPollVote: (String, List<String>) -> Unit = { _, _ -> }
+)
+
+// ── Inline Sent Reply ──────────────────────────────────────────────────
+
+@Composable
+private fun InlineSentReply(
+    content: String,
+    profile: ProfileData?,
+    eventRepo: EventRepository?,
+    onProfileClick: (String) -> Unit,
+    onNoteClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        ProfilePicture(
+            url = profile?.picture,
+            size = 28
+        )
+        Spacer(Modifier.width(6.dp))
+        com.wisp.app.ui.component.RichContent(
+            content = content,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            eventRepo = eventRepo,
+            onProfileClick = onProfileClick,
+            onNoteClick = onNoteClick,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+// ── Inline Reply Composer ──────────────────────────────────────────────
+
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+@Composable
+private fun InlineReplyComposer(
+    onSend: (String) -> Unit,
+    onUploadMedia: (List<Uri>, onUrl: (String) -> Unit) -> Unit = { _, _ -> },
+    onFocused: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val textFieldState = remember { TextFieldState() }
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        BasicTextField(
+            state = textFieldState,
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            modifier = Modifier
+                .weight(1f)
+                .onFocusChanged { if (it.isFocused) onFocused() }
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant,
+                    RoundedCornerShape(20.dp)
+                )
+                .padding(horizontal = 14.dp, vertical = 10.dp)
+                .contentReceiver(object : ReceiveContentListener {
+                    override fun onReceive(
+                        transferableContent: TransferableContent
+                    ): TransferableContent? {
+                        if (!transferableContent.hasMediaType(MediaType.Image)) {
+                            return transferableContent
+                        }
+                        val clipData = transferableContent.clipEntry.clipData
+                        val uris = (0 until clipData.itemCount)
+                            .mapNotNull { i -> clipData.getItemAt(i).uri }
+                        if (uris.isNotEmpty()) {
+                            onUploadMedia(uris) { url ->
+                                textFieldState.edit {
+                                    val current = toString()
+                                    val newText = if (current.isBlank()) url else "$current\n$url"
+                                    replace(0, length, newText)
+                                }
+                            }
+                        }
+                        return transferableContent.consume { item -> item.uri != null }
+                    }
+                }),
+            lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = 6),
+            textStyle = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            ),
+            decorator = { innerTextField ->
+                Box {
+                    if (textFieldState.text.isEmpty()) {
+                        Text(
+                            "Reply...",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    innerTextField()
+                }
+            }
+        )
+        Spacer(Modifier.width(6.dp))
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .background(MaterialTheme.colorScheme.primary, CircleShape)
+                .clickable {
+                    val trimmed = textFieldState.text.toString().trim()
+                    if (trimmed.isNotEmpty()) {
+                        onSend(trimmed)
+                        textFieldState.edit { replace(0, length, "") }
+                    }
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                Icons.AutoMirrored.Filled.Send,
+                contentDescription = "Send reply",
+                modifier = Modifier.size(14.dp),
+                tint = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+    }
+}
+
+@Composable
+private fun NotificationTypeIcon(item: FlatNotificationItem, showSats: Boolean = false) {
+    val iconSize = 28.dp
+    if (item.type == NotificationType.ZAP) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Outlined.CurrencyBitcoin,
+                contentDescription = "Zap",
+                modifier = Modifier.size(iconSize),
+                tint = WispThemeColors.zapColor
+            )
+            if (showSats && item.zapSats > 0) {
+                Text(
+                    text = formatSatsCompact(item.zapSats),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = WispThemeColors.zapColor,
+                    maxLines = 1
+                )
+            }
+        }
+        return
+    }
+    when (item.type) {
+        NotificationType.REACTION -> {
+            if (item.emoji != null) {
+                val shortcode = Nip30.shortcodeRegex.matchEntire(item.emoji)?.groupValues?.get(1)
+                if (item.emojiUrl != null) {
+                    AsyncImage(
+                        model = item.emojiUrl,
+                        contentDescription = shortcode ?: item.emoji,
+                        modifier = Modifier.size(iconSize)
+                    )
+                } else {
+                    val displayEmoji = if (item.emoji == "+") "\u2764\uFE0F" else item.emoji
+                    if (shortcode == null) {
+                        Text(
+                            text = displayEmoji,
+                            fontSize = 22.sp
+                        )
+                    } else {
+                        Icon(
+                            Icons.Outlined.FavoriteBorder,
+                            contentDescription = "Reaction",
+                            modifier = Modifier.size(iconSize),
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
+            } else {
+                Icon(
+                    Icons.Outlined.FavoriteBorder,
+                    contentDescription = "Reaction",
+                    modifier = Modifier.size(iconSize),
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+        NotificationType.ZAP -> { /* handled above */ }
+        NotificationType.REPOST -> {
+            Icon(
+                Icons.Outlined.Repeat,
+                contentDescription = "Repost",
+                modifier = Modifier.size(iconSize),
+                tint = WispThemeColors.repostColor
+            )
+        }
+        NotificationType.REPLY -> {
+            Icon(
+                Icons.Outlined.ChatBubbleOutline,
+                contentDescription = "Reply",
+                modifier = Modifier.size(iconSize),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+        NotificationType.QUOTE -> {
+            Text(
+                text = "\u201C\u201D",
+                fontSize = 20.sp,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        NotificationType.MENTION -> {
+            Icon(
+                Icons.Outlined.AlternateEmail,
+                contentDescription = "Mention",
+                modifier = Modifier.size(iconSize),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+        NotificationType.VOTE -> {
+            Icon(
+                Icons.Outlined.BarChart,
+                contentDescription = "Vote",
+                modifier = Modifier.size(iconSize),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
+
+private fun actionText(item: FlatNotificationItem): String = when (item.type) {
+    NotificationType.REACTION -> "reacted"
+    NotificationType.ZAP -> "zapped"
+    NotificationType.REPOST -> "reposted"
+    NotificationType.REPLY -> "replied"
+    NotificationType.QUOTE -> "quoted"
+    NotificationType.MENTION -> "mentioned you"
+    NotificationType.VOTE -> "voted"
+}
+
+// ── Daily Summary Bar ──────────────────────────────────────────────────
+
+@Composable
+private fun DailySummaryBar(summary: NotificationSummary, onFilterSelect: (NotificationFilter) -> Unit) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "24h",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            SummaryStat(Icons.Outlined.ChatBubbleOutline, summary.replyCount.toString()) { onFilterSelect(NotificationFilter.REPLIES) }
+            SummaryStat(Icons.Outlined.FavoriteBorder, summary.reactionCount.toString()) { onFilterSelect(NotificationFilter.REACTIONS) }
+            SummaryStat(Icons.Outlined.CurrencyBitcoin, formatSatsCompact(summary.zapSats)) { onFilterSelect(NotificationFilter.ZAPS) }
+            SummaryStat(Icons.Outlined.Repeat, summary.repostCount.toString()) { onFilterSelect(NotificationFilter.REPOSTS) }
+            SummaryStat(Icons.Outlined.AlternateEmail, (summary.mentionCount + summary.quoteCount).toString()) { onFilterSelect(NotificationFilter.MENTIONS) }
+        }
+    }
+}
+
+@Composable
+private fun SummaryStat(icon: androidx.compose.ui.graphics.vector.ImageVector, value: String, onClick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 4.dp, vertical = 2.dp)
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            modifier = Modifier.size(22.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+// ── Formatters ─────────────────────────────────────────────────────────
+
+private fun formatSatsCompact(sats: Long): String = when {
+    sats >= 1_000_000 -> "${sats / 1_000_000}M"
+    sats >= 1_000 -> "${sats / 1_000}K"
+    else -> sats.toString()
 }
 
 private val notifDateTimeFormat = SimpleDateFormat("MMM d, HH:mm", Locale.US)
@@ -1141,10 +1095,4 @@ private fun formatNotifTimestamp(epoch: Long): String {
     } else {
         notifDateTimeFormat.format(date)
     }
-}
-
-private fun formatSats(sats: Long): String = when {
-    sats >= 1_000_000 -> "${sats / 1_000_000}M sats"
-    sats >= 1_000 -> "${sats / 1_000}K sats"
-    else -> "$sats sats"
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -101,6 +101,7 @@ class EventRouter(
                     5 -> eventRepo.addEvent(event)
                     6 -> eventRepo.addEvent(event)
                     7 -> eventRepo.addEvent(event)
+                    Nip88.KIND_POLL_RESPONSE -> eventRepo.addEvent(event)
                     9735 -> {
                         eventRepo.addEvent(event)
                         eventRepo.addEventRelay(event.id, relayUrl)
@@ -204,7 +205,7 @@ class EventRouter(
             // (engagement subs fetch reposts for all viewed posts, not just ours).
             val myPubkey = getUserPubkey()
             val isNotifEligible = myPubkey != null && event.pubkey != myPubkey &&
-                event.kind in intArrayOf(1, 6, 7, 9735) &&
+                event.kind in intArrayOf(1, 6, 7, 9735, Nip88.KIND_POLL_RESPONSE) &&
                 !muteRepo.isBlocked(event.pubkey)
             val isRepostOfOther = event.kind == 6 && run {
                 val repostedId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
@@ -4,8 +4,10 @@ import android.app.Application
 import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.wisp.app.nostr.FlatNotificationItem
 import com.wisp.app.nostr.NotificationGroup
 import com.wisp.app.nostr.NotificationSummary
+import com.wisp.app.nostr.NotificationType
 import com.wisp.app.nostr.ProfileData
 import com.wisp.app.repo.ContactRepository
 import com.wisp.app.repo.EventRepository
@@ -24,7 +26,8 @@ enum class NotificationFilter(val label: String) {
     REACTIONS("Reactions"),
     ZAPS("Zaps"),
     REPOSTS("Reposts"),
-    MENTIONS("Mentions")
+    MENTIONS("Mentions"),
+    VOTES("Votes")
 }
 
 class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
@@ -50,6 +53,9 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
     val notifReceived: SharedFlow<Unit>
         get() = notifRepo?.notifReceived ?: MutableSharedFlow()
 
+    val flatNotifications: StateFlow<List<FlatNotificationItem>>
+        get() = notifRepo?.flatNotifications ?: MutableStateFlow(emptyList())
+
     val eventRepository: EventRepository?
         get() = eventRepo
 
@@ -67,6 +73,9 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _filteredNotifications = MutableStateFlow<List<NotificationGroup>>(emptyList())
     val filteredNotifications: StateFlow<List<NotificationGroup>> = _filteredNotifications
+
+    private val _filteredFlatNotifications = MutableStateFlow<List<FlatNotificationItem>>(emptyList())
+    val filteredFlatNotifications: StateFlow<List<FlatNotificationItem>> = _filteredFlatNotifications
 
     private var notifRepo: NotificationRepository? = null
     private var eventRepo: EventRepository? = null
@@ -107,8 +116,22 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
                     NotificationFilter.MENTIONS -> notifs.filter {
                         it is NotificationGroup.MentionNotification || it is NotificationGroup.QuoteNotification
                     }
+                    NotificationFilter.VOTES -> emptyList() // votes only exist in flat list
                 }
             }.collect { _filteredNotifications.value = it }
+        }
+        viewModelScope.launch {
+            combine(flatNotifications, _filter) { items, filterType ->
+                when (filterType) {
+                    NotificationFilter.ALL -> items
+                    NotificationFilter.REPLIES -> items.filter { it.type == NotificationType.REPLY }
+                    NotificationFilter.REACTIONS -> items.filter { it.type == NotificationType.REACTION }
+                    NotificationFilter.ZAPS -> items.filter { it.type == NotificationType.ZAP }
+                    NotificationFilter.REPOSTS -> items.filter { it.type == NotificationType.REPOST }
+                    NotificationFilter.MENTIONS -> items.filter { it.type == NotificationType.MENTION || it.type == NotificationType.QUOTE }
+                    NotificationFilter.VOTES -> items.filter { it.type == NotificationType.VOTE }
+                }
+            }.collect { _filteredFlatNotifications.value = it }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace grouped notification UI with flat chronological list — compact rows with type icon, avatar, name, and action text
- Tap any notification to expand inline: full PostCard with action bar, reaction details, relay/client info
- Reply notifications expand with original note, reply, inline composer (GIF keyboard + blossom upload), and PoW mining support
- Add poll vote notifications (kind 1018) showing voted option labels
- Type-specific left icons: emoji for reactions, bitcoin for zaps, repeat for reposts, chat bubble for replies, quote marks for quotes, at-sign for mentions, bar chart for votes
- Zap amounts displayed under the bitcoin icon
- Filter dropdown includes new "Votes" option
- Auto-scroll reply composer above keyboard on focus
- Version bump to 0.10.0

## Test plan
- [ ] Navigate to notifications, verify flat chronological list renders
- [ ] Tap reaction/zap/repost/quote/mention/reply notifications — each expands inline with full PostCard
- [ ] Expand a reply notification, verify original note + reply + inline composer shown
- [ ] Send inline reply, verify it renders with media support (GIF keyboard)
- [ ] Verify PoW is mined for inline replies when enabled in settings
- [ ] Create a poll, have someone vote, verify vote notification appears with option label
- [ ] Filter by each type (All/Replies/Reactions/Zaps/Reposts/Mentions/Votes)
- [ ] Verify 24h summary bar counts are correct
- [ ] Verify pull-to-refresh works
- [ ] Verify sound effects still fire for new notifications
- [ ] Verify timestamps align consistently on the right edge
- [ ] Tap reply composer on a notification near bottom of screen, verify auto-scroll above keyboard