### PR TITLE
feat: profile page sort feeds and followers tab

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 38
-        versionName = "0.10.1"
+        versionCode = 39
+        versionName = "0.11.0"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -29,14 +29,18 @@ import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.QrCode2
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -89,6 +93,7 @@ import com.wisp.app.ui.component.QrCodeDialog
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.component.RichContent
 import com.wisp.app.ui.component.ZapDialog
+import com.wisp.app.viewmodel.ProfileSortMode
 import com.wisp.app.viewmodel.UserProfileViewModel
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -244,11 +249,26 @@ fun UserProfileScreen(
         )
     }
 
+    val notesSortMode by viewModel.notesSortMode.collectAsState()
+    val repliesSortMode by viewModel.repliesSortMode.collectAsState()
+    val sortedNotes by viewModel.sortedNotes.collectAsState()
+    val sortedNotesLoading by viewModel.sortedNotesLoading.collectAsState()
+    val sortedReplies by viewModel.sortedReplies.collectAsState()
+    val sortedRepliesLoading by viewModel.sortedRepliesLoading.collectAsState()
+    val followers by viewModel.followers.collectAsState()
+    val followersLoading by viewModel.followersLoading.collectAsState()
+
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+    var showSortDropdown by remember { mutableStateOf(false) }
+
+    if (selectedTab == 4) {
+        LaunchedEffect(Unit) { viewModel.loadFollowers() }
+    }
+
     var blockedContentRevealed by remember { mutableStateOf(false) }
     var fullScreenMediaImageUrl by remember { mutableStateOf<String?>(null) }
     var fullScreenMediaVideoUrl by remember { mutableStateOf<String?>(null) }
-    val tabTitles = listOf("Notes", "Replies", "Media", "Following", "Relays")
+    val tabTitles = listOf("Notes", "Replies", "Media", "Following", "Followers", "Relays")
 
     if (fullScreenMediaImageUrl != null) {
         FullScreenImageViewer(
@@ -430,6 +450,54 @@ fun UserProfileScreen(
                 }
             }
 
+            if (selectedTab == 0 || selectedTab == 1) {
+                item {
+                    val currentSortMode = if (selectedTab == 0) notesSortMode else repliesSortMode
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surface)
+                            .padding(vertical = 6.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Box {
+                            Surface(
+                                onClick = { showSortDropdown = true },
+                                shape = RoundedCornerShape(20.dp),
+                                color = MaterialTheme.colorScheme.surfaceVariant
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(currentSortMode.label, style = MaterialTheme.typography.labelLarge)
+                                    Spacer(Modifier.width(2.dp))
+                                    Icon(Icons.Default.ArrowDropDown, contentDescription = "Sort", modifier = Modifier.size(16.dp))
+                                }
+                            }
+                            DropdownMenu(
+                                expanded = showSortDropdown,
+                                onDismissRequest = { showSortDropdown = false }
+                            ) {
+                                ProfileSortMode.entries.forEach { mode ->
+                                    DropdownMenuItem(
+                                        text = { Text(mode.label) },
+                                        onClick = {
+                                            showSortDropdown = false
+                                            if (selectedTab == 0) viewModel.setNotesSortMode(mode)
+                                            else viewModel.setRepliesSortMode(mode)
+                                        },
+                                        trailingIcon = if (currentSortMode == mode) {{
+                                            Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                                        }} else null
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             when (selectedTab) {
                 0 -> if (isBlocked && !blockedContentRevealed) {
                     item { BlockedContentOverlay(onReveal = { blockedContentRevealed = true }) }
@@ -490,10 +558,19 @@ fun UserProfileScreen(
                         }
                     }
 
-                    if (rootNotes.isEmpty() && pinnedEvents.isEmpty()) {
+                    val displayNotes = if (notesSortMode == ProfileSortMode.RECENCY) rootNotes else sortedNotes
+                    if (notesSortMode != ProfileSortMode.RECENCY && sortedNotes.isEmpty() && sortedNotesLoading) {
+                        item {
+                            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxWidth().padding(32.dp)) {
+                                CircularProgressIndicator()
+                            }
+                        }
+                    } else if (notesSortMode != ProfileSortMode.RECENCY && sortedNotes.isEmpty() && !sortedNotesLoading) {
+                        item { FeedCrawlingMessage() }
+                    } else if (displayNotes.isEmpty() && pinnedEvents.isEmpty()) {
                         item { EmptyTabContent("No notes yet") }
                     } else {
-                        items(items = rootNotes, key = { it.id }) { event ->
+                        items(items = displayNotes, key = { it.id }) { event ->
                             if (event.kind == 30023) {
                                 ProfileArticleCard(
                                     event = event,
@@ -587,7 +664,7 @@ fun UserProfileScreen(
                                 onOpenEmojiLibrary = onOpenEmojiLibrary
                             )
                         }
-                        if (rootNotes.isNotEmpty()) {
+                        if (rootNotes.isNotEmpty() && notesSortMode == ProfileSortMode.RECENCY) {
                             item {
                                 LoadMoreButton(onClick = { viewModel.loadMoreNotes() })
                             }
@@ -597,10 +674,19 @@ fun UserProfileScreen(
                 1 -> if (isBlocked && !blockedContentRevealed) {
                     item { BlockedContentOverlay(onReveal = { blockedContentRevealed = true }) }
                 } else {
-                    if (replies.isEmpty()) {
+                    val displayReplies = if (repliesSortMode == ProfileSortMode.RECENCY) replies else sortedReplies
+                    if (repliesSortMode != ProfileSortMode.RECENCY && sortedReplies.isEmpty() && sortedRepliesLoading) {
+                        item {
+                            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxWidth().padding(32.dp)) {
+                                CircularProgressIndicator()
+                            }
+                        }
+                    } else if (repliesSortMode != ProfileSortMode.RECENCY && sortedReplies.isEmpty() && !sortedRepliesLoading) {
+                        item { FeedCrawlingMessage() }
+                    } else if (displayReplies.isEmpty()) {
                         item { EmptyTabContent("No replies yet") }
                     } else {
-                        items(items = replies, key = { it.id }) { event ->
+                        items(items = displayReplies, key = { it.id }) { event ->
                             val likeCount = reactionVersion.let { eventRepo?.getReactionCount(event.id) ?: 0 }
                             val replyCount = replyCountVersion.let { eventRepo?.getReplyCount(event.id) ?: 0 }
                             val repostCount2 = repostVersion.let { eventRepo?.getRepostCount(event.id) ?: 0 }
@@ -679,8 +765,10 @@ fun UserProfileScreen(
                                 onOpenEmojiLibrary = onOpenEmojiLibrary
                             )
                         }
-                        item {
-                            LoadMoreButton(onClick = { viewModel.loadMoreReplies() })
+                        if (repliesSortMode == ProfileSortMode.RECENCY) {
+                            item {
+                                LoadMoreButton(onClick = { viewModel.loadMoreReplies() })
+                            }
                         }
                     }
                 }
@@ -717,6 +805,26 @@ fun UserProfileScreen(
                     }
                 }
                 4 -> {
+                    if (followersLoading && followers.isEmpty()) {
+                        item {
+                            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxWidth().padding(32.dp)) {
+                                CircularProgressIndicator()
+                            }
+                        }
+                    } else if (followers.isEmpty()) {
+                        item { EmptyTabContent("No followers found") }
+                    } else {
+                        items(items = followers, key = { it.pubkey }) { followerProfile ->
+                            FollowerRow(
+                                profile = followerProfile,
+                                isFollowing = myFollowList.any { it.pubkey == followerProfile.pubkey },
+                                onToggleFollow = { onToggleFollow?.invoke(followerProfile.pubkey) },
+                                onClick = { onNavigateToProfile?.invoke(followerProfile.pubkey) }
+                            )
+                        }
+                    }
+                }
+                5 -> {
                     if (relayList.isEmpty() && relayHints.isEmpty()) {
                         item { EmptyTabContent("No relay list published") }
                     } else {
@@ -1272,6 +1380,57 @@ private fun LoadMoreButton(onClick: () -> Unit) {
         OutlinedButton(onClick = onClick) {
             Text("Load More")
         }
+    }
+}
+
+@Composable
+private fun FollowerRow(
+    profile: ProfileData,
+    isFollowing: Boolean,
+    onToggleFollow: () -> Unit,
+    onClick: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+    ) {
+        ProfilePicture(url = profile.picture, size = 40)
+        Spacer(Modifier.width(12.dp))
+        Text(
+            text = profile.displayString,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+        Spacer(Modifier.width(8.dp))
+        FollowButton(isFollowing = isFollowing, onClick = onToggleFollow)
+    }
+}
+
+@Composable
+private fun FeedCrawlingMessage() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp, vertical = 40.dp)
+    ) {
+        Text(
+            text = "Still crawling or account too new",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = "No ranked results yet. Check back later.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/UserProfileViewModel.kt
@@ -25,11 +25,29 @@ import com.wisp.app.repo.KeyRepository
 import com.wisp.app.repo.RelayHintStore
 import com.wisp.app.repo.RelayListRepository
 import com.wisp.app.relay.SubscriptionManager
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+
+enum class ProfileSortMode(val label: String) {
+    RECENCY("Recent"),
+    LIKES("Likes"),
+    REPOSTS("Reposts"),
+    ZAPS("Zaps"),
+    REPLIES("Replies")
+}
+
+private fun ProfileSortMode.relaySlug() = when (this) {
+    ProfileSortMode.LIKES -> "likes"
+    ProfileSortMode.REPOSTS -> "reposts"
+    ProfileSortMode.ZAPS -> "zaps"
+    ProfileSortMode.REPLIES -> "replies"
+    ProfileSortMode.RECENCY -> error("No relay URL for recency")
+}
 
 class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
     private val keyRepo = KeyRepository(app)
@@ -71,6 +89,30 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
     private val _followProfileVersion = MutableStateFlow(0)
     val followProfileVersion: StateFlow<Int> = _followProfileVersion
 
+    private val _notesSortMode = MutableStateFlow(ProfileSortMode.RECENCY)
+    val notesSortMode: StateFlow<ProfileSortMode> = _notesSortMode
+
+    private val _repliesSortMode = MutableStateFlow(ProfileSortMode.RECENCY)
+    val repliesSortMode: StateFlow<ProfileSortMode> = _repliesSortMode
+
+    private val _sortedNotes = MutableStateFlow<List<NostrEvent>>(emptyList())
+    val sortedNotes: StateFlow<List<NostrEvent>> = _sortedNotes
+
+    private val _sortedNotesLoading = MutableStateFlow(false)
+    val sortedNotesLoading: StateFlow<Boolean> = _sortedNotesLoading
+
+    private val _sortedReplies = MutableStateFlow<List<NostrEvent>>(emptyList())
+    val sortedReplies: StateFlow<List<NostrEvent>> = _sortedReplies
+
+    private val _sortedRepliesLoading = MutableStateFlow(false)
+    val sortedRepliesLoading: StateFlow<Boolean> = _sortedRepliesLoading
+
+    private val _followers = MutableStateFlow<List<ProfileData>>(emptyList())
+    val followers: StateFlow<List<ProfileData>> = _followers
+
+    private val _followersLoading = MutableStateFlow(false)
+    val followersLoading: StateFlow<Boolean> = _followersLoading
+
     private var targetPubkey: String = ""
     private var eventRepoRef: EventRepository? = null
     private var relayPoolRef: RelayPool? = null
@@ -84,6 +126,12 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
     private var extendedNetworkRepoRef: ExtendedNetworkRepository? = null
     private var isLoadingMoreNotes = false
     private var isLoadingMoreReplies = false
+    private var profileFeedNotesGen = 0
+    private var profileFeedRepliesGen = 0
+    private var profileFollowersGen = 0
+    private var profileFeedNotesJob: Job? = null
+    private var profileFeedRepliesJob: Job? = null
+    private var profileFollowersJob: Job? = null
     // Track oldest event timestamps from the target user (kind 1/6) for pagination.
     // rootNotes contains repost inner events with different authors/timestamps,
     // so we track the user's own event timestamps separately.
@@ -121,6 +169,14 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
         latestProfileTimestamp = 0
         latestFollowListTimestamp = 0
         latestRelayListTimestamp = 0
+        _notesSortMode.value = ProfileSortMode.RECENCY
+        _repliesSortMode.value = ProfileSortMode.RECENCY
+        _sortedNotes.value = emptyList()
+        _sortedNotesLoading.value = false
+        _sortedReplies.value = emptyList()
+        _sortedRepliesLoading.value = false
+        _followers.value = emptyList()
+        _followersLoading.value = false
         _profile.value = eventRepo.getProfileData(pubkey)
         _relayHints.value = relayHintStore?.getHints(pubkey) ?: emptySet()
         _isFollowing.value = contactRepo.isFollowing(pubkey)
@@ -337,7 +393,10 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
         for (subId in activeEngagementSubIds) relayPool.closeOnAllRelays(subId)
         activeEngagementSubIds.clear()
 
-        val eventIds = (_rootNotes.value.map { it.id } + _replies.value.map { it.id }).distinct()
+        val eventIds = (_rootNotes.value.map { it.id } +
+            _replies.value.map { it.id } +
+            _sortedNotes.value.map { it.id } +
+            _sortedReplies.value.map { it.id }).distinct()
         if (eventIds.isEmpty()) return
 
         // All events belong to targetPubkey — route to their inbox relays
@@ -389,6 +448,12 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
             relayPool.closeOnAllRelays(subId)
         }
         activeEngagementSubIds.clear()
+        profileFeedNotesJob?.cancel()
+        profileFeedNotesJob = null
+        profileFeedRepliesJob?.cancel()
+        profileFeedRepliesJob = null
+        profileFollowersJob?.cancel()
+        profileFollowersJob = null
     }
 
     override fun onCleared() {
@@ -448,6 +513,165 @@ class UserProfileViewModel(app: Application) : AndroidViewModel(app) {
             pool.closeOnAllRelays("userreplies-more")
             isLoadingMoreReplies = false
         }
+    }
+
+    fun setNotesSortMode(mode: ProfileSortMode) {
+        _notesSortMode.value = mode
+        if (mode == ProfileSortMode.RECENCY) {
+            profileFeedNotesJob?.cancel()
+            profileFeedNotesJob = null
+            _sortedNotes.value = emptyList()
+            _sortedNotesLoading.value = false
+        } else {
+            val url = "wss://feeds.nostrarchives.com/profiles/root/${mode.relaySlug()}"
+            subscribeProfileRelayFeed(url, isReplies = false)
+        }
+    }
+
+    fun setRepliesSortMode(mode: ProfileSortMode) {
+        _repliesSortMode.value = mode
+        if (mode == ProfileSortMode.RECENCY) {
+            profileFeedRepliesJob?.cancel()
+            profileFeedRepliesJob = null
+            _sortedReplies.value = emptyList()
+            _sortedRepliesLoading.value = false
+        } else {
+            val url = "wss://feeds.nostrarchives.com/profiles/replies/${mode.relaySlug()}"
+            subscribeProfileRelayFeed(url, isReplies = true)
+        }
+    }
+
+    fun loadFollowers() {
+        val pool = relayPoolRef ?: return
+        if (_followersLoading.value && _followers.value.isNotEmpty()) return
+
+        profileFollowersJob?.cancel()
+        _followers.value = emptyList()
+        _followersLoading.value = true
+
+        val pubkey = targetPubkey
+        profileFollowersGen++
+        val gen = profileFollowersGen
+        val subId = "profile-followers-$gen"
+
+        profileFollowersJob = viewModelScope.launch {
+            val filter = Filter(kinds = listOf(0), authors = listOf(pubkey), limit = 500)
+            var connected = false
+            val url = "wss://feeds.nostrarchives.com/profiles/followers"
+            for (attempt in 0..2) {
+                if (profileFollowersGen != gen) { _followersLoading.value = false; return@launch }
+                if (attempt > 0) { pool.disconnectRelay(url); delay(1500L) }
+                pool.sendToRelayOrEphemeral(url, ClientMessage.req(subId, filter), skipBadCheck = true)
+                val deadline = System.currentTimeMillis() + 5_000
+                while (System.currentTimeMillis() < deadline) {
+                    if (profileFollowersGen != gen) { _followersLoading.value = false; return@launch }
+                    if (pool.isRelayConnected(url)) { connected = true; break }
+                    delay(200)
+                }
+                if (connected) break
+            }
+            if (!connected) { _followersLoading.value = false; return@launch }
+
+            val seenPubkeys = mutableSetOf<String>()
+            val collectJob = launch {
+                pool.relayEvents.collect { (event, _, subscriptionId) ->
+                    if (subscriptionId != subId) return@collect
+                    if (profileFollowersGen != gen) return@collect
+                    if (event.kind == 0 && seenPubkeys.add(event.pubkey)) {
+                        eventRepoRef?.cacheEvent(event)
+                        val profileData = ProfileData.fromEvent(event) ?: return@collect
+                        val current = _followers.value.toMutableList()
+                        current.add(profileData)
+                        _followers.value = current
+                    }
+                }
+            }
+
+            val sm = subManagerRef
+            if (sm != null) sm.awaitEoseCount(subId, 1)
+            else withTimeoutOrNull(15_000) { pool.eoseSignals.first { it == subId } }
+            collectJob.cancel()
+            pool.closeOnAllRelays(subId)
+            _followersLoading.value = false
+        }
+    }
+
+    private fun subscribeProfileRelayFeed(url: String, isReplies: Boolean) {
+        val pool = relayPoolRef ?: return
+        if (isReplies) {
+            profileFeedRepliesGen++
+            val gen = profileFeedRepliesGen
+            val subId = "profile-feed-replies-$gen"
+            profileFeedRepliesJob?.cancel()
+            _sortedReplies.value = emptyList()
+            _sortedRepliesLoading.value = true
+            profileFeedRepliesJob = viewModelScope.launch { runProfileFeedSub(pool, url, subId, gen, isReplies = true) }
+        } else {
+            profileFeedNotesGen++
+            val gen = profileFeedNotesGen
+            val subId = "profile-feed-notes-$gen"
+            profileFeedNotesJob?.cancel()
+            _sortedNotes.value = emptyList()
+            _sortedNotesLoading.value = true
+            profileFeedNotesJob = viewModelScope.launch { runProfileFeedSub(pool, url, subId, gen, isReplies = false) }
+        }
+    }
+
+    private suspend fun runProfileFeedSub(pool: RelayPool, url: String, subId: String, gen: Int, isReplies: Boolean) {
+        val genCheck = { if (isReplies) profileFeedRepliesGen == gen else profileFeedNotesGen == gen }
+        val setLoading = { v: Boolean -> if (isReplies) _sortedRepliesLoading.value = v else _sortedNotesLoading.value = v }
+        val pubkey = targetPubkey
+        val filter = Filter(kinds = listOf(1), authors = listOf(pubkey), limit = 100)
+
+        var connected = false
+        for (attempt in 0..2) {
+            if (!genCheck()) { setLoading(false); return }
+            if (attempt > 0) { pool.disconnectRelay(url); delay(1500L) }
+            pool.sendToRelayOrEphemeral(url, ClientMessage.req(subId, filter), skipBadCheck = true)
+            val deadline = System.currentTimeMillis() + 5_000
+            while (System.currentTimeMillis() < deadline) {
+                if (!genCheck()) { setLoading(false); return }
+                if (pool.isRelayConnected(url)) { connected = true; break }
+                delay(200)
+            }
+            if (connected) break
+        }
+        if (!connected) { setLoading(false); return }
+
+        val seenIds = mutableSetOf<String>()
+        val collectJob = viewModelScope.launch {
+            pool.relayEvents.collect { (event, _, subscriptionId) ->
+                if (subscriptionId != subId) return@collect
+                if (!genCheck()) return@collect
+                if (event.kind == 1 && seenIds.add(event.id)) {
+                    eventRepoRef?.cacheEvent(event)
+                    if (isReplies) {
+                        val current = _sortedReplies.value.toMutableList()
+                        current.add(event)
+                        _sortedReplies.value = current
+                    } else {
+                        val current = _sortedNotes.value.toMutableList()
+                        current.add(event)
+                        _sortedNotes.value = current
+                    }
+                }
+            }
+        }
+
+        // After 5 seconds with no events, stop showing the spinner so the empty message appears
+        val timeoutJob = viewModelScope.launch {
+            delay(5_000)
+            if (genCheck()) setLoading(false)
+        }
+
+        val sm = subManagerRef
+        if (sm != null) sm.awaitEoseCount(subId, 1)
+        else withTimeoutOrNull(15_000) { pool.eoseSignals.first { it == subId } }
+        collectJob.cancel()
+        timeoutJob.cancel()
+        setLoading(false)
+        pool.closeOnAllRelays(subId)
+        subscribeEngagementForProfile(pool)
     }
 
     fun toggleFollow(


### PR DESCRIPTION
## Summary
- Adds a sort dropdown (Recent / Likes / Reposts / Zaps / Replies) to the Notes and Replies tabs on profile pages, fetching ranked feeds from `feeds.nostrarchives.com/profiles/...` with the pubkey sent as an `authors` filter
- Adds a Followers tab that streams follower profiles from the same relay infrastructure
- Fetches engagement data (reactions, zaps, reposts, reply counts) after each sorted feed EOSE so counters populate correctly
- Shows a spinner while loading; after 5 seconds with no results displays a friendly "Still crawling or account too new — check back later" message
- Bumps version to 0.11.0

## Test plan
- [ ] Open a profile → Notes tab shows sort dropdown defaulting to "Recent"
- [ ] Select "Likes" → spinner appears, then ranked notes load with counters populated
- [ ] Switch back to "Recent" → original recency list restored
- [ ] Repeat for Replies tab
- [ ] Select a sort with no results → spinner shows for ~5s, then crawling message appears
- [ ] Open Followers tab → follower profiles stream in with follow buttons
- [ ] Tap a follower → navigates to their profile
- [ ] Relays tab still works (now at index 5)
- [ ] Navigate away and back → sort resets to Recent, followers reload on tab select

🤖 Generated with [Claude Code](https://claude.com/claude-code)