### PR TITLE
feat: DM notifications with inline reply

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -362,7 +362,11 @@ fun WispNavHost(
 
     // Initialize notifications viewmodel with shared repos
     LaunchedEffect(Unit) {
-        notificationsViewModel.init(feedViewModel.notifRepo, feedViewModel.eventRepo, feedViewModel.contactRepo)
+        notificationsViewModel.init(
+            feedViewModel.notifRepo, feedViewModel.eventRepo, feedViewModel.contactRepo,
+            feedViewModel.dmRepo, feedViewModel.relayPool, feedViewModel.relayListRepo,
+            feedViewModel.powPrefs
+        )
     }
 
     // Resolve deep link URI to a navigation route
@@ -466,6 +470,21 @@ fun WispNavHost(
     LaunchedEffect(Unit) {
         notificationsViewModel.replyReceived.collect {
             if (currentNotifSoundEnabled) HapticHelper.pulse()
+        }
+    }
+    LaunchedEffect(Unit) {
+        notificationsViewModel.dmReceived.collect {
+            isReplyAnimating = true
+            kotlinx.coroutines.delay(1000)
+            isReplyAnimating = false
+            if (currentNotifSoundEnabled) HapticHelper.pulse()
+        }
+    }
+    // Background decryption of pending DM gift wraps (remote signer mode)
+    val pendingDmCount by dmListViewModel.pendingDecryptCount.collectAsState()
+    LaunchedEffect(pendingDmCount, activeSigner) {
+        if (pendingDmCount > 0) {
+            activeSigner?.let { dmListViewModel.decryptPending(it) }
         }
     }
     LaunchedEffect(Unit) {
@@ -2142,6 +2161,9 @@ fun WispNavHost(
                             } catch (_: Exception) {}
                         }
                     }
+                },
+                onSendDm = { peerPubkey, content ->
+                    notificationsViewModel.sendDm(peerPubkey, content, activeSigner)
                 }
             )
 

--- a/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/NotificationItem.kt
@@ -1,6 +1,6 @@
 package com.wisp.app.nostr
 
-enum class NotificationType { REACTION, ZAP, REPOST, REPLY, QUOTE, MENTION, VOTE }
+enum class NotificationType { REACTION, ZAP, REPOST, REPLY, QUOTE, MENTION, VOTE, DM }
 
 data class FlatNotificationItem(
     val id: String,
@@ -16,6 +16,8 @@ data class FlatNotificationItem(
     val replyEventId: String? = null,
     val quoteEventId: String? = null,
     val voteOptionIds: List<String> = emptyList(),
+    val dmContent: String? = null,
+    val dmPeerPubkey: String? = null,
 )
 
 data class NotificationSummary(
@@ -25,7 +27,8 @@ data class NotificationSummary(
     val zapSats: Long = 0,
     val repostCount: Int = 0,
     val mentionCount: Int = 0,
-    val quoteCount: Int = 0
+    val quoteCount: Int = 0,
+    val dmCount: Int = 0
 )
 
 data class ZapEntry(

--- a/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/DmRepository.kt
@@ -7,11 +7,16 @@ import com.wisp.app.nostr.DmConversation
 import com.wisp.app.nostr.DmMessage
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.wipe
+import com.wisp.app.nostr.FlatNotificationItem
+import com.wisp.app.nostr.NotificationType
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.util.concurrent.ConcurrentHashMap
 
 class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
+    private val myPubkey: String? = pubkeyHex
     private val prefs: SharedPreferences? =
         context?.getSharedPreferences("wisp_dm_${pubkeyHex ?: "anon"}", Context.MODE_PRIVATE)
     private var lastReadDmTimestamp: Long = prefs?.getLong("last_read_dm", 0L) ?: 0L
@@ -48,6 +53,19 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
     val decrypting: StateFlow<Boolean> = _decrypting
     private val decryptingRefCount = java.util.concurrent.atomic.AtomicInteger(0)
 
+    /** Only play sounds for DMs created after this timestamp (set at subscription time). */
+    @Volatile var soundEligibleAfter: Long = System.currentTimeMillis() / 1000
+
+    @Volatile var appIsActive: Boolean = true
+
+    private val _dmReceived = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val dmReceived: SharedFlow<Unit> = _dmReceived
+
+    private val dmNotifItems = mutableListOf<FlatNotificationItem>()
+    private val dmNotifIds = mutableSetOf<String>()
+    private val _dmNotifications = MutableStateFlow<List<FlatNotificationItem>>(emptyList())
+    val dmNotifications: StateFlow<List<FlatNotificationItem>> = _dmNotifications
+
     fun markDecryptingStart() {
         decryptingRefCount.incrementAndGet()
         _decrypting.value = true
@@ -60,6 +78,7 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
     }
 
     fun addMessage(msg: DmMessage, peerPubkey: String) {
+        var isNewIncoming = false
         synchronized(lock) {
             val existingMsgId = seenGiftWraps.get(msg.giftWrapId)
             if (existingMsgId != null) {
@@ -73,11 +92,36 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
                 _hasUnreadDms.value = true
             }
 
+            // Track incoming DMs as notification items
+            val incoming = myPubkey != null && msg.senderPubkey != myPubkey
+            if (incoming) {
+                val flatId = "dm:${msg.id}"
+                if (dmNotifIds.add(flatId)) {
+                    dmNotifItems.add(FlatNotificationItem(
+                        id = flatId,
+                        type = NotificationType.DM,
+                        actorPubkey = msg.senderPubkey,
+                        referencedEventId = msg.id,
+                        timestamp = msg.createdAt,
+                        dmContent = msg.content,
+                        dmPeerPubkey = peerPubkey
+                    ))
+                    val sorted = dmNotifItems.sortedByDescending { it.timestamp }
+                    _dmNotifications.value = if (sorted.size > 200) sorted.take(200) else sorted
+                }
+                if (msg.createdAt >= soundEligibleAfter && appIsActive) {
+                    isNewIncoming = true
+                }
+            }
+
             val messages = conversations.get(peerPubkey) ?: mutableListOf<DmMessage>().also {
                 conversations.put(peerPubkey, it)
             }
             messages.add(msg)
             messages.sortBy { it.createdAt }
+        }
+        if (isNewIncoming) {
+            _dmReceived.tryEmit(Unit)
         }
         updateConversationList()
     }
@@ -176,6 +220,8 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
             conversationKeyCache.evictAll()
             seenGiftWraps.clear()
             dmRelayCache.evictAll()
+            dmNotifItems.clear()
+            dmNotifIds.clear()
         }
         synchronized(pendingLock) {
             pendingGiftWraps.clear()
@@ -184,7 +230,9 @@ class DmRepository(context: Context? = null, pubkeyHex: String? = null) {
         _conversationList.value = emptyList()
         _hasUnreadDms.value = false
         _decrypting.value = false
+        _dmNotifications.value = emptyList()
         decryptingRefCount.set(0)
+        soundEligibleAfter = System.currentTimeMillis() / 1000
         prefs?.edit()?.clear()?.apply()
     }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.outlined.BarChart
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.MailOutline
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -137,6 +138,7 @@ fun NotificationsScreen(
     translationRepo: TranslationRepository? = null,
     onPollVote: (String, List<String>) -> Unit = { _, _ -> },
     onUploadMedia: (List<Uri>, onUrl: (String) -> Unit) -> Unit = { _, _ -> },
+    onSendDm: (peerPubkey: String, content: String) -> Unit = { _, _ -> },
 ) {
     val notifications by viewModel.filteredFlatNotifications.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
@@ -152,6 +154,9 @@ fun NotificationsScreen(
 
     // Track inline replies sent by user: replyEventId -> list of sent content strings
     var inlineReplies by remember { mutableStateOf(mapOf<String, List<String>>()) }
+
+    // Track inline DM replies sent by user: peerPubkey -> list of sent content strings
+    var inlineDmReplies by remember { mutableStateOf(mapOf<String, List<String>>()) }
 
     // Version flows for PostCard cache invalidation
     val reactionVersion = eventRepo?.reactionVersion?.collectAsState()?.value ?: 0
@@ -338,6 +343,7 @@ fun NotificationsScreen(
                         profileVersion = profileVersion,
                         isExpanded = isExpanded,
                         inlineReplies = inlineReplies[item.replyEventId ?: ""] ?: emptyList(),
+                        inlineDmReplies = inlineDmReplies[item.dmPeerPubkey ?: ""] ?: emptyList(),
                         userPubkey = userPubkey,
                         postCardParams = postCardParams,
                         onClick = {
@@ -349,6 +355,11 @@ fun NotificationsScreen(
                             val key = item.replyEventId ?: ""
                             val existing = inlineReplies[key] ?: emptyList()
                             inlineReplies = inlineReplies + (key to (existing + content))
+                        },
+                        onSendDm = { peerPubkey, content ->
+                            onSendDm(peerPubkey, content)
+                            val existing = inlineDmReplies[peerPubkey] ?: emptyList()
+                            inlineDmReplies = inlineDmReplies + (peerPubkey to (existing + content))
                         },
                         onUploadMedia = onUploadMedia,
                         onReplyFocused = {
@@ -386,11 +397,13 @@ private fun ZenNotificationRow(
     profileVersion: Int,
     isExpanded: Boolean = false,
     inlineReplies: List<String> = emptyList(),
+    inlineDmReplies: List<String> = emptyList(),
     userPubkey: String? = null,
     postCardParams: NotifPostCardParams? = null,
     onClick: () -> Unit,
     onProfileClick: (String) -> Unit,
     onSendReply: (NostrEvent, String) -> Unit = { _, _ -> },
+    onSendDm: (String, String) -> Unit = { _, _ -> },
     onUploadMedia: (List<Uri>, onUrl: (String) -> Unit) -> Unit = { _, _ -> },
     onReplyFocused: () -> Unit = {}
 ) {
@@ -471,7 +484,18 @@ private fun ZenNotificationRow(
             enter = expandVertically(),
             exit = shrinkVertically()
         ) {
-            if (item.type == NotificationType.REPLY) {
+            if (item.type == NotificationType.DM) {
+                DmExpansion(
+                    item = item,
+                    resolveProfile = resolveProfile,
+                    profileVersion = profileVersion,
+                    inlineDmReplies = inlineDmReplies,
+                    userPubkey = userPubkey,
+                    onSendDm = onSendDm,
+                    onProfileClick = onProfileClick,
+                    onFocused = onReplyFocused
+                )
+            } else if (item.type == NotificationType.REPLY) {
                 ReplyExpansion(
                     item = item,
                     eventRepo = eventRepo,
@@ -516,6 +540,66 @@ private fun NoteExpansion(
         ReferencedNotePostCard(
             eventId = eventId,
             params = params
+        )
+    }
+}
+
+// ── DM Expansion ──────────────────────────────────────────────────────
+
+@Composable
+private fun DmExpansion(
+    item: FlatNotificationItem,
+    resolveProfile: (String) -> ProfileData?,
+    profileVersion: Int,
+    inlineDmReplies: List<String> = emptyList(),
+    userPubkey: String? = null,
+    onSendDm: (String, String) -> Unit = { _, _ -> },
+    onProfileClick: (String) -> Unit = {},
+    onFocused: () -> Unit = {}
+) {
+    val peerPubkey = item.dmPeerPubkey ?: return
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp)
+    ) {
+        // Their message
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 68.dp, end = 16.dp)
+        ) {
+            Text(
+                text = item.dmContent ?: "",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(12.dp)
+            )
+        }
+
+        // User's inline DM replies
+        val userProfile = remember(profileVersion, userPubkey) {
+            userPubkey?.let { resolveProfile(it) }
+        }
+        inlineDmReplies.forEach { content ->
+            InlineSentReply(
+                content = content,
+                profile = userProfile,
+                onProfileClick = onProfileClick,
+                onNoteClick = {},
+                modifier = Modifier.padding(start = 48.dp, top = 4.dp, end = 16.dp)
+            )
+        }
+
+        // Inline DM composer
+        InlineReplyComposer(
+            onSend = { content -> onSendDm(peerPubkey, content) },
+            onFocused = onFocused,
+            placeholder = "Message...",
+            modifier = Modifier.padding(start = 48.dp, top = 8.dp, end = 16.dp, bottom = 4.dp)
         )
     }
 }
@@ -775,7 +859,7 @@ private data class NotifPostCardParams(
 private fun InlineSentReply(
     content: String,
     profile: ProfileData?,
-    eventRepo: EventRepository?,
+    eventRepo: EventRepository? = null,
     onProfileClick: (String) -> Unit,
     onNoteClick: (String) -> Unit,
     modifier: Modifier = Modifier
@@ -809,6 +893,7 @@ private fun InlineReplyComposer(
     onSend: (String) -> Unit,
     onUploadMedia: (List<Uri>, onUrl: (String) -> Unit) -> Unit = { _, _ -> },
     onFocused: () -> Unit = {},
+    placeholder: String = "Reply...",
     modifier: Modifier = Modifier
 ) {
     val textFieldState = remember { TextFieldState() }
@@ -858,7 +943,7 @@ private fun InlineReplyComposer(
                 Box {
                     if (textFieldState.text.isEmpty()) {
                         Text(
-                            "Reply...",
+                            placeholder,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -980,6 +1065,14 @@ private fun NotificationTypeIcon(item: FlatNotificationItem, showSats: Boolean =
                 tint = MaterialTheme.colorScheme.primary
             )
         }
+        NotificationType.DM -> {
+            Icon(
+                Icons.Outlined.MailOutline,
+                contentDescription = "DM",
+                modifier = Modifier.size(iconSize),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
         NotificationType.VOTE -> {
             Icon(
                 Icons.Outlined.BarChart,
@@ -999,6 +1092,7 @@ private fun actionText(item: FlatNotificationItem): String = when (item.type) {
     NotificationType.QUOTE -> "quoted"
     NotificationType.MENTION -> "mentioned you"
     NotificationType.VOTE -> "voted"
+    NotificationType.DM -> "messaged you"
 }
 
 // ── Daily Summary Bar ──────────────────────────────────────────────────
@@ -1026,6 +1120,7 @@ private fun DailySummaryBar(summary: NotificationSummary, onFilterSelect: (Notif
             SummaryStat(Icons.Outlined.CurrencyBitcoin, formatSatsCompact(summary.zapSats)) { onFilterSelect(NotificationFilter.ZAPS) }
             SummaryStat(Icons.Outlined.Repeat, summary.repostCount.toString()) { onFilterSelect(NotificationFilter.REPOSTS) }
             SummaryStat(Icons.Outlined.AlternateEmail, (summary.mentionCount + summary.quoteCount).toString()) { onFilterSelect(NotificationFilter.MENTIONS) }
+            SummaryStat(Icons.Outlined.MailOutline, summary.dmCount.toString()) { onFilterSelect(NotificationFilter.DMS) }
         }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/NotificationsViewModel.kt
@@ -2,23 +2,42 @@ package com.wisp.app.viewmodel
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.wisp.app.nostr.ClientMessage
+import com.wisp.app.nostr.DmMessage
+import com.wisp.app.nostr.Filter
 import com.wisp.app.nostr.FlatNotificationItem
+import com.wisp.app.nostr.Nip17
+import com.wisp.app.nostr.Nip51
+import com.wisp.app.nostr.NostrSigner
 import com.wisp.app.nostr.NotificationGroup
 import com.wisp.app.nostr.NotificationSummary
 import com.wisp.app.nostr.NotificationType
 import com.wisp.app.nostr.ProfileData
+import com.wisp.app.nostr.SignerCancelledException
+import com.wisp.app.nostr.hexToByteArray
+import com.wisp.app.nostr.toHex
+import com.wisp.app.relay.RelayConfig
+import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.ContactRepository
+import com.wisp.app.repo.DmRepository
 import com.wisp.app.repo.EventRepository
+import com.wisp.app.repo.KeyRepository
 import com.wisp.app.repo.NotificationRepository
+import com.wisp.app.repo.PowPreferences
+import com.wisp.app.repo.RelayListRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 enum class NotificationFilter(val label: String) {
     ALL("All"),
@@ -27,7 +46,8 @@ enum class NotificationFilter(val label: String) {
     ZAPS("Zaps"),
     REPOSTS("Reposts"),
     MENTIONS("Mentions"),
-    VOTES("Votes")
+    VOTES("Votes"),
+    DMS("DMs")
 }
 
 class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
@@ -53,6 +73,9 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
     val notifReceived: SharedFlow<Unit>
         get() = notifRepo?.notifReceived ?: MutableSharedFlow()
 
+    val dmReceived: SharedFlow<Unit>
+        get() = dmRepo?.dmReceived ?: MutableSharedFlow()
+
     val flatNotifications: StateFlow<List<FlatNotificationItem>>
         get() = notifRepo?.flatNotifications ?: MutableStateFlow(emptyList())
 
@@ -62,8 +85,8 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
     val contactRepository: ContactRepository?
         get() = contactRepo
 
-    val summary24h: StateFlow<NotificationSummary>
-        get() = notifRepo?.summary24h ?: MutableStateFlow(NotificationSummary())
+    private val _combinedSummary = MutableStateFlow(NotificationSummary())
+    val summary24h: StateFlow<NotificationSummary> = _combinedSummary
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing
@@ -80,13 +103,31 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
     private var notifRepo: NotificationRepository? = null
     private var eventRepo: EventRepository? = null
     private var contactRepo: ContactRepository? = null
+    private var dmRepo: DmRepository? = null
+    private var relayPool: RelayPool? = null
+    private var relayListRepo: RelayListRepository? = null
+    private var powPrefs: PowPreferences? = null
+    private val keyRepo = KeyRepository(getApplication())
 
-    fun init(notificationRepository: NotificationRepository, eventRepository: EventRepository, contactRepository: ContactRepository) {
+    fun init(
+        notificationRepository: NotificationRepository,
+        eventRepository: EventRepository,
+        contactRepository: ContactRepository,
+        dmRepository: DmRepository? = null,
+        relayPool: RelayPool? = null,
+        relayListRepository: RelayListRepository? = null,
+        powPreferences: PowPreferences? = null
+    ) {
         notifRepo = notificationRepository
         eventRepo = eventRepository
         contactRepo = contactRepository
+        dmRepo = dmRepository
+        this.relayPool = relayPool
+        relayListRepo = relayListRepository
+        powPrefs = powPreferences
         startPeriodicRefresh()
         startFilterCombine()
+        startSummaryCombine()
     }
 
     private fun startPeriodicRefresh() {
@@ -97,6 +138,9 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
             }
         }
     }
+
+    private val dmNotifications: StateFlow<List<FlatNotificationItem>>
+        get() = dmRepo?.dmNotifications ?: MutableStateFlow(emptyList())
 
     private fun startFilterCombine() {
         viewModelScope.launch {
@@ -117,21 +161,35 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
                         it is NotificationGroup.MentionNotification || it is NotificationGroup.QuoteNotification
                     }
                     NotificationFilter.VOTES -> emptyList() // votes only exist in flat list
+                    NotificationFilter.DMS -> emptyList() // DMs only exist in flat list
                 }
             }.collect { _filteredNotifications.value = it }
         }
         viewModelScope.launch {
-            combine(flatNotifications, _filter) { items, filterType ->
-                when (filterType) {
-                    NotificationFilter.ALL -> items
+            combine(flatNotifications, dmNotifications, _filter) { items, dmItems, filterType ->
+                val merged = when (filterType) {
+                    NotificationFilter.ALL -> (items + dmItems).sortedByDescending { it.timestamp }
                     NotificationFilter.REPLIES -> items.filter { it.type == NotificationType.REPLY }
                     NotificationFilter.REACTIONS -> items.filter { it.type == NotificationType.REACTION }
                     NotificationFilter.ZAPS -> items.filter { it.type == NotificationType.ZAP }
                     NotificationFilter.REPOSTS -> items.filter { it.type == NotificationType.REPOST }
                     NotificationFilter.MENTIONS -> items.filter { it.type == NotificationType.MENTION || it.type == NotificationType.QUOTE }
                     NotificationFilter.VOTES -> items.filter { it.type == NotificationType.VOTE }
+                    NotificationFilter.DMS -> dmItems
                 }
+                merged
             }.collect { _filteredFlatNotifications.value = it }
+        }
+    }
+
+    private fun startSummaryCombine() {
+        val baseSummary = notifRepo?.summary24h ?: return
+        viewModelScope.launch {
+            combine(baseSummary, dmNotifications) { summary, dmItems ->
+                val cutoff = System.currentTimeMillis() / 1000 - 86400L
+                val dmCount = dmItems.count { it.timestamp >= cutoff }
+                summary.copy(dmCount = dmCount)
+            }.collect { _combinedSummary.value = it }
         }
     }
 
@@ -166,5 +224,202 @@ class NotificationsViewModel(app: Application) : AndroidViewModel(app) {
 
     fun getProfileData(pubkey: String): ProfileData? {
         return eventRepo?.getProfileData(pubkey)
+    }
+
+    // ── Inline DM Send ──────────────────────────────────────────────────
+
+    private val _dmSending = MutableStateFlow(false)
+    val dmSending: StateFlow<Boolean> = _dmSending
+
+    fun sendDm(peerPubkey: String, content: String, signer: NostrSigner? = null) {
+        val text = content.trim()
+        if (text.isBlank() || _dmSending.value) return
+        val pool = relayPool ?: return
+        val repo = dmRepo ?: return
+
+        _dmSending.value = true
+
+        viewModelScope.launch(Dispatchers.Default) {
+            try {
+                val recipientDmRelays = fetchRecipientDmRelays(peerPubkey, pool, repo)
+                val deliveryRelays = resolveDeliveryRelays(peerPubkey, recipientDmRelays, pool)
+
+                val dmPowEnabled = powPrefs?.isDmPowEnabled() == true
+                val dmDifficulty = if (dmPowEnabled) powPrefs?.getDmDifficulty() ?: 0 else 0
+
+                if (signer != null) {
+                    // Remote signer mode
+                    val recipientWrap = Nip17.createGiftWrapRemote(
+                        signer = signer,
+                        recipientPubkeyHex = peerPubkey,
+                        message = text,
+                        targetDifficulty = dmDifficulty
+                    )
+                    val recipientMsg = ClientMessage.event(recipientWrap)
+                    val sentRelayUrls = sendToDeliveryRelays(pool, deliveryRelays, recipientMsg)
+
+                    val selfWrap = Nip17.createGiftWrapRemote(
+                        signer = signer,
+                        recipientPubkeyHex = signer.pubkeyHex,
+                        message = text,
+                        rumorPTag = peerPubkey,
+                        targetDifficulty = dmDifficulty
+                    )
+                    val selfMsg = ClientMessage.event(selfWrap)
+                    if (pool.hasDmRelays()) pool.sendToDmRelays(selfMsg)
+                    else pool.sendToWriteRelays(selfMsg)
+
+                    val dmMsg = DmMessage(
+                        id = "${recipientWrap.id}:${System.currentTimeMillis() / 1000}",
+                        senderPubkey = signer.pubkeyHex,
+                        content = text,
+                        createdAt = System.currentTimeMillis() / 1000,
+                        giftWrapId = recipientWrap.id,
+                        relayUrls = sentRelayUrls
+                    )
+                    repo.addMessage(dmMsg, peerPubkey)
+                    repo.markGiftWrapSeen(selfWrap.id, dmMsg.id)
+                } else {
+                    // Local signer mode
+                    val keypair = keyRepo.getKeypair() ?: return@launch
+                    val senderPubkeyHex = keypair.pubkey.toHex()
+
+                    val recipientWrap = Nip17.createGiftWrap(
+                        senderPrivkey = keypair.privkey,
+                        senderPubkey = keypair.pubkey,
+                        recipientPubkey = peerPubkey.hexToByteArray(),
+                        message = text,
+                        targetDifficulty = dmDifficulty
+                    )
+                    val recipientMsg = ClientMessage.event(recipientWrap)
+                    val sentRelayUrls = sendToDeliveryRelays(pool, deliveryRelays, recipientMsg)
+
+                    val selfWrap = Nip17.createGiftWrap(
+                        senderPrivkey = keypair.privkey,
+                        senderPubkey = keypair.pubkey,
+                        recipientPubkey = keypair.pubkey,
+                        message = text,
+                        rumorPTag = peerPubkey,
+                        targetDifficulty = dmDifficulty
+                    )
+                    val selfMsg = ClientMessage.event(selfWrap)
+                    if (pool.hasDmRelays()) pool.sendToDmRelays(selfMsg)
+                    else pool.sendToWriteRelays(selfMsg)
+
+                    val dmMsg = DmMessage(
+                        id = "${recipientWrap.id}:${System.currentTimeMillis() / 1000}",
+                        senderPubkey = senderPubkeyHex,
+                        content = text,
+                        createdAt = System.currentTimeMillis() / 1000,
+                        giftWrapId = recipientWrap.id,
+                        relayUrls = sentRelayUrls
+                    )
+                    repo.addMessage(dmMsg, peerPubkey)
+                    repo.markGiftWrapSeen(selfWrap.id, dmMsg.id)
+                }
+            } catch (e: SignerCancelledException) {
+                Log.w("NotifVM", "DM signing cancelled", e)
+            } catch (e: Exception) {
+                Log.w("NotifVM", "DM send failed", e)
+            } finally {
+                _dmSending.value = false
+            }
+        }
+    }
+
+    private suspend fun fetchRecipientDmRelays(
+        peerPubkey: String,
+        pool: RelayPool,
+        repo: DmRepository
+    ): List<String> {
+        repo.getCachedDmRelays(peerPubkey)?.let { return it }
+
+        val subId = "dm_relay_${peerPubkey.take(8)}"
+        val filter = Filter(
+            kinds = listOf(Nip51.KIND_DM_RELAYS),
+            authors = listOf(peerPubkey),
+            limit = 1
+        )
+        val reqMsg = ClientMessage.req(subId, filter)
+        for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+            pool.sendToRelayOrEphemeral(url, reqMsg, skipBadCheck = true)
+        }
+        pool.sendToAll(reqMsg)
+
+        val result = withTimeoutOrNull(4000L) {
+            pool.relayEvents.first { it.subscriptionId == subId }
+        }
+
+        val closeMsg = ClientMessage.close(subId)
+        for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+            pool.sendToRelay(url, closeMsg)
+        }
+        pool.sendToAll(closeMsg)
+
+        if (result != null) {
+            val urls = Nip51.parseRelaySet(result.event)
+            if (urls.isNotEmpty()) {
+                repo.cacheDmRelays(peerPubkey, urls)
+                return urls
+            }
+        }
+        return emptyList()
+    }
+
+    private suspend fun resolveDeliveryRelays(
+        peerPubkey: String,
+        recipientDmRelays: List<String>,
+        pool: RelayPool
+    ): List<String> {
+        if (recipientDmRelays.isNotEmpty()) return recipientDmRelays
+
+        if (relayListRepo?.hasRelayList(peerPubkey) != true) {
+            fetchPeerRelayList(peerPubkey, pool)
+        }
+        relayListRepo?.getReadRelays(peerPubkey)?.takeIf { it.isNotEmpty() }?.let { return it }
+        relayListRepo?.getWriteRelays(peerPubkey)?.takeIf { it.isNotEmpty() }?.let { return it }
+        return pool.getWriteRelayUrls()
+    }
+
+    private suspend fun fetchPeerRelayList(peerPubkey: String, pool: RelayPool) {
+        val repo = relayListRepo ?: return
+        val subId = "rl_${peerPubkey.take(8)}"
+        val filter = Filter(kinds = listOf(10002), authors = listOf(peerPubkey), limit = 1)
+        val reqMsg = ClientMessage.req(subId, filter)
+        for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+            pool.sendToRelayOrEphemeral(url, reqMsg, skipBadCheck = true)
+        }
+        pool.sendToAll(reqMsg)
+
+        val result = withTimeoutOrNull(4000L) {
+            pool.relayEvents.first { it.subscriptionId == subId }
+        }
+
+        val closeMsg = ClientMessage.close(subId)
+        for (url in RelayConfig.DEFAULT_INDEXER_RELAYS) {
+            pool.sendToRelay(url, closeMsg)
+        }
+        pool.sendToAll(closeMsg)
+
+        if (result != null) repo.updateFromEvent(result.event)
+    }
+
+    private suspend fun sendToDeliveryRelays(
+        pool: RelayPool,
+        deliveryRelays: List<String>,
+        message: String
+    ): Set<String> {
+        for (url in deliveryRelays) pool.markDmDeliveryTarget(url)
+        val sent = mutableSetOf<String>()
+        for (url in deliveryRelays) {
+            try {
+                if (pool.sendToRelayOrEphemeral(url, message, skipBadCheck = true)) {
+                    sent.add(url)
+                }
+            } catch (e: Exception) {
+                Log.w("NotifVM", "Failed to send DM to $url", e)
+            }
+        }
+        return sent
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -597,6 +597,7 @@ class StartupCoordinator(
      */
     fun subscribeDmsAndNotifications(myPubkey: String) {
         notifRepo.soundEligibleAfter = System.currentTimeMillis() / 1000
+        dmRepo.soundEligibleAfter = System.currentTimeMillis() / 1000
         val dmFilter = Filter(kinds = listOf(1059), pTags = listOf(myPubkey))
         val dmReqMsg = ClientMessage.req("dms", dmFilter)
         relayPool.sendToAll(dmReqMsg)
@@ -770,6 +771,7 @@ class StartupCoordinator(
     fun onAppPause() {
         Log.d("RLC", "[Startup] onAppPause — feedType=${feedSub.feedType.value} connectedCount=${relayPool.connectedCount.value}")
         notifRepo.appIsActive = false
+        dmRepo.appIsActive = false
         lifecycleManager.onAppPause()
     }
 
@@ -777,6 +779,7 @@ class StartupCoordinator(
     fun onAppResume(pausedMs: Long) {
         Log.d("RLC", "[Startup] onAppResume — paused ${pausedMs/1000}s, feedType=${feedSub.feedType.value} connectedCount=${relayPool.connectedCount.value}")
         notifRepo.appIsActive = true
+        dmRepo.appIsActive = true
         lifecycleManager.onAppResume(pausedMs)
     }
 


### PR DESCRIPTION
## Summary
- DMs now appear in the zen notifications feed alongside replies, reactions, zaps, and other types
- Incoming DMs trigger the ICQ flower animation and sound (same as replies), gated by `soundEligibleAfter`/`appIsActive` so historical DMs don't fire on app launch
- Expanding a DM shows the message content with an inline composer for quick replies
- Inline DM replies use full NIP-17 gift wrap encryption, send to recipient's DM relays (kind 10050) with fallback chain, send a self-copy to own DM/write relays, and apply proof-of-work when the user has it enabled
- DMs filter tab and 24h summary stat in the daily summary bar
- Background decryption of pending gift wraps for remote signer (Amber) mode so DM notifications appear without visiting the DM screen first

## Test plan
- [ ] Receive a DM while on any screen — ICQ flower animation + sound should play
- [ ] Open notifications tab — DM should appear with mail icon and "messaged you" text
- [ ] Tap DM notification — should expand showing message content and inline composer
- [ ] Send inline DM reply — message should encrypt and deliver correctly
- [ ] Filter by DMs tab — should show only DM notifications
- [ ] Verify 24h summary bar shows DM count
- [ ] Verify no sound on app launch from historical DMs
- [ ] Test with remote signer (Amber) — DMs should decrypt in background