### PR TITLE
feat: advanced search with author filter

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -37,6 +37,7 @@ import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.NostrUriData
 import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.nostr.ProfileData
 import com.wisp.app.nostr.LocalSigner
 import com.wisp.app.nostr.RemoteSigner
 import com.wisp.app.nostr.SignerIntentBridge
@@ -1044,7 +1045,17 @@ fun WispNavHost(
                 onPollVote = { pollId, optionIds -> feedViewModel.publishPollVote(pollId, optionIds) },
                 resolvedEmojis = profileResolvedEmojis,
                 unicodeEmojis = profileUnicodeEmojis,
-                onOpenEmojiLibrary = { showProfileEmojiLibrary = true }
+                onOpenEmojiLibrary = { showProfileEmojiLibrary = true },
+                onSearchAuthor = {
+                    val authorProfile = userProfileViewModel.profile.value
+                        ?: ProfileData(pubkey = pubkey, name = null, displayName = null, about = null, picture = null, nip05 = null, banner = null, lud16 = null, updatedAt = 0)
+                    searchViewModel.prepareAuthorSearch(authorProfile)
+                    navController.navigate(Routes.SEARCH) {
+                        popUpTo(Routes.FEED) { saveState = true }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
             )
             if (showProfileEmojiLibrary) {
                 com.wisp.app.ui.component.EmojiLibrarySheet(

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
@@ -1,5 +1,6 @@
 package com.wisp.app.ui.screen
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -20,6 +22,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
@@ -95,6 +99,10 @@ fun SearchScreen(
     val selectedRelayOption by viewModel.selectedRelayOption.collectAsState()
     val selectedRelayUrl by viewModel.selectedRelayUrl.collectAsState()
     val searchRelays by viewModel.searchRelays.collectAsState()
+    val authorFilter by viewModel.authorFilter.collectAsState()
+    val authorSearchResults by viewModel.authorSearchResults.collectAsState()
+    val isAuthorSearching by viewModel.isAuthorSearching.collectAsState()
+    var advancedExpanded by remember { mutableStateOf(authorFilter != null) }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -137,17 +145,55 @@ fun SearchScreen(
                 )
             }
 
-            // Relay selector
-            RelaySelector(
-                searchRelays = searchRelays,
-                selectedOption = selectedRelayOption,
-                selectedRelayUrl = selectedRelayUrl,
-                onSelectDefault = { viewModel.selectDefaultRelay() },
-                onSelectAllRelays = { viewModel.selectAllRelays() },
-                onSelectRelay = { viewModel.selectRelay(it) },
-                onAddRelay = { viewModel.addSearchRelay(it) },
-                onRemoveRelay = { viewModel.removeSearchRelay(it) }
-            )
+            // Advanced search toggle
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { advancedExpanded = !advancedExpanded }
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Advanced search",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Icon(
+                    if (advancedExpanded) Icons.Default.KeyboardArrowUp
+                    else Icons.Default.KeyboardArrowDown,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            AnimatedVisibility(visible = advancedExpanded) {
+                Column {
+                    RelaySelector(
+                        searchRelays = searchRelays,
+                        selectedOption = selectedRelayOption,
+                        selectedRelayUrl = selectedRelayUrl,
+                        onSelectDefault = { viewModel.selectDefaultRelay() },
+                        onSelectAllRelays = { viewModel.selectAllRelays() },
+                        onSelectRelay = { viewModel.selectRelay(it) },
+                        onAddRelay = { viewModel.addSearchRelay(it) },
+                        onRemoveRelay = { viewModel.removeSearchRelay(it) }
+                    )
+
+                    // Author filter (Notes only)
+                    if (filter == SearchFilter.NOTES) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        AuthorFilter(
+                            authorFilter = authorFilter,
+                            authorSearchResults = authorSearchResults,
+                            isAuthorSearching = isAuthorSearching,
+                            onSearchAuthors = { viewModel.searchAuthors(it, relayPool, eventRepo) },
+                            onSelectAuthor = { viewModel.setAuthorFilter(it) },
+                            onClearAuthor = { viewModel.clearAuthorFilter() }
+                        )
+                    }
+                }
+            }
 
             // Search bar
             Row(
@@ -434,6 +480,125 @@ private fun AddRelayDialog(
             }
         }
     )
+}
+
+@Composable
+private fun AuthorFilter(
+    authorFilter: ProfileData?,
+    authorSearchResults: List<ProfileData>,
+    isAuthorSearching: Boolean,
+    onSearchAuthors: (String) -> Unit,
+    onSelectAuthor: (ProfileData) -> Unit,
+    onClearAuthor: () -> Unit
+) {
+    var authorQuery by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        Text(
+            "Author",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+
+        if (authorFilter != null) {
+            // Show selected author
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                ProfilePicture(url = authorFilter.picture, size = 32)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = authorFilter.displayString,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                IconButton(
+                    onClick = onClearAuthor,
+                    modifier = Modifier.size(32.dp)
+                ) {
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = "Clear author",
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        } else {
+            // Author search input
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedTextField(
+                    value = authorQuery,
+                    onValueChange = { authorQuery = it },
+                    placeholder = { Text("Search for author") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(
+                        onSearch = { onSearchAuthors(authorQuery) }
+                    )
+                )
+                IconButton(onClick = { onSearchAuthors(authorQuery) }) {
+                    Icon(Icons.Default.Search, contentDescription = "Search authors")
+                }
+            }
+
+            // Author search results
+            if (isAuthorSearching) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            authorSearchResults.forEach { profile ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onSelectAuthor(profile)
+                            authorQuery = ""
+                        }
+                        .padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    ProfilePicture(url = profile.picture, size = 32)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = profile.displayString,
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        if (!profile.nip05.isNullOrBlank()) {
+                            Text(
+                                text = profile.nip05,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.QrCode2
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -148,7 +149,8 @@ fun UserProfileScreen(
     onPollVote: (String, List<String>) -> Unit = { _, _ -> },
     resolvedEmojis: Map<String, String> = emptyMap(),
     unicodeEmojis: List<String> = emptyList(),
-    onOpenEmojiLibrary: (() -> Unit)? = null
+    onOpenEmojiLibrary: (() -> Unit)? = null,
+    onSearchAuthor: (() -> Unit)? = null
 ) {
     val profile by viewModel.profile.collectAsState()
     val isFollowing by viewModel.isFollowing.collectAsState()
@@ -279,6 +281,11 @@ fun UserProfileScreen(
                 },
                 actions = {
                     val context = LocalContext.current
+                    if (onSearchAuthor != null) {
+                        IconButton(onClick = onSearchAuthor) {
+                            Icon(Icons.Default.Search, "Search notes")
+                        }
+                    }
                     IconButton(onClick = { showQrDialog = true }) {
                         Icon(Icons.Default.QrCode2, "QR Code")
                     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
@@ -46,6 +46,16 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
     private val _searchRelays = MutableStateFlow(keyRepo.getSearchRelays())
     val searchRelays: StateFlow<List<String>> = _searchRelays
 
+    // Author filter (for note search)
+    private val _authorFilter = MutableStateFlow<ProfileData?>(null)
+    val authorFilter: StateFlow<ProfileData?> = _authorFilter
+
+    private val _authorSearchResults = MutableStateFlow<List<ProfileData>>(emptyList())
+    val authorSearchResults: StateFlow<List<ProfileData>> = _authorSearchResults
+
+    private val _isAuthorSearching = MutableStateFlow(false)
+    val isAuthorSearching: StateFlow<Boolean> = _isAuthorSearching
+
     // Results
     private val _users = MutableStateFlow<List<ProfileData>>(emptyList())
     val users: StateFlow<List<ProfileData>> = _users
@@ -57,11 +67,13 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
     val isSearching: StateFlow<Boolean> = _isSearching
 
     private var searchJob: Job? = null
+    private var authorSearchJob: Job? = null
     private var relayPool: RelayPool? = null
     private var searchCounter = 0
 
     private var userSubId = "search-users-0"
     private var noteSubId = "search-notes-0"
+    private var authorSubId = "search-author-0"
 
     fun selectFilter(filter: SearchFilter) {
         _filter.value = filter
@@ -105,6 +117,81 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
         _query.value = newQuery
     }
 
+    fun setAuthorFilter(profile: ProfileData) {
+        _authorFilter.value = profile
+        _authorSearchResults.value = emptyList()
+    }
+
+    fun clearAuthorFilter() {
+        _authorFilter.value = null
+    }
+
+    fun prepareAuthorSearch(profile: ProfileData) {
+        _filter.value = SearchFilter.NOTES
+        _authorFilter.value = profile
+        _authorSearchResults.value = emptyList()
+    }
+
+    fun searchAuthors(query: String, relayPool: RelayPool, eventRepo: EventRepository) {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) {
+            _authorSearchResults.value = emptyList()
+            return
+        }
+
+        authorSearchJob?.cancel()
+        searchCounter++
+        authorSubId = "search-author-$searchCounter"
+        _isAuthorSearching.value = true
+        _authorSearchResults.value = emptyList()
+
+        val relaysToQuery = when (_selectedRelayOption.value) {
+            RelayOption.DEFAULT -> listOf(DEFAULT_SEARCH_RELAY)
+            RelayOption.ALL_RELAYS -> _searchRelays.value
+            RelayOption.INDIVIDUAL -> listOfNotNull(_selectedRelayUrl.value)
+        }
+
+        val authorFilter = Filter(kinds = listOf(0), search = trimmed, limit = 10)
+        val req = ClientMessage.req(authorSubId, authorFilter)
+        for (url in relaysToQuery) {
+            relayPool.sendToRelayOrEphemeral(url, req)
+        }
+
+        val activeSubId = authorSubId
+        val seenPubkeys = mutableSetOf<String>()
+
+        authorSearchJob = viewModelScope.launch {
+            val eventJob = launch {
+                relayPool.relayEvents.collect { relayEvent ->
+                    if (relayEvent.subscriptionId != activeSubId) return@collect
+                    val event = relayEvent.event
+                    if (event.kind == 0 && event.pubkey !in seenPubkeys) {
+                        seenPubkeys.add(event.pubkey)
+                        eventRepo.cacheEvent(event)
+                        val profile = ProfileData.fromEvent(event)
+                        if (profile != null) {
+                            _authorSearchResults.value = _authorSearchResults.value + profile
+                        }
+                    }
+                }
+            }
+
+            val eoseJob = launch {
+                relayPool.eoseSignals.collect { subId ->
+                    if (subId == activeSubId) {
+                        _isAuthorSearching.value = false
+                    }
+                }
+            }
+
+            delay(3000)
+            _isAuthorSearching.value = false
+            relayPool.closeOnAllRelays(activeSubId)
+            eventJob.cancel()
+            eoseJob.cancel()
+        }
+    }
+
     fun search(query: String, relayPool: RelayPool, eventRepo: EventRepository, muteRepo: MuteRepository? = null) {
         val trimmed = query.trim()
         if (trimmed.isEmpty()) {
@@ -143,7 +230,13 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
                 userSubId
             }
             SearchFilter.NOTES -> {
-                val noteFilter = Filter(kinds = listOf(1), search = trimmed, limit = 50)
+                val authorPubkey = _authorFilter.value?.pubkey
+                val noteFilter = Filter(
+                    kinds = listOf(1),
+                    authors = authorPubkey?.let { listOf(it) },
+                    search = trimmed,
+                    limit = 50
+                )
                 val noteReq = ClientMessage.req(noteSubId, noteFilter)
                 for (url in relaysToQuery) {
                     relayPool.sendToRelayOrEphemeral(url, noteReq)
@@ -203,11 +296,15 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
 
     fun clear() {
         searchJob?.cancel()
+        authorSearchJob?.cancel()
         relayPool?.let { closeSubscriptions(it) }
         _query.value = ""
         _users.value = emptyList()
         _notes.value = emptyList()
         _isSearching.value = false
+        _authorFilter.value = null
+        _authorSearchResults.value = emptyList()
+        _isAuthorSearching.value = false
     }
 
     companion object {
@@ -217,5 +314,6 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
     private fun closeSubscriptions(relayPool: RelayPool) {
         relayPool.closeOnAllRelays(userSubId)
         relayPool.closeOnAllRelays(noteSubId)
+        relayPool.closeOnAllRelays(authorSubId)
     }
 }


### PR DESCRIPTION
## Summary
- Moved search relay selector into a collapsible "Advanced search" section to reduce UI clutter
- Added author filter for note search — users can search for people inline and select one to filter notes by author
- Added search icon on profile screen top bar that navigates to search pre-filtered by that user, with advanced section auto-expanded

## Test plan
- [ ] Verify "Advanced search" section collapses/expands on both People and Notes tabs
- [ ] Verify relay selector works correctly inside the collapsed section
- [ ] Verify author search in Notes advanced settings finds and selects users
- [ ] Verify selected author filters note search results
- [ ] Verify search icon on profile page navigates to search with author pre-selected and advanced section open
- [ ] Verify clearing author filter works