### PR TITLE
fix: apply mute/block safety filters to hashtag and search feeds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 41
-        versionName = "0.11.2"
+        versionCode = 42
+        versionName = "0.11.3"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1332,7 +1332,8 @@ fun WispNavHost(
                     tag = tag,
                     relayPool = feedViewModel.relayPool,
                     eventRepo = feedViewModel.eventRepo,
-                    topRelayUrls = feedViewModel.getScoredRelays().take(10).map { it.url }
+                    topRelayUrls = feedViewModel.getScoredRelays().take(10).map { it.url },
+                    muteRepo = feedViewModel.muteRepo
                 )
             }
             val hashtagNoteActions = remember {
@@ -1423,7 +1424,8 @@ fun WispNavHost(
                     name = name,
                     relayPool = feedViewModel.relayPool,
                     eventRepo = feedViewModel.eventRepo,
-                    topRelayUrls = feedViewModel.getScoredRelays().take(10).map { it.url }
+                    topRelayUrls = feedViewModel.getScoredRelays().take(10).map { it.url },
+                    muteRepo = feedViewModel.muteRepo
                 )
             }
             val setFeedNoteActions = remember {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/HashtagFeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/HashtagFeedViewModel.kt
@@ -9,11 +9,14 @@ import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.EventRepository
+import com.wisp.app.repo.MuteRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -33,6 +36,7 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
     private var relayPoolRef: RelayPool? = null
     private var eventRepoRef: EventRepository? = null
     private var loadJob: Job? = null
+    private var muteObserverJob: Job? = null
     private val activeSubIds = mutableListOf<String>()
     private var topRelayUrls: List<String> = emptyList()
     private var loadCounter = 0
@@ -43,10 +47,11 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
         tag: String,
         relayPool: RelayPool,
         eventRepo: EventRepository,
-        topRelayUrls: List<String> = emptyList()
+        topRelayUrls: List<String> = emptyList(),
+        muteRepo: MuteRepository? = null
     ) {
         _setName.value = null
-        loadTags(listOf(tag), tag, relayPool, eventRepo, topRelayUrls)
+        loadTags(listOf(tag), tag, relayPool, eventRepo, topRelayUrls, muteRepo)
     }
 
     fun loadHashtags(
@@ -54,10 +59,11 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
         name: String,
         relayPool: RelayPool,
         eventRepo: EventRepository,
-        topRelayUrls: List<String> = emptyList()
+        topRelayUrls: List<String> = emptyList(),
+        muteRepo: MuteRepository? = null
     ) {
         _setName.value = name
-        loadTags(tags, tags.firstOrNull() ?: "", relayPool, eventRepo, topRelayUrls)
+        loadTags(tags, tags.firstOrNull() ?: "", relayPool, eventRepo, topRelayUrls, muteRepo)
     }
 
     private fun loadTags(
@@ -65,7 +71,8 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
         displayTag: String,
         relayPool: RelayPool,
         eventRepo: EventRepository,
-        topRelayUrls: List<String> = emptyList()
+        topRelayUrls: List<String> = emptyList(),
+        muteRepo: MuteRepository? = null
     ) {
         if (tags.isEmpty()) return
 
@@ -78,6 +85,15 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
         relayPoolRef = relayPool
         eventRepoRef = eventRepo
         this.topRelayUrls = topRelayUrls
+
+        muteObserverJob?.cancel()
+        if (muteRepo != null) {
+            muteObserverJob = muteRepo.blockedPubkeys
+                .onEach { blocked ->
+                    _notes.value = _notes.value.filter { it.pubkey !in blocked }
+                }
+                .launchIn(viewModelScope)
+        }
 
         loadCounter++
         noteSub = "hashtag-notes-$loadCounter"
@@ -93,6 +109,8 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
                     if (relayEvent.subscriptionId == currentNoteSub) {
                         val event = relayEvent.event
                         if (event.kind == 1 && event.id !in seenIds) {
+                            if (muteRepo?.isBlocked(event.pubkey) == true) return@collect
+                            if (muteRepo?.containsMutedWord(event.content) == true) return@collect
                             seenIds.add(event.id)
                             eventRepo.cacheEvent(event)
                             eventRepo.requestProfileIfMissing(event.pubkey)
@@ -174,6 +192,7 @@ class HashtagFeedViewModel(app: Application) : AndroidViewModel(app) {
     override fun onCleared() {
         super.onCleared()
         loadJob?.cancel()
+        muteObserverJob?.cancel()
         relayPoolRef?.let { closeAllSubs(it) }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
@@ -269,6 +269,7 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
                             val event = relayEvent.event
                             if (event.kind == 1 && event.id !in seenNoteIds) {
                                 if (muteRepo?.isBlocked(event.pubkey) == true) return@collect
+                                if (muteRepo?.containsMutedWord(event.content) == true) return@collect
                                 seenNoteIds.add(event.id)
                                 _notes.value = _notes.value + event
                                 eventRepo.cacheEvent(event)


### PR DESCRIPTION
## Summary
- Hashtag feeds now filter out notes from blocked users and notes containing muted words
- Search note results now also check muted words (blocked user check already existed)
- Blocking a user from the hashtag feed immediately removes their notes via `blockedPubkeys` StateFlow observation — no reload needed
- Bumps version to 0.11.3

## Test plan
- [ ] Mute a word, open a hashtag feed — notes containing that word should not appear
- [ ] Block a user, open a hashtag feed — their notes should not appear
- [ ] Block a user directly from the hashtag feed — their notes should disappear instantly
- [ ] Search notes — blocked users and muted words should be filtered from results