### PR TITLE
fix: skip notifications for reactions/reposts/zaps on others' posts

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -77,6 +77,16 @@ class NotificationRepository(
             val pollEvent = pollId?.let { eventRepo?.getEvent(it) }
             if (pollEvent == null || pollEvent.pubkey != myPubkey) return
         }
+        // Reactions, reposts, and zaps: only notify if the referenced event is ours.
+        // A p-tag on these events can come from thread inheritance (the original note
+        // being reacted to was in a thread the user participated in), so a p-tag match
+        // alone is not sufficient. If the referenced event is cached and belongs to
+        // someone else, this is activity on another person's post — skip it.
+        if (event.kind == 6 || event.kind == 7 || event.kind == 9735) {
+            val referencedId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
+            val referencedEvent = referencedId?.let { eventRepo?.getEvent(it) }
+            if (referencedEvent != null && referencedEvent.pubkey != myPubkey) return
+        }
 
         synchronized(lock) {
             // Atomic check-then-put inside lock to prevent race when the same


### PR DESCRIPTION
## Summary

- Reactions (kind 7), reposts (kind 6), and zaps (kind 9735) that arrive via the `notif` subscription can carry the user's `#p` tag due to NIP-10 thread inheritance — if the user ever participated in a thread, subsequent activity in that thread p-tags them, so the relay correctly delivers it
- Previously, passing the p-tag check was treated as sufficient to add to notifications, causing unrelated activity on other people's posts to appear as the user's notifications
- Fix adds a check in `NotificationRepository.addEvent`: if the referenced event (via `#e` tag) is in cache and belongs to someone other than the user, the notification is dropped
- If the referenced event is not cached, the check is skipped to avoid dropping legitimate notifications for older posts

## Test plan

- [ ] Participate in a thread started by someone else, then have another user react to a post in that thread — verify no notification appears
- [ ] Have someone react to your own post — verify notification still appears
- [ ] Have someone repost your own post — verify notification still appears
- [ ] Have someone zap your own post — verify notification still appears
- [ ] Verify existing notification types (replies, mentions) are unaffected