### PR TITLE
fix: ensure self-data always loads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 40
-        versionName = "0.11.1"
+        versionCode = 41
+        versionName = "0.11.2"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayConfig.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayConfig.kt
@@ -31,9 +31,10 @@ data class RelayConfig(
 
         /** Fallback indexer relays used when the user hasn't configured search relays (kind 10007). */
         val DEFAULT_INDEXER_RELAYS = listOf(
-            "wss://purplepag.es",
             "wss://indexer.coracle.social",
             "wss://relay.nos.social",
+            "wss://nos.lol",
+            "wss://indexer.nostrarchives.com",
             "wss://relay.damus.io",
             "wss://relay.primal.net"
         )

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -208,6 +208,9 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
             if (myPubkey != null) startup.subscribeDmsAndNotifications(myPubkey)
             if (force) {
                 startup.fetchRelayListsForFollows()
+                // After a long pause, NIP-51 lists (bookmarks, hashtag sets, media servers, etc.)
+                // may be stale. Re-fetch self-data so they're up to date.
+                startup.refreshSelfData()
             }
         }
     )

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -392,9 +392,16 @@ class StartupCoordinator(
                 feedSub._initLoadingState.value = InitLoadingState.WarmLoading
 
                 relayPool.awaitAnyConnected(minCount = minOf(3, relayCount), timeoutMs = 5_000)
-                // Fire-and-forget self-data refresh
+                // Fire-and-forget self-data refresh — catch exceptions so a self-data failure
+                // does not prevent DM and notification subscriptions from being set up.
                 launch {
-                    subscribeSelfData()
+                    try {
+                        subscribeSelfData()
+                    } catch (e: Exception) {
+                        Log.e("StartupCoord", "subscribeSelfData failed on warm start, ensuring DMs/notifs are subscribed", e)
+                        val pk = getUserPubkey()
+                        if (pk != null) subscribeDmsAndNotifications(pk)
+                    }
                     fetchMissingEmojiSets()
                 }
 
@@ -460,19 +467,22 @@ class StartupCoordinator(
             Filter(kinds = listOf(Nip30.KIND_USER_EMOJI_LIST), authors = listOf(myPubkey), limit = 1),
             Filter(kinds = listOf(Nip30.KIND_EMOJI_SET), authors = listOf(myPubkey), limit = 50)
         )
-        // Send to all indexer relays (ephemeral if not already connected) —
-        // these are the most reliable sources for user metadata on first launch.
+        // Send to indexer relays (ephemeral if not already connected) AND the user's own
+        // write relays — write relays are the authoritative source since the user published
+        // directly there. Indexers may lag or be unreachable for some users.
         val indexerRelays = RelayConfig.DEFAULT_INDEXER_RELAYS
+        val writeRelayUrls = relayPool.getWriteRelayUrls()
+        val selfDataRelays = (indexerRelays + writeRelayUrls).distinct()
         val reqMsg = ClientMessage.req("self-data", selfDataFilters)
-        for (url in indexerRelays) {
+        for (url in selfDataRelays) {
             relayPool.sendToRelayOrEphemeral(url, reqMsg)
         }
 
-        // Wait for indexer relays to EOSE so we get the newest kind 3 (follow list).
+        // Wait for relays to EOSE so we get the newest kind 3 (follow list).
         // contactRepo.updateFromEvent already keeps the newest by created_at, so collecting
         // from several relays ensures we don't proceed with a stale follow list from
         // a single fast relay.
-        val eoseCount = subManager.awaitEoseCount("self-data", expectedCount = indexerRelays.size, timeoutMs = 4_000)
+        val eoseCount = subManager.awaitEoseCount("self-data", expectedCount = selfDataRelays.size, timeoutMs = 4_000)
 
         // EOSE and events travel on separate SharedFlows, so the kind 3 event may still
         // be buffered in relayEvents waiting for the processing loop on Dispatchers.Default.
@@ -786,6 +796,21 @@ class StartupCoordinator(
     fun refreshDmsAndNotifications() {
         val pk = getUserPubkey() ?: return
         subscribeDmsAndNotifications(pk)
+    }
+
+    /**
+     * Re-fetch self-data (NIP-51 lists, follow list, relay lists, etc.) in the background.
+     * Called after a long pause (force reconnect) to ensure lists like bookmarks, hashtag
+     * sets, and media servers are refreshed — they are not re-fetched by subscribeDmsAndNotifications.
+     */
+    fun refreshSelfData() {
+        scope.launch {
+            try {
+                subscribeSelfData()
+            } catch (e: Exception) {
+                Log.e("StartupCoord", "refreshSelfData failed", e)
+            }
+        }
     }
 
     fun refreshRelays() {


### PR DESCRIPTION
## Summary
- Self-data subscription now also targets the user's own write relays in addition to hardcoded indexers — write relays are authoritative (the user published directly there); indexers can lag or be unreachable for some users, causing NIP-51 lists to silently fail to load
- On force reconnect (30s+ background pause), `refreshSelfData()` is now called so bookmarks, hashtag sets, and media servers are re-fetched — previously only DM/notification subscriptions were refreshed, leaving NIP-51 data stale
- Warm-start fire-and-forget `subscribeSelfData()` is now wrapped in try/catch so an exception cannot silently skip setting up DM and notification subscriptions
- Update `DEFAULT_INDEXER_RELAYS`: remove `purplepag.es`, add `nos.lol` and `indexer.nostrarchives.com`
- Bump version to 0.11.2 (41)

## Test plan
- [ ] Cold start: follow list, bookmarks, hashtag sets, media servers all load correctly
- [ ] Warm start: same lists load after returning to app
- [ ] Background 30s+, resume: NIP-51 lists (bookmarks, hashtag sets) are present and not empty
- [ ] Notifications show only activity on your own posts (no random thread noise)
- [ ] User with slow/unreachable indexers still loads self-data via write relays

🤖 Generated with [Claude Code](https://claude.com/claude-code)