### PR TITLE
feat: drafts & scheduled posts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 39
-        versionName = "0.11.0"
+        versionCode = 40
+        versionName = "0.11.1"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -872,6 +872,12 @@ fun WispNavHost(
         composable(Routes.DRAFTS) {
             LaunchedEffect(Unit) {
                 draftsViewModel.loadDrafts(feedViewModel.relayPool, activeSigner)
+                draftsViewModel.loadScheduledPosts(feedViewModel.relayPool, activeSigner)
+            }
+            val profileVersion by feedViewModel.eventRepo.profileVersion.collectAsState()
+            val userPubkey = feedViewModel.getUserPubkey()
+            val userProfile = remember(userPubkey, profileVersion) {
+                userPubkey?.let { feedViewModel.eventRepo.getProfileData(it) }
             }
             DraftsScreen(
                 viewModel = draftsViewModel,
@@ -908,7 +914,11 @@ fun WispNavHost(
                 },
                 onDeleteDraft = { dTag ->
                     draftsViewModel.deleteDraft(dTag, feedViewModel.relayPool, activeSigner)
-                }
+                },
+                onDeleteScheduled = { eventId ->
+                    draftsViewModel.deleteScheduledPost(eventId, feedViewModel.relayPool, activeSigner)
+                },
+                userProfile = userProfile
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -84,6 +84,17 @@ class RelayPool {
         Log.d("RelayPool", "AUTH denied for ${request.relayUrl}")
     }
 
+    fun isAuthenticated(url: String): Boolean = url in authenticatedRelays
+
+    /**
+     * Pre-approve auth for a relay (e.g. scheduler relay) so that when it sends an AUTH
+     * challenge it is auto-signed without prompting the user. Must be called before connecting.
+     */
+    fun autoApproveRelayAuth(url: String) {
+        dmDeliveryTargets.add(url)
+        userApprovedAuthRelays.add(url)
+    }
+
     /**
      * Ensure the OkHttpClient matches the current Tor state.
      * If Tor was enabled/disabled since the client was built, rebuild it.
@@ -730,6 +741,27 @@ class RelayPool {
     /** Remove a tracked subscription for a relay. */
     private fun untrackSubscription(relayUrl: String, subId: String) {
         activeSubscriptions[relayUrl]?.remove(subId)
+    }
+
+    /**
+     * Open a connection to a relay without sending any messages — useful to trigger the AUTH
+     * handshake before sending an event that requires authentication.
+     */
+    fun connectEphemeralRelay(url: String) {
+        ensureClientCurrent()
+        if (url in blockedUrls) return
+        if (!RelayConfig.isConnectableUrl(url)) return
+        if (ephemeralRelays.containsKey(url) || relayIndex.containsKey(url)) return
+        if (ephemeralRelays.size >= MAX_EPHEMERAL) return
+        ephemeralRelays.computeIfAbsent(url) {
+            val relay = Relay(RelayConfig(url, read = true, write = false), client)
+            wireByteTracking(relay)
+            relayIndex[url] = relay
+            collectMessages(relay)
+            relay.connect()
+            relay
+        }
+        ephemeralLastUsed[url] = System.currentTimeMillis()
     }
 
     fun sendToRelayOrEphemeral(url: String, message: String, skipBadCheck: Boolean = false): Boolean {

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -349,7 +349,7 @@ fun WispDrawerContent(
         )
         NavigationDrawerItem(
             icon = { Icon(Icons.Outlined.Edit, contentDescription = null) },
-            label = { Text("Drafts") },
+            label = { Text("Drafts & Scheduled") },
             selected = false,
             onClick = onDrafts,
             modifier = Modifier.padding(horizontal = 12.dp)

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DraftsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DraftsScreen.kt
@@ -1,6 +1,8 @@
 package com.wisp.app.ui.screen
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,29 +10,47 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.wisp.app.nostr.Nip30
 import com.wisp.app.nostr.Nip37
+import com.wisp.app.nostr.NostrEvent
+import com.wisp.app.nostr.ProfileData
+import com.wisp.app.ui.component.ProfilePicture
+import com.wisp.app.ui.component.RichContent
+import com.wisp.app.ui.component.parseImetaTags
 import com.wisp.app.viewmodel.DraftsViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -42,14 +62,21 @@ fun DraftsScreen(
     viewModel: DraftsViewModel,
     onBack: () -> Unit,
     onDraftClick: (Nip37.Draft) -> Unit,
-    onDeleteDraft: (String) -> Unit
+    onDeleteDraft: (String) -> Unit,
+    onDeleteScheduled: (String) -> Unit,
+    userProfile: ProfileData? = null,
+    initialTab: Int = 0
 ) {
     val drafts by viewModel.drafts.collectAsState()
+    val scheduledPosts by viewModel.scheduledPosts.collectAsState()
+    val scheduledLoading by viewModel.scheduledLoading.collectAsState()
+
+    var selectedTab by remember { mutableIntStateOf(initialTab) }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Drafts") },
+                title = { Text("Drafts & Scheduled") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
@@ -61,79 +88,324 @@ fun DraftsScreen(
             )
         }
     ) { padding ->
-        if (drafts.isEmpty()) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .padding(32.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Spacer(Modifier.height(64.dp))
-                Text(
-                    "No drafts",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            TabRow(selectedTabIndex = selectedTab) {
+                Tab(
+                    selected = selectedTab == 0,
+                    onClick = { selectedTab = 0 },
+                    text = { Text("Drafts") },
+                    icon = { Icon(Icons.Outlined.Edit, contentDescription = null, modifier = Modifier.size(18.dp)) }
+                )
+                Tab(
+                    selected = selectedTab == 1,
+                    onClick = { selectedTab = 1 },
+                    text = { Text("Scheduled") },
+                    icon = { Icon(Icons.Outlined.Schedule, contentDescription = null, modifier = Modifier.size(18.dp)) }
                 )
             }
-        } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-            ) {
-                items(items = drafts, key = { it.dTag }) { draft ->
-                    val isReply = draft.tags.any { it.size >= 2 && it[0] == "e" }
-                    val preview = draft.content.take(100)
 
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onDraftClick(draft) }
-                            .padding(horizontal = 16.dp, vertical = 12.dp)
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            if (isReply) {
-                                Text(
-                                    text = "Reply",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.primary
-                                )
-                            }
-                            Text(
-                                text = preview.ifBlank { "(empty)" },
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                text = formatDraftTimestamp(draft.createdAt),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        Spacer(Modifier.width(8.dp))
-                        IconButton(onClick = { onDeleteDraft(draft.dTag) }) {
-                            Icon(
-                                Icons.Outlined.Close,
-                                contentDescription = "Delete draft",
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outline, thickness = 0.5.dp)
+            when (selectedTab) {
+                0 -> DraftsTab(
+                    drafts = drafts,
+                    userProfile = userProfile,
+                    onDraftClick = onDraftClick,
+                    onDeleteDraft = onDeleteDraft
+                )
+                1 -> ScheduledTab(
+                    posts = scheduledPosts,
+                    loading = scheduledLoading,
+                    userProfile = userProfile,
+                    onDelete = onDeleteScheduled
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DraftsTab(
+    drafts: List<Nip37.Draft>,
+    userProfile: ProfileData?,
+    onDraftClick: (Nip37.Draft) -> Unit,
+    onDeleteDraft: (String) -> Unit
+) {
+    if (drafts.isEmpty()) {
+        EmptyState(
+            icon = { Icon(Icons.Outlined.Edit, contentDescription = null, modifier = Modifier.size(48.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)) },
+            message = "No drafts saved"
+        )
+    } else {
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(items = drafts, key = { it.dTag }) { draft ->
+                DraftItem(
+                    draft = draft,
+                    userProfile = userProfile,
+                    onClick = { onDraftClick(draft) },
+                    onDelete = { onDeleteDraft(draft.dTag) }
+                )
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 0.5.dp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScheduledTab(
+    posts: List<NostrEvent>,
+    loading: Boolean,
+    userProfile: ProfileData?,
+    onDelete: (String) -> Unit
+) {
+    when {
+        loading && posts.isEmpty() -> {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+        posts.isEmpty() -> {
+            EmptyState(
+                icon = { Icon(Icons.Outlined.Schedule, contentDescription = null, modifier = Modifier.size(48.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)) },
+                message = "No scheduled posts"
+            )
+        }
+        else -> {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(items = posts, key = { it.id }) { post ->
+                    ScheduledPostItem(
+                        post = post,
+                        userProfile = userProfile,
+                        onDelete = { onDelete(post.id) }
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 0.5.dp)
                 }
             }
         }
     }
 }
 
-private val draftTimeFormat = SimpleDateFormat("MMM d, h:mm a", Locale.US)
+@Composable
+private fun DraftItem(
+    draft: Nip37.Draft,
+    userProfile: ProfileData?,
+    onClick: () -> Unit,
+    onDelete: () -> Unit
+) {
+    val isReply = draft.tags.any { it.size >= 2 && it[0] == "e" }
+    val displayName = userProfile?.displayString ?: "Draft"
+    val emojiMap = remember(draft.dTag) { emptyMap<String, String>() }
+    val imetaMap = remember(draft.dTag) { emptyMap<String, String>() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        // Header row — mirrors PostCard
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            ProfilePicture(url = userProfile?.picture)
+            Spacer(Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (!userProfile?.nip05.isNullOrBlank()) {
+                    Text(
+                        text = userProfile!!.nip05!!,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            if (isReply) {
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shape = RoundedCornerShape(4.dp)
+                ) {
+                    Text(
+                        text = "Reply",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp)
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+            }
+            Text(
+                text = formatDraftTimestamp(draft.createdAt),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
+            IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
+                Icon(
+                    Icons.Outlined.Close,
+                    contentDescription = "Delete draft",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+
+        Spacer(Modifier.height(6.dp))
+
+        // Note content — full RichContent
+        RichContent(
+            content = draft.content.ifBlank { "(empty)" },
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (draft.content.isBlank()) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.onSurface,
+            emojiMap = emojiMap,
+            imetaMap = imetaMap
+        )
+
+        Spacer(Modifier.height(4.dp))
+    }
+}
+
+@Composable
+private fun ScheduledPostItem(
+    post: NostrEvent,
+    userProfile: ProfileData?,
+    onDelete: () -> Unit
+) {
+    val displayName = remember(post.pubkey, userProfile?.displayString) {
+        userProfile?.displayString ?: (post.pubkey.take(8) + "…" + post.pubkey.takeLast(4))
+    }
+    val publishTime = post.created_at
+    val isFuture = publishTime > System.currentTimeMillis() / 1000
+    val emojiMap = remember(post.id) { Nip30.parseEmojiTags(post) }
+    val imetaMap = remember(post.id) { parseImetaTags(post) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        // Header row — mirrors PostCard
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            ProfilePicture(url = userProfile?.picture)
+            Spacer(Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (!userProfile?.nip05.isNullOrBlank()) {
+                    Text(
+                        text = userProfile!!.nip05!!,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            Spacer(Modifier.width(8.dp))
+            // Publish time badge in place of the timestamp
+            Surface(
+                color = if (isFuture) MaterialTheme.colorScheme.primaryContainer
+                        else MaterialTheme.colorScheme.errorContainer,
+                shape = RoundedCornerShape(4.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(3.dp)
+                ) {
+                    Icon(
+                        Icons.Outlined.AccessTime,
+                        contentDescription = null,
+                        modifier = Modifier.size(11.dp),
+                        tint = if (isFuture) MaterialTheme.colorScheme.onPrimaryContainer
+                               else MaterialTheme.colorScheme.onErrorContainer
+                    )
+                    Text(
+                        text = formatScheduledTime(publishTime),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (isFuture) MaterialTheme.colorScheme.onPrimaryContainer
+                                else MaterialTheme.colorScheme.onErrorContainer
+                    )
+                }
+            }
+            // Remove button
+            IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
+                Icon(
+                    Icons.Outlined.Close,
+                    contentDescription = "Remove from schedule",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+
+        Spacer(Modifier.height(6.dp))
+
+        // Note content — full RichContent just like PostCard
+        RichContent(
+            content = post.content,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            emojiMap = emojiMap,
+            imetaMap = imetaMap
+        )
+
+        Spacer(Modifier.height(4.dp))
+    }
+}
+
+@Composable
+private fun EmptyState(
+    icon: @Composable () -> Unit,
+    message: String
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        icon()
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+private val draftTimestampFormat = SimpleDateFormat("MMM d, h:mm a", Locale.US)
+private val scheduledSameDayFormat = SimpleDateFormat("h:mm a", Locale.US)
+private val scheduledDateFormat = SimpleDateFormat("MMM d, h:mm a", Locale.US)
 
 private fun formatDraftTimestamp(epoch: Long): String {
     if (epoch == 0L) return ""
-    return draftTimeFormat.format(Date(epoch * 1000))
+    return draftTimestampFormat.format(Date(epoch * 1000))
+}
+
+private fun formatScheduledTime(epoch: Long): String {
+    val date = Date(epoch * 1000)
+    val now = Date()
+    val todayCal = java.util.Calendar.getInstance().apply { time = now }
+    val targetCal = java.util.Calendar.getInstance().apply { time = date }
+    return if (todayCal.get(java.util.Calendar.DAY_OF_YEAR) == targetCal.get(java.util.Calendar.DAY_OF_YEAR) &&
+               todayCal.get(java.util.Calendar.YEAR) == targetCal.get(java.util.Calendar.YEAR)) {
+        scheduledSameDayFormat.format(date)
+    } else {
+        scheduledDateFormat.format(date)
+    }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -34,7 +34,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 private val NOSTR_URI_REGEX = Regex("nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+|note1[a-z0-9]{58}|nevent1[a-z0-9]+)")
 // Matches bare bech32 IDs not already preceded by "nostr:" or embedded in a URL
@@ -480,6 +482,14 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             val msg = ClientMessage.event(event)
             var sentCount = 0
             for (url in SCHEDULER_RELAYS) {
+                // Pre-approve auth so the relay auto-signs without prompting
+                relayPool.autoApproveRelayAuth(url)
+                // Connect without sending anything — relay will issue AUTH challenge on open
+                relayPool.connectEphemeralRelay(url)
+                // Wait for auth to complete before sending the EVENT (up to 5s)
+                withTimeoutOrNull(5_000) {
+                    relayPool.authCompleted.first { it == url }
+                }
                 if (relayPool.sendToRelayOrEphemeral(url, msg, skipBadCheck = true)) sentCount++
             }
             if (sentCount == 0) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/DraftsViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/DraftsViewModel.kt
@@ -5,32 +5,49 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.wisp.app.nostr.ClientMessage
 import com.wisp.app.nostr.Filter
+import com.wisp.app.nostr.Nip09
 import com.wisp.app.nostr.Nip37
+import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.NostrSigner
 import com.wisp.app.relay.RelayPool
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 class DraftsViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _drafts = MutableStateFlow<List<Nip37.Draft>>(emptyList())
     val drafts: StateFlow<List<Nip37.Draft>> = _drafts
 
-    private var loaded = false
-    private val subId = "drafts_${System.currentTimeMillis()}"
+    private val _scheduledPosts = MutableStateFlow<List<NostrEvent>>(emptyList())
+    val scheduledPosts: StateFlow<List<NostrEvent>> = _scheduledPosts
+
+    private val _scheduledLoading = MutableStateFlow(false)
+    val scheduledLoading: StateFlow<Boolean> = _scheduledLoading
+
+    private var draftsLoaded = false
+    private val draftsSubId = "drafts_${System.currentTimeMillis()}"
+    private var scheduledJob: Job? = null
+
+    companion object {
+        val SCHEDULER_RELAY = "wss://scheduler.nostrarchives.com"
+    }
 
     fun loadDrafts(relayPool: RelayPool, signer: NostrSigner?) {
-        if (loaded || signer == null) return
-        loaded = true
+        if (draftsLoaded || signer == null) return
+        draftsLoaded = true
 
         val filter = Filter(
             kinds = listOf(Nip37.KIND_DRAFT),
             authors = listOf(signer.pubkeyHex),
             limit = 50
         )
-        relayPool.sendToWriteRelays(ClientMessage.req(subId, filter))
+        relayPool.sendToWriteRelays(ClientMessage.req(draftsSubId, filter))
 
         viewModelScope.launch(Dispatchers.Default) {
             relayPool.events.collect { event ->
@@ -40,7 +57,6 @@ class DraftsViewModel(app: Application) : AndroidViewModel(app) {
                 try {
                     val decrypted = signer.nip44Decrypt(event.content, signer.pubkeyHex)
                     if (decrypted.isBlank()) {
-                        // Blank content = deletion — remove draft with this d-tag
                         val dTag = event.tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.get(1)
                         if (dTag != null) {
                             _drafts.value = _drafts.value.filter { it.dTag != dTag }
@@ -48,7 +64,6 @@ class DraftsViewModel(app: Application) : AndroidViewModel(app) {
                         return@collect
                     }
                     val draft = Nip37.parseDraft(event, decrypted) ?: return@collect
-                    // Replace existing draft with same d-tag, or add new
                     val current = _drafts.value.toMutableList()
                     val idx = current.indexOfFirst { it.dTag == draft.dTag }
                     if (idx >= 0) {
@@ -60,6 +75,74 @@ class DraftsViewModel(app: Application) : AndroidViewModel(app) {
                 } catch (_: Exception) {
                     // Decryption failed, skip
                 }
+            }
+        }
+    }
+
+    fun loadScheduledPosts(relayPool: RelayPool, signer: NostrSigner?) {
+        if (signer == null) return
+
+        // Cancel previous collector to avoid stacking up collectors on every screen visit
+        scheduledJob?.cancel()
+
+        // Only show spinner if we have nothing to display yet
+        if (_scheduledPosts.value.isEmpty()) _scheduledLoading.value = true
+
+        val subId = "scheduled_${System.currentTimeMillis()}"
+
+        scheduledJob = viewModelScope.launch(Dispatchers.Default) {
+            relayPool.autoApproveRelayAuth(SCHEDULER_RELAY)
+            relayPool.connectEphemeralRelay(SCHEDULER_RELAY)
+
+            val filter = Filter(
+                kinds = listOf(1),
+                authors = listOf(signer.pubkeyHex),
+                limit = 100
+            )
+
+            // Skip auth wait if relay is already authenticated from a previous load
+            if (!relayPool.isAuthenticated(SCHEDULER_RELAY)) {
+                withTimeoutOrNull(5_000) {
+                    relayPool.authCompleted.first { it == SCHEDULER_RELAY }
+                }
+            }
+            relayPool.sendToRelayOrEphemeral(SCHEDULER_RELAY, ClientMessage.req(subId, filter), skipBadCheck = true)
+
+            // Stop spinner after 10s if relay sends nothing
+            val timeoutJob = launch {
+                delay(10_000)
+                _scheduledLoading.value = false
+            }
+
+            relayPool.relayEvents.collect { relayEvent ->
+                if (relayEvent.relayUrl != SCHEDULER_RELAY) return@collect
+                if (relayEvent.subscriptionId != subId) return@collect
+                val event = relayEvent.event
+                if (event.kind != 1) return@collect
+                if (event.pubkey != signer.pubkeyHex) return@collect
+
+                timeoutJob.cancel()
+                _scheduledLoading.value = false
+                val current = _scheduledPosts.value.toMutableList()
+                if (current.none { it.id == event.id }) {
+                    current.add(event)
+                    _scheduledPosts.value = current.sortedBy { it.created_at }
+                }
+            }
+        }
+    }
+
+    fun deleteScheduledPost(eventId: String, relayPool: RelayPool, signer: NostrSigner?) {
+        if (signer == null) return
+        _scheduledPosts.value = _scheduledPosts.value.filter { it.id != eventId }
+
+        viewModelScope.launch(Dispatchers.Default) {
+            try {
+                val tags = Nip09.buildDeletionTags(eventId, 1)
+                val event = signer.signEvent(kind = 5, content = "", tags = tags)
+                relayPool.sendToRelayOrEphemeral(SCHEDULER_RELAY, ClientMessage.event(event), skipBadCheck = true)
+            } catch (_: Exception) {
+                // Best effort
             }
         }
     }
@@ -100,6 +183,10 @@ class DraftsViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun resetLoadState() {
-        loaded = false
+        draftsLoaded = false
+        scheduledJob?.cancel()
+        scheduledJob = null
+        _scheduledPosts.value = emptyList()
+        _scheduledLoading.value = false
     }
 }


### PR DESCRIPTION
## Summary
- Redesigns the Drafts screen as two tabs: **Drafts** and **Scheduled**, with the sidebar entry renamed to "Drafts & Scheduled"
- Scheduled posts are fetched from `wss://scheduler.nostrarchives.com` with NIP-42 auth handled automatically; the list refreshes on every screen visit so newly scheduled posts appear immediately
- Both drafts and scheduled posts render as full post cards (avatar, display name, NIP-05, `RichContent`) matching the feed — including inline images and rich text
- Scheduled post cards show a publish-time badge (e.g. "today at 3:00 PM") where the timestamp normally sits, and a remove button to send a kind-5 deletion to the scheduler relay
- Fixes an auth race condition when publishing to the scheduler relay: the client now connects first, waits for the AUTH handshake to complete, then sends the EVENT (previously the EVENT was sent before auth, causing silent rejection)
- Bumps version to 0.11.1 (versionCode 40)

## Test plan
- [ ] Navigate to Drafts & Scheduled from sidebar — two tabs visible
- [ ] Drafts tab shows existing drafts as post cards; tapping opens composer, X deletes
- [ ] Schedule a post from the compose screen; navigate to Scheduled tab — new post appears without needing to restart the app
- [ ] Scheduled post card shows correct publish time badge and renders content (links, images) correctly
- [ ] Tapping X on a scheduled post removes it from the list and sends deletion to scheduler relay
- [ ] Re-entering the screen fetches a fresh list each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)