### PR TITLE
feat: diagnostic logger for notification pipeline

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 43
-        versionName = "0.11.4"
+        versionCode = 44
+        versionName = "0.11.5"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,5 +41,14 @@
                 <data android:scheme="nostr" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/app/src/main/kotlin/com/wisp/app/WispApp.kt
+++ b/app/src/main/kotlin/com/wisp/app/WispApp.kt
@@ -11,6 +11,7 @@ import coil3.request.crossfade
 import com.wisp.app.db.WispObjectBox
 import com.wisp.app.relay.HttpClientFactory
 import com.wisp.app.relay.TorManager
+import com.wisp.app.repo.DiagnosticLogger
 import com.wisp.app.repo.ZapSender
 import okhttp3.Call
 
@@ -19,6 +20,7 @@ class WispApp : Application(), SingletonImageLoader.Factory {
     override fun onCreate() {
         super.onCreate()
         CrashHandler.install(this)
+        DiagnosticLogger.init(this)
         WispObjectBox.init(this)
         TorManager.initialize(this)
         ZapSender.init(this)

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -3,6 +3,7 @@ package com.wisp.app.relay
 import android.util.Log
 import android.util.LruCache
 import com.wisp.app.nostr.ClientMessage
+import com.wisp.app.repo.DiagnosticLogger
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.RelayMessage
 import com.wisp.app.nostr.RelayMessage.Auth
@@ -410,6 +411,11 @@ class RelayPool {
                             type = ConsoleLogType.NOTICE,
                             message = "CLOSED [${msg.subscriptionId}]: ${msg.message}"
                         ))
+                        if (DiagnosticLogger.isEnabled &&
+                            (msg.subscriptionId.startsWith("notif") || msg.subscriptionId == "dms")) {
+                            DiagnosticLogger.log("CLOSED", "sub=${msg.subscriptionId} relay=${relay.config.url} " +
+                                "msg=${msg.message}")
+                        }
                         if (appIsActive && isRateLimitMessage(msg.message)) {
                             healthTracker?.onRateLimitHit(relay.config.url)
                         }
@@ -883,6 +889,9 @@ class RelayPool {
             return
         }
         Log.d("RLC", "[Pool] resync ${relay.config.url}: sending ${snapshot.size} subs: ${snapshot.map { it.key }}")
+        if (DiagnosticLogger.isEnabled) {
+            DiagnosticLogger.log("RESYNC", "relay=${relay.config.url} subs=${snapshot.map { it.key }}")
+        }
         for ((_, message) in snapshot) {
             relay.send(message)
         }
@@ -943,6 +952,10 @@ class RelayPool {
         isReconnecting = false
         val total = relays.size + dmRelays.size
         Log.d("RLC", "[Pool] reconnectAll() END — reconnected $total relays, activeSubs remaining=${activeSubscriptions.size}")
+        if (DiagnosticLogger.isEnabled) {
+            val retainedSubs = activeSubscriptions.values.flatMap { it.keys }.distinct()
+            DiagnosticLogger.log("RECONNECT", "reconnectAll completed — $total relays, retainedSubs=$retainedSubs")
+        }
         updateConnectedCount()
         return total
     }
@@ -987,6 +1000,9 @@ class RelayPool {
         ephemeralLastUsed.clear()
         isReconnecting = false
         Log.d("RLC", "[Pool] forceReconnectAll() END — all subs/trackers cleared")
+        if (DiagnosticLogger.isEnabled) {
+            DiagnosticLogger.log("RECONNECT", "forceReconnectAll completed — all subs cleared")
+        }
         updateConnectedCount()
     }
 

--- a/app/src/main/kotlin/com/wisp/app/repo/DiagnosticLogger.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/DiagnosticLogger.kt
@@ -1,0 +1,89 @@
+package com.wisp.app.repo
+
+import android.content.Context
+import android.util.Log
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Zero-cost diagnostic file logger. All hot-path calls check [isEnabled] first —
+ * when disabled, no string formatting, object allocation, or disk I/O occurs.
+ *
+ * Activated by long-pressing the version string in Interface settings 5 times.
+ * Logs are written to app-internal storage and can be shared via ACTION_SEND.
+ */
+object DiagnosticLogger {
+    @Volatile var isEnabled: Boolean = false
+
+    private var writer: BufferedWriter? = null
+    private val lock = Any()
+    private const val MAX_SIZE = 512 * 1024L  // 512KB
+    private const val LOG_FILE_NAME = "wisp_diagnostic.log"
+    private val dateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+
+    fun init(context: Context) {
+        isEnabled = context.getSharedPreferences("wisp_settings", Context.MODE_PRIVATE)
+            .getBoolean("diagnostic_mode", false)
+        if (isEnabled) openWriter(context)
+    }
+
+    fun log(tag: String, msg: String) {
+        if (!isEnabled) return
+        synchronized(lock) {
+            try {
+                writer?.appendLine("[${dateFormat.format(Date())}] $tag: $msg")
+                writer?.flush()
+            } catch (e: Exception) {
+                Log.w("DiagLogger", "Write failed: ${e.message}")
+            }
+        }
+    }
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        context.getSharedPreferences("wisp_settings", Context.MODE_PRIVATE)
+            .edit().putBoolean("diagnostic_mode", enabled).apply()
+        isEnabled = enabled
+        if (enabled) {
+            openWriter(context)
+            log("DIAG", "Diagnostic logging enabled")
+        } else {
+            synchronized(lock) {
+                try { writer?.close() } catch (_: Exception) {}
+                writer = null
+            }
+        }
+    }
+
+    fun getLogFile(context: Context): File {
+        return File(context.filesDir, LOG_FILE_NAME)
+    }
+
+    fun clear(context: Context) {
+        synchronized(lock) {
+            try { writer?.close() } catch (_: Exception) {}
+            writer = null
+            getLogFile(context).delete()
+            if (isEnabled) openWriter(context)
+        }
+    }
+
+    private fun openWriter(context: Context) {
+        synchronized(lock) {
+            try {
+                val file = getLogFile(context)
+                // Rotate if over max size
+                if (file.exists() && file.length() > MAX_SIZE) {
+                    val backup = File(context.filesDir, "$LOG_FILE_NAME.old")
+                    file.renameTo(backup)
+                }
+                writer = BufferedWriter(FileWriter(getLogFile(context), true))
+            } catch (e: Exception) {
+                Log.w("DiagLogger", "Failed to open log file: ${e.message}")
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -552,6 +552,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     fun getEvent(id: String): NostrEvent? = eventCache.get(id)
 
+    fun getCacheSize(): Int = eventCache.size()
+
     fun bumpEventCacheVersion() { _eventCacheVersion.value++ }
 
     fun getProfileData(pubkey: String): ProfileData? = profileRepo?.get(pubkey)

--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -65,12 +65,19 @@ class NotificationRepository(
     private val _notifReceived = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val notifReceived: SharedFlow<Unit> = _notifReceived
 
-    fun addEvent(event: NostrEvent, myPubkey: String, replyToMyEvent: Boolean = false) {
+    fun addEvent(event: NostrEvent, myPubkey: String, replyToMyEvent: Boolean = false, source: String = "") {
         if (event.pubkey == myPubkey) return
         val hasPTag = event.tags.any { it.size >= 2 && it[0] == "p" && it[1] == myPubkey }
         // Kind 6 reposts may omit the p-tag; callers must pre-filter kind 6 ownership.
         // replyToMyEvent bypasses p-tag check for kind 1 replies found via e-tag subscription.
-        if (!hasPTag && event.kind != 6 && event.kind != Nip88.KIND_POLL_RESPONSE && !(replyToMyEvent && event.kind == 1)) return
+        if (!hasPTag && event.kind != 6 && event.kind != Nip88.KIND_POLL_RESPONSE && !(replyToMyEvent && event.kind == 1)) {
+            if (DiagnosticLogger.isEnabled) {
+                DiagnosticLogger.log("NOTIF", "REJECTED:no_ptag id=${event.id.take(12)} kind=${event.kind} " +
+                    "pubkey=${event.pubkey.take(8)} myPubkey=${myPubkey.take(8)} source=$source " +
+                    "hasPTag=false replyToMyEvent=$replyToMyEvent")
+            }
+            return
+        }
         // Kind 1018 poll votes: only notify if the poll is ours
         if (event.kind == Nip88.KIND_POLL_RESPONSE) {
             val pollId = Nip88.getPollEventId(event)
@@ -85,7 +92,13 @@ class NotificationRepository(
         if (event.kind == 6 || event.kind == 7 || event.kind == 9735) {
             val referencedId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
             val referencedEvent = referencedId?.let { eventRepo?.getEvent(it) }
-            if (referencedEvent != null && referencedEvent.pubkey != myPubkey) return
+            if (referencedEvent != null && referencedEvent.pubkey != myPubkey) {
+                if (DiagnosticLogger.isEnabled) {
+                    DiagnosticLogger.log("NOTIF", "REJECTED:not_our_event id=${event.id.take(12)} kind=${event.kind} " +
+                        "refId=${referencedId?.take(12)} refOwner=${referencedEvent.pubkey.take(8)} source=$source")
+                }
+                return
+            }
         }
 
         synchronized(lock) {
@@ -107,6 +120,26 @@ class NotificationRepository(
                 else -> false
             }
             if (!merged) return
+
+            if (DiagnosticLogger.isEnabled) {
+                val ownershipStatus = if (event.kind in intArrayOf(6, 7, 9735)) {
+                    val refId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
+                    val refEvent = refId?.let { eventRepo?.getEvent(it) }
+                    when {
+                        refEvent?.pubkey == myPubkey -> "cached_ours"
+                        refEvent != null -> "cached_others"
+                        else -> "not_cached"
+                    }
+                } else "n/a"
+                val logMsg = "ACCEPTED id=${event.id.take(12)} kind=${event.kind} " +
+                    "pubkey=${event.pubkey.take(8)} source=$source " +
+                    "hasPTag=$hasPTag ownership=$ownershipStatus"
+                DiagnosticLogger.log("NOTIF", logMsg)
+                if (!hasPTag) {
+                    DiagnosticLogger.log("CANARY", "accepted_without_ptag id=${event.id.take(12)} " +
+                        "kind=${event.kind} source=$source replyToMyEvent=$replyToMyEvent")
+                }
+            }
 
             if (event.created_at > lastReadTimestamp) {
                 if (isViewing) {
@@ -658,6 +691,8 @@ class NotificationRepository(
             else -> null
         }
     }
+
+    fun getSeenEventsSize(): Int = seenEvents.size()
 
     companion object {
         private const val KEY_LAST_READ = "last_read_timestamp"

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -52,6 +53,10 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
+import android.content.Intent
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.FileProvider
+import com.wisp.app.repo.DiagnosticLogger
 import com.wisp.app.repo.InterfacePreferences
 import com.wisp.app.ui.theme.ThemePreset
 import com.wisp.app.ui.theme.Themes
@@ -362,6 +367,102 @@ fun InterfaceScreen(
                         interfacePrefs.setClientTagEnabled(it)
                     }
                 )
+            }
+
+            Spacer(Modifier.height(32.dp))
+
+            // Version — long-press 5 times to reveal diagnostic mode
+            val context = LocalContext.current
+            val versionName = remember {
+                try {
+                    context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "?"
+                } catch (_: Exception) { "?" }
+            }
+            var tapCount by remember { mutableIntStateOf(0) }
+            var diagnosticRevealed by remember { mutableStateOf(DiagnosticLogger.isEnabled) }
+            var diagnosticEnabled by remember { mutableStateOf(DiagnosticLogger.isEnabled) }
+
+            Text(
+                text = "Wisp v$versionName",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        tapCount++
+                        if (tapCount >= 5) diagnosticRevealed = true
+                    }
+                    .padding(vertical = 8.dp)
+            )
+
+            if (diagnosticRevealed) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = "Diagnostics",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Diagnostic mode", style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            "Log event processing decisions to a file for debugging",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = diagnosticEnabled,
+                        onCheckedChange = {
+                            diagnosticEnabled = it
+                            DiagnosticLogger.setEnabled(context, it)
+                        }
+                    )
+                }
+
+                if (diagnosticEnabled) {
+                    Spacer(Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text(
+                            text = "Share logs",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier
+                                .clickable {
+                                    val logFile = DiagnosticLogger.getLogFile(context)
+                                    if (logFile.exists()) {
+                                        val uri = FileProvider.getUriForFile(
+                                            context,
+                                            "${context.packageName}.fileprovider",
+                                            logFile
+                                        )
+                                        val intent = Intent(Intent.ACTION_SEND).apply {
+                                            type = "text/plain"
+                                            putExtra(Intent.EXTRA_STREAM, uri)
+                                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                        }
+                                        context.startActivity(Intent.createChooser(intent, "Share diagnostic logs"))
+                                    }
+                                }
+                                .padding(vertical = 8.dp)
+                        )
+                        Text(
+                            text = "Clear logs",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier
+                                .clickable { DiagnosticLogger.clear(context) }
+                                .padding(vertical = 8.dp)
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -31,6 +31,7 @@ import com.wisp.app.repo.MetadataFetcher
 import com.wisp.app.repo.MuteRepository
 import com.wisp.app.repo.NotificationRepository
 import com.wisp.app.repo.PinRepository
+import com.wisp.app.repo.DiagnosticLogger
 import com.wisp.app.repo.RelayHintStore
 import com.wisp.app.repo.RelayListRepository
 import com.wisp.app.repo.RelaySetRepository
@@ -113,7 +114,7 @@ class EventRouter(
                     }
                     else -> eventRepo.cacheEvent(event)
                 }
-                notifRepo.addEvent(event, myPubkey)
+                notifRepo.addEvent(event, myPubkey, source = "notif")
                 if (eventRepo.getProfileData(event.pubkey) == null) {
                     metadataFetcher.addToPendingProfiles(event.pubkey)
                 }
@@ -131,7 +132,7 @@ class EventRouter(
                 eventRepo.cacheEvent(event)
                 val parentId = Nip10.getReplyTarget(event)
                 if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
-                notifRepo.addEvent(event, myPubkey, replyToMyEvent = true)
+                notifRepo.addEvent(event, myPubkey, replyToMyEvent = true, source = "notif-replies-etag")
                 if (eventRepo.getProfileData(event.pubkey) == null) {
                     metadataFetcher.addToPendingProfiles(event.pubkey)
                 }
@@ -141,7 +142,7 @@ class EventRouter(
             val myPubkey = getUserPubkey()
             if (myPubkey != null && event.kind == 1) {
                 eventRepo.cacheEvent(event)
-                notifRepo.addEvent(event, myPubkey)
+                notifRepo.addEvent(event, myPubkey, source = "notif-quotes-qtag")
                 if (eventRepo.getProfileData(event.pubkey) == null) {
                     metadataFetcher.addToPendingProfiles(event.pubkey)
                 }
@@ -213,7 +214,7 @@ class EventRouter(
                 repostedEvent == null || repostedEvent.pubkey != myPubkey
             }
             if (isNotifEligible && !isRepostOfOther) {
-                notifRepo.addEvent(event, myPubkey!!)
+                notifRepo.addEvent(event, myPubkey!!, source = subscriptionId)
                 if (eventRepo.getProfileData(event.pubkey) == null) {
                     metadataFetcher.addToPendingProfiles(event.pubkey)
                 }
@@ -240,6 +241,11 @@ class EventRouter(
             if (event.kind == 10002) {
                 relayListRepo.updateFromEvent(event)
                 val myPubkey = getUserPubkey()
+                if (DiagnosticLogger.isEnabled && event.kind in SELF_DATA_KINDS) {
+                    val isMine = myPubkey != null && event.pubkey == myPubkey
+                    DiagnosticLogger.log("SELF_DATA", "kind=${event.kind} pubkey=${event.pubkey.take(8)} " +
+                        "myPubkey=${myPubkey?.take(8)} isMine=$isMine sub=$subscriptionId relay=$relayUrl")
+                }
                 if (myPubkey != null && event.pubkey == myPubkey && isNewestSelfData(event)) {
                     val relays = Nip65.parseRelayList(event)
                     if (relays.isNotEmpty()) {
@@ -410,6 +416,16 @@ class EventRouter(
                 if (myPubkey != null && event.pubkey == myPubkey) contactRepo.updateFromEvent(event)
             }
         }
+    }
+
+    companion object {
+        private val SELF_DATA_KINDS = intArrayOf(
+            0, 3, 10002, 10050, 10007, 10006,
+            Nip51.KIND_MUTE_LIST, Nip51.KIND_BOOKMARK_LIST, Nip51.KIND_PIN_LIST,
+            Blossom.KIND_SERVER_LIST, Nip51.KIND_FOLLOW_SET, Nip51.KIND_INTEREST_SET,
+            Nip51.KIND_BOOKMARK_SET, Nip51.KIND_RELAY_SET, Nip51.KIND_FAVORITE_RELAYS,
+            Nip30.KIND_USER_EMOJI_LIST, Nip30.KIND_EMOJI_SET
+        )
     }
 
     private fun processGiftWrap(event: NostrEvent, relayUrl: String) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -34,6 +34,7 @@ import com.wisp.app.repo.SparkRepository
 import com.wisp.app.repo.WalletModeRepository
 import com.wisp.app.repo.PinRepository
 import com.wisp.app.repo.ProfileRepository
+import com.wisp.app.repo.DiagnosticLogger
 import com.wisp.app.repo.RelayHintStore
 import com.wisp.app.repo.RelayInfoRepository
 import com.wisp.app.repo.RelayListRepository
@@ -108,6 +109,7 @@ class StartupCoordinator(
     private var authCompletedJob: Job? = null
     private var notifRefreshJob: Job? = null
     private var startupJob: Job? = null
+    private var healthSnapshotJob: Job? = null
 
     var relaysInitialized = false
         private set
@@ -122,6 +124,7 @@ class StartupCoordinator(
         authCompletedJob?.cancel()
         notifRefreshJob?.cancel()
         startupJob?.cancel()
+        healthSnapshotJob?.cancel()
         feedSub.reset()
 
         // Stop lifecycle manager and disconnect relays
@@ -223,7 +226,16 @@ class StartupCoordinator(
         // Main event processing loop — runs on Default dispatcher to keep UI thread free
         eventProcessingJob = scope.launch(processingContext) {
             relayPool.relayEvents.collect { (event, relayUrl, subscriptionId) ->
-                eventRouter.processRelayEvent(event, relayUrl, subscriptionId)
+                try {
+                    eventRouter.processRelayEvent(event, relayUrl, subscriptionId)
+                } catch (e: Exception) {
+                    Log.e("StartupCoord", "processRelayEvent crashed", e)
+                    if (DiagnosticLogger.isEnabled) {
+                        DiagnosticLogger.log("CRASH", "processRelayEvent exception: ${e.message}\n" +
+                            "  event: id=${event.id.take(12)} kind=${event.kind} sub=$subscriptionId relay=$relayUrl\n" +
+                            "  stacktrace: ${e.stackTraceToString().take(500)}")
+                    }
+                }
             }
         }
 
@@ -251,6 +263,20 @@ class StartupCoordinator(
                 relayPool.cleanupEphemeralRelays()
                 eventRepo.trimSeenEvents()
                 relayHintStore.flush()
+            }
+        }
+
+        // Periodic health snapshot (every 60s when diagnostics enabled)
+        healthSnapshotJob = scope.launch(processingContext) {
+            while (true) {
+                delay(60_000)
+                if (!DiagnosticLogger.isEnabled) continue
+                val pk = getUserPubkey()
+                DiagnosticLogger.log("HEALTH", "pubkey=${pk?.take(8)} " +
+                    "eventProcessingJob.active=${eventProcessingJob?.isActive} " +
+                    "connectedRelays=${relayPool.connectedCount.value} " +
+                    "notifSeenSize=${notifRepo.getSeenEventsSize()} " +
+                    "eventCacheSize=${eventRepo.getCacheSize()}")
             }
         }
 

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path name="diagnostics" path="." />
+</paths>


### PR DESCRIPTION
## Summary
- Add zero-cost diagnostic file logger (`DiagnosticLogger.kt`) to trace event processing decisions when users report notification contamination or stale feeds
- Wrap `processRelayEvent` in try-catch so a single malformed event no longer crashes the entire pipeline — this alone likely fixes the "feeds become stale + settings don't load" symptom
- Log notification accept/reject decisions with source subscription ID, CLOSED messages, relay resync/reconnect events, and periodic health snapshots
- Hidden toggle: tap version string 5x in Settings > Interface to reveal diagnostic mode with share/clear buttons
- Bump version to 0.11.5

## Test plan
- [x] Enable diagnostic mode via 5 taps on version string in Interface settings
- [x] Verify log file contains NOTIF, CLOSED, RESYNC, HEALTH entries
- [x] Verify share button sends log file via Android share sheet
- [x] Verify clear button deletes log file
- [x] Verify zero performance impact with diagnostics OFF (no string formatting, no disk I/O)
- [x] Verify release build (R8) doesn't strip DiagnosticLogger
- [x] Tested on both debug and release builds