### PR TITLE
fix: hashtag modal UX improvements

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -1745,9 +1745,8 @@ private fun HashtagPickerDialog(
     var confirmDeleteDTag by remember { mutableStateOf<String?>(null) }
     var showNewSetField by remember { mutableStateOf(false) }
     val newSetFocusRequester = remember { FocusRequester() }
-    // First set always expanded by default
     var expandedDTags by remember(sets.size) {
-        mutableStateOf(sets.firstOrNull()?.let { setOf(it.dTag) } ?: emptySet())
+        mutableStateOf(emptySet<String>())
     }
 
     AlertDialog(
@@ -1856,7 +1855,7 @@ private fun HashtagPickerDialog(
                                             }
                                         )
                                 )
-                                if (isExpanded && set.hashtags.isNotEmpty()) {
+                                if (set.hashtags.isNotEmpty()) {
                                     TextButton(
                                         onClick = { onViewSetFeed(set) },
                                         modifier = Modifier.heightIn(min = 32.dp),
@@ -1947,7 +1946,7 @@ private fun HashtagPickerDialog(
                                 }
                             }
                         }
-                        Spacer(Modifier.size(8.dp))
+                        Spacer(Modifier.size(6.dp))
                     }
                 }
                 if (showNewSetField) {


### PR DESCRIPTION
## Summary
- All sets collapsed by default (previously first set was auto-expanded)
- Feed button always visible on sets with hashtags — no need to expand first
- Reduced spacing between sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)