### PR TITLE
fix: restore relay self-reconnect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 42
-        versionName = "0.11.3"
+        versionCode = 43
+        versionName = "0.11.4"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -2,9 +2,13 @@ package com.wisp.app.relay
 
 import android.util.Log
 import com.wisp.app.nostr.RelayMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -12,32 +16,42 @@ import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 
 data class RelayFailure(val relayUrl: String, val httpCode: Int?, val message: String)
 
 class Relay(
     val config: RelayConfig,
     private val client: OkHttpClient,
+    private val scope: CoroutineScope? = null
 ) {
     @Volatile private var webSocket: WebSocket? = null
     private val connectLock = Any()
     @Volatile var isConnected = false
         private set
+    var autoReconnect = true
+    /** Set to false when app is backgrounded to suppress reconnect attempts. */
+    @Volatile var reconnectEnabled = true
     @Volatile var cooldownUntil: Long = 0L
 
+    // Connection attempt tracking for automatic backoff
+    private val connectAttempts = mutableListOf<Long>()
+    private val attemptLock = Any()
+
     companion object {
-        const val INITIAL_RECONNECT_DELAY_MS = 1_000L
-        const val MAX_RECONNECT_DELAY_MS = 5 * 60_000L
-        /** Minimum time a connection must stay open before its backoff is considered reset. */
-        private const val STABLE_CONNECTION_MS = 10_000L
+        private const val ATTEMPT_WINDOW_MS = 60_000L       // Track attempts in the last 60s
+        private const val MAX_ATTEMPTS_IN_WINDOW = 20        // Threshold before backing off
+        private const val BACKOFF_COOLDOWN_MS = 5 * 60_000L  // 5 min cooldown when threshold hit
+
+        /** Shared scheduler for non-blocking reconnect delays (avoids blocking OkHttp dispatcher threads). */
+        private val reconnectScheduler = Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "relay-reconnect").apply { isDaemon = true }
+        }
 
         fun createClient(): OkHttpClient = HttpClientFactory.createRelayClient()
     }
-
-    @Volatile var reconnectDelayMs: Long = INITIAL_RECONNECT_DELAY_MS
-        private set
-    @Volatile var lastAttemptMs: Long = 0L
-        private set
 
     private val sendLock = Any()
     private val pendingMessages = ConcurrentLinkedQueue<String>()
@@ -64,24 +78,36 @@ class Relay(
     var onBytesReceived: ((url: String, size: Int) -> Unit)? = null
     var onBytesSent: ((url: String, size: Int) -> Unit)? = null
 
-    /**
-     * Called synchronously on OkHttp's thread at the start of onOpen, before drainPendingMessages.
-     * Use to immediately resend subscriptions so they hit the wire within the relay's idle-timeout
-     * window (some uWebSockets-based relays drop connections that send nothing within ~150ms).
-     */
-    var onConnected: (() -> Unit)? = null
-
     fun connect() {
         synchronized(connectLock) {
             if (isConnected || webSocket != null) return
 
+            // Check if we're in a cooldown period
             val now = System.currentTimeMillis()
             if (now < cooldownUntil) {
                 Log.d("Relay", "Skipping connect to ${config.url} — cooled down for ${(cooldownUntil - now) / 1000}s more")
                 return
             }
 
-            lastAttemptMs = now
+            // Track this attempt and check for excessive reconnections
+            synchronized(attemptLock) {
+                connectAttempts.add(now)
+                // Prune old attempts outside the window
+                connectAttempts.removeAll { now - it > ATTEMPT_WINDOW_MS }
+                if (connectAttempts.size >= MAX_ATTEMPTS_IN_WINDOW) {
+                    cooldownUntil = now + BACKOFF_COOLDOWN_MS
+                    connectAttempts.clear()
+                    Log.w("Relay", "Too many connection attempts to ${config.url} " +
+                        "(${MAX_ATTEMPTS_IN_WINDOW} in ${ATTEMPT_WINDOW_MS / 1000}s), " +
+                        "backing off for ${BACKOFF_COOLDOWN_MS / 1000 / 60} min")
+                    _connectionErrors.tryEmit(ConsoleLogEntry(
+                        relayUrl = config.url,
+                        type = ConsoleLogType.CONN_FAILURE,
+                        message = "Too many reconnect attempts — cooling off for ${BACKOFF_COOLDOWN_MS / 1000 / 60} min"
+                    ))
+                    return
+                }
+            }
 
             val request = try {
                 Request.Builder()
@@ -98,19 +124,16 @@ class Relay(
                 Log.d("TorRelay", "[Relay] connect() .onion relay: ${config.url} proxy=${client.proxy} connectTimeout=${client.connectTimeoutMillis}ms")
             }
             webSocket = client.newWebSocket(request, object : WebSocketListener() {
-                var openedAtMs = 0L
-
                 override fun onOpen(webSocket: WebSocket, response: Response) {
                     Log.d("RLC", "[Relay] ws#$socketId onOpen ${config.url} | isConnected was=$isConnected")
                     if (config.url.contains(".onion")) {
                         Log.d("TorRelay", "[Relay] .onion connection SUCCESS: ${config.url}")
                     }
-                    openedAtMs = System.currentTimeMillis()
                     isConnected = true
-                    lastAttemptMs = 0L
-                    onConnected?.invoke()
-                    drainPendingMessages(webSocket)
+                    // Successful connection — reset attempt tracking
+                    synchronized(attemptLock) { connectAttempts.clear() }
                     _connectionState.tryEmit(true)
+                    drainPendingMessages(webSocket)
                 }
 
                 override fun onMessage(webSocket: WebSocket, text: String) {
@@ -136,23 +159,21 @@ class Relay(
                             this@Relay.webSocket = null
                         }
                     }
+                    // Only emit state/errors and reconnect for the current WebSocket.
+                    // Stale callbacks from a replaced socket must not wipe the new socket's state.
                     if (isCurrent) {
-                        val now = System.currentTimeMillis()
-                        lastAttemptMs = now
-                        val connectedDurationMs = if (openedAtMs > 0) now - openedAtMs else 0L
-                        reconnectDelayMs = if (connectedDurationMs >= STABLE_CONNECTION_MS) {
-                            INITIAL_RECONNECT_DELAY_MS  // Was stable — reset backoff
-                        } else {
-                            minOf(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS)  // Fast fail — back off
-                        }
-                        openedAtMs = 0L
                         _connectionState.tryEmit(false)
-                        _connectionErrors.tryEmit(ConsoleLogEntry(
-                            relayUrl = config.url,
-                            type = ConsoleLogType.CONN_FAILURE,
-                            message = t.message ?: t.javaClass.simpleName
-                        ))
-                        _failures.tryEmit(RelayFailure(config.url, response?.code, t.message ?: t.javaClass.simpleName))
+                        // Suppress error emissions during force reconnect — disconnect()
+                        // triggers onFailure for the torn-down socket, flooding the console.
+                        if (reconnectEnabled) {
+                            _connectionErrors.tryEmit(ConsoleLogEntry(
+                                relayUrl = config.url,
+                                type = ConsoleLogType.CONN_FAILURE,
+                                message = t.message ?: t.javaClass.simpleName
+                            ))
+                            _failures.tryEmit(RelayFailure(config.url, response?.code, t.message ?: t.javaClass.simpleName))
+                        }
+                        reconnect()
                     }
                 }
 
@@ -166,24 +187,16 @@ class Relay(
                         }
                     }
                     if (isCurrent) {
-                        val now = System.currentTimeMillis()
-                        val connectedDurationMs = if (openedAtMs > 0) now - openedAtMs else 0L
-                        openedAtMs = 0L
                         _connectionState.tryEmit(false)
-                        if (code == 1000) {
-                            reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS  // Clean close — reset backoff
-                        } else {
-                            lastAttemptMs = now
-                            reconnectDelayMs = if (connectedDurationMs >= STABLE_CONNECTION_MS) {
-                                INITIAL_RECONNECT_DELAY_MS
-                            } else {
-                                minOf(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS)
+                        if (code != 1000) {
+                            if (reconnectEnabled) {
+                                _connectionErrors.tryEmit(ConsoleLogEntry(
+                                    relayUrl = config.url,
+                                    type = ConsoleLogType.CONN_CLOSED,
+                                    message = "Code $code: $reason"
+                                ))
                             }
-                            _connectionErrors.tryEmit(ConsoleLogEntry(
-                                relayUrl = config.url,
-                                type = ConsoleLogType.CONN_CLOSED,
-                                message = "Code $code: $reason"
-                            ))
+                            reconnect()
                         }
                     }
                 }
@@ -191,31 +204,18 @@ class Relay(
         }
     }
 
-    /** Returns true if this relay is disconnected and enough time has passed to attempt reconnection. */
-    fun needsReconnect(): Boolean {
-        if (isConnected || webSocket != null) return false
-        val now = System.currentTimeMillis()
-        return now >= cooldownUntil && now >= lastAttemptMs + reconnectDelayMs
-    }
-
-    /** Calls connect() only if the relay needs reconnection. */
-    fun connectIfNeeded() {
-        if (needsReconnect()) connect()
-    }
-
     fun send(message: String): Boolean {
         val ws = webSocket
         if (ws != null && isConnected) {
             onBytesSent?.invoke(config.url, message.length)
+            // Serialize all writes — OkHttp's WebSocket writer is not thread-safe.
+            // Also prevents cancel() (which acquires sendLock) from racing with send().
             synchronized(sendLock) {
                 return ws.send(message)
             }
         }
-        // REQ subscriptions are never queued — resyncSubscriptions re-sends them on
-        // reconnect via activeSubscriptions. Queueing REQs would cause drainPendingMessages
-        // and resyncSubscriptions to both fire the same REQ on reconnect, causing duplicate
-        // subscriptions and server-side errors.
-        if (!message.startsWith("[\"REQ\"") && pendingMessages.size < maxPendingMessages) {
+        // Queue message for delivery when connected
+        if (pendingMessages.size < maxPendingMessages) {
             pendingMessages.add(message)
         }
         return false
@@ -255,11 +255,15 @@ class Relay(
             Log.d("RLC", "[Relay] disconnect() ${config.url} | wasConnected=$wasConnected hasSocket=${ws != null}")
             isConnected = false
             webSocket = null
+            pendingReconnect?.cancel(false)
+            pendingReconnect = null
+            pendingReconnectJob?.cancel()
+            pendingReconnectJob = null
+            // Acquire sendLock before cancel() to ensure no in-flight send() or
+            // drainPendingMessages() is using the WebSocket when we tear it down.
+            // Without this, cancel() can null OkHttp's internal writer mid-send → NPE.
             if (ws != null) {
-                // Graceful close — sends WebSocket CLOSE frame so the server knows
-                // we're leaving cleanly. Avoids RST-then-SYN storms on big relays
-                // that were actively streaming events when we backgrounded.
-                synchronized(sendLock) { ws.close(1001, null) }
+                synchronized(sendLock) { ws.cancel() }
             }
         }
     }
@@ -272,6 +276,10 @@ class Relay(
             val ws = webSocket
             isConnected = false
             webSocket = null
+            pendingReconnect?.cancel(false)
+            pendingReconnect = null
+            pendingReconnectJob?.cancel()
+            pendingReconnectJob = null
             if (ws != null) {
                 synchronized(sendLock) { ws.cancel() }
             }
@@ -281,8 +289,31 @@ class Relay(
     /** Reset backoff state — call when user explicitly reconnects */
     fun resetBackoff() {
         cooldownUntil = 0L
-        reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
-        lastAttemptMs = 0L
+        synchronized(attemptLock) { connectAttempts.clear() }
+    }
+
+    @Volatile private var pendingReconnect: ScheduledFuture<*>? = null
+    @Volatile private var pendingReconnectJob: Job? = null
+
+    private fun reconnect() {
+        if (!autoReconnect || !reconnectEnabled) return
+        if (scope != null) {
+            pendingReconnectJob?.cancel()
+            pendingReconnectJob = scope.launch {
+                val now = System.currentTimeMillis()
+                val delayMs = maxOf(3000L, cooldownUntil - now)
+                delay(delayMs)
+                if (!isConnected) connect()
+            }
+        } else {
+            // Fallback for relays created without a scope — use scheduler instead of
+            // blocking a thread from the shared OkHttp dispatcher pool
+            val now = System.currentTimeMillis()
+            val delayMs = maxOf(3000L, cooldownUntil - now)
+            pendingReconnect = reconnectScheduler.schedule({
+                if (!isConnected) connect()
+            }, delayMs, TimeUnit.MILLISECONDS)
+        }
     }
 
 }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -110,7 +110,10 @@ class RelayPool {
     @Volatile var appIsActive = false
         set(value) {
             field = value
-            if (value) startReconnectSweep() else stopReconnectSweep()
+            // Suppress/enable auto-reconnect on all relays based on app state.
+            // When backgrounded, relays that drop shouldn't waste resources retrying —
+            // onAppResume handles reconnection.
+            setReconnectEnabled(value)
         }
     /** True while reconnectAll/forceReconnectAll is in progress — guards health tracker
      *  from recording disconnect churn as real failures. */
@@ -244,7 +247,7 @@ class RelayPool {
         val existingUrls = relays.map { it.config.url }.toSet()
         for (config in filtered) {
             if (config.url !in existingUrls) {
-                val relay = Relay(config, client)
+                val relay = Relay(config, client, scope)
                 wireByteTracking(relay)
                 relays.add(relay)
                 relayIndex[config.url] = relay
@@ -269,7 +272,7 @@ class RelayPool {
         val existingUrls = dmRelays.map { it.config.url }.toSet()
         for (url in filtered) {
             if (url !in existingUrls) {
-                val relay = Relay(RelayConfig(url, read = true, write = true), client)
+                val relay = Relay(RelayConfig(url, read = true, write = true), client, scope)
                 wireByteTracking(relay)
                 dmRelays.add(relay)
                 relayIndex[url] = relay
@@ -294,26 +297,11 @@ class RelayPool {
         }
     }
 
-    private var reconnectSweepJob: Job? = null
-
-    private fun startReconnectSweep() {
-        reconnectSweepJob?.cancel()
-        reconnectSweepJob = scope.launch {
-            while (appIsActive) {
-                delay(3_000)
-                if (appIsActive) {
-                    for (relay in relays) relay.connectIfNeeded()
-                    for (relay in dmRelays) relay.connectIfNeeded()
-                    // Ephemeral relays are NOT swept — they're recreated on demand
-                }
-            }
-        }
-    }
-
-    private fun stopReconnectSweep() {
-        reconnectSweepJob?.cancel()
-        reconnectSweepJob = null
-        Log.d("RLC", "[Pool] reconnect sweep stopped (app backgrounded)")
+    private fun setReconnectEnabled(enabled: Boolean) {
+        for (relay in relays) relay.reconnectEnabled = enabled
+        for (relay in dmRelays) relay.reconnectEnabled = enabled
+        for (relay in ephemeralRelays.values.toList()) relay.reconnectEnabled = enabled
+        if (!enabled) Log.d("RLC", "[Pool] auto-reconnect suppressed (app backgrounded)")
     }
 
     private fun cancelRelayJobs(url: String) {
@@ -324,7 +312,6 @@ class RelayPool {
         val parentJob = SupervisorJob()
         relayJobs[relay.config.url]?.cancel()
         relayJobs[relay.config.url] = parentJob
-        relay.onConnected = { resyncSubscriptions(relay) }
 
         scope.launch(parentJob) {
             relay.messages.collect { msg ->
@@ -439,6 +426,10 @@ class RelayPool {
                 Log.d("RLC", "[Pool] connectionState=$connected for ${relay.config.url} | relay.isConnected=${relay.isConnected} appIsActive=$appIsActive isReconnecting=$isReconnecting")
                 updateConnectedCount()
                 if (connected) {
+                    // Always resync regardless of appIsActive — relays that connect
+                    // during the awaitAnyConnected window (before appIsActive=true)
+                    // would otherwise miss their subscriptions entirely.
+                    resyncSubscriptions(relay)
                     if (appIsActive && !isReconnecting) healthTracker?.onRelayConnected(relay.config.url)
                 } else {
                     if (appIsActive && !isReconnecting) healthTracker?.closeSession(relay.config.url)
@@ -754,7 +745,8 @@ class RelayPool {
         if (ephemeralRelays.containsKey(url) || relayIndex.containsKey(url)) return
         if (ephemeralRelays.size >= MAX_EPHEMERAL) return
         ephemeralRelays.computeIfAbsent(url) {
-            val relay = Relay(RelayConfig(url, read = true, write = false), client)
+            val relay = Relay(RelayConfig(url, read = true, write = false), client, scope)
+            relay.autoReconnect = false
             wireByteTracking(relay)
             relayIndex[url] = relay
             collectMessages(relay)
@@ -818,7 +810,8 @@ class RelayPool {
         var isNew = false
         val ephemeral = ephemeralRelays.computeIfAbsent(url) {
             isNew = true
-            val relay = Relay(RelayConfig(url, read = true, write = false), client)
+            val relay = Relay(RelayConfig(url, read = true, write = false), client, scope)
+            relay.autoReconnect = false
             wireByteTracking(relay)
             relayIndex[url] = relay
             collectMessages(relay)
@@ -879,13 +872,18 @@ class RelayPool {
             Log.d("RLC", "[Pool] resync ${relay.config.url}: no tracked subscriptions")
             return
         }
-        if (subs.isEmpty()) {
+        // Snapshot to avoid ConcurrentModificationException — reconnectAll can clear
+        // activeSubscriptions on a different thread while we iterate here.
+        val snapshot = try { subs.entries.toList() } catch (e: Exception) {
+            Log.w("RLC", "[Pool] resync ${relay.config.url}: snapshot failed (concurrent modification)")
+            return
+        }
+        if (snapshot.isEmpty()) {
             Log.d("RLC", "[Pool] resync ${relay.config.url}: 0 subscriptions (empty map)")
             return
         }
-        val subIds = subs.keys.toList()
-        Log.d("RLC", "[Pool] resync ${relay.config.url}: sending ${subIds.size} subs: $subIds")
-        for ((_, message) in subs) {
+        Log.d("RLC", "[Pool] resync ${relay.config.url}: sending ${snapshot.size} subs: ${snapshot.map { it.key }}")
+        for ((_, message) in snapshot) {
             relay.send(message)
         }
     }
@@ -922,15 +920,17 @@ class RelayPool {
             relay.disconnect()
             subscriptionTracker.untrackRelay(relay.config.url)
             relay.connect()
+            relay.reconnectEnabled = true
         }
         for (relay in dmRelays) {
             relay.resetBackoff()
             relay.disconnect()
             subscriptionTracker.untrackRelay(relay.config.url)
             relay.connect()
+            relay.reconnectEnabled = true
         }
         // Evict ALL ephemeral relays — they'll be recreated on demand.
-        // Even "connected" ephemerals may be stale.
+        // Even "connected" ephemerals may be stale and have autoReconnect=false.
         for ((url, relay) in ephemeralRelays) {
             relay.disconnect()
             relayIndex.remove(url)
@@ -964,14 +964,18 @@ class RelayPool {
         // Tear down and reconnect persistent relays
         for (relay in relays) {
             relay.resetBackoff()
+            relay.reconnectEnabled = false  // Suppress onFailure errors from disconnect()
             relay.disconnect()
             relay.connect()
+            relay.reconnectEnabled = true
         }
         // Tear down and reconnect DM relays
         for (relay in dmRelays) {
             relay.resetBackoff()
+            relay.reconnectEnabled = false  // Suppress onFailure errors from disconnect()
             relay.disconnect()
             relay.connect()
+            relay.reconnectEnabled = true
         }
         // Evict all ephemeral relays — they'll be recreated on demand
         for ((url, relay) in ephemeralRelays) {
@@ -1050,7 +1054,8 @@ class RelayPool {
         if (!RelayConfig.isConnectableUrl(url)) return
         if (ephemeralRelays.containsKey(url)) return
         if (ephemeralRelays.size >= MAX_EPHEMERAL) return
-        val relay = Relay(RelayConfig(url, read = true, write = false), client)
+        val relay = Relay(RelayConfig(url, read = true, write = false), client, scope)
+        relay.autoReconnect = false
         wireByteTracking(relay)
         relayIndex[url] = relay
         collectMessages(relay)

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayProber.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayProber.kt
@@ -106,6 +106,7 @@ object RelayProber {
         for (bootstrapUrl in BOOTSTRAP) {
             try {
                 val relay = Relay(RelayConfig(bootstrapUrl, read = true, write = false), client)
+                relay.autoReconnect = false
                 relay.connect()
 
                 val connected = withTimeoutOrNull(5000L) {
@@ -230,6 +231,7 @@ object RelayProber {
         // Ephemeral write test: connect, send kind 20242, await OK
         return try {
             val relay = Relay(RelayConfig(url, read = true, write = true), wsClient)
+            relay.autoReconnect = false
             relay.connect()
 
             val connected = withTimeoutOrNull(PROBE_TIMEOUT_MS) {

--- a/app/src/main/kotlin/com/wisp/app/repo/NwcRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NwcRepository.kt
@@ -107,7 +107,7 @@ class NwcRepository(private val context: Context, private val relayPool: RelayPo
         scope = newScope
 
         val client = Relay.createClient()
-        val r = Relay(RelayConfig(conn.relayUrl), client)
+        val r = Relay(RelayConfig(conn.relayUrl), client, scope = newScope)
         relay = r
 
         emitStatus("Connecting to relay ${conn.relayUrl}...")

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -413,6 +413,7 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         val timeoutMs = if (isTor) 15_000L else 4_000L
         val client = HttpClientFactory.createRelayClient()
         val relay = Relay(RelayConfig(url, read = true, write = false), client)
+        relay.autoReconnect = false
         return try {
             relay.connect()
             val connected = relay.awaitConnected(timeoutMs = timeoutMs)


### PR DESCRIPTION
## Summary
- Restore the original relay self-reconnect model where each Relay handles its own reconnection via `onFailure`/`onClosed` callbacks, replacing the external 3s polling sweep introduced in 9526fdf
- The external sweep caused race conditions leading to notification contamination (irrelevant notes appearing) and general slowness
- Fix pre-existing `ConcurrentModificationException` in `resyncSubscriptions` by snapshotting entries before iteration
- Bump version to 0.11.4 (43)

## Test plan
- [ ] Verify relays reconnect automatically after temporary disconnection
- [ ] Verify notifications only show relevant tagged notes
- [ ] Verify app resume from background reconnects cleanly without thrashing
- [ ] Verify ephemeral relays do not auto-reconnect
- [ ] Verify no `ConcurrentModificationException` crashes on reconnect