### PR TITLE
fix: never mark ephemeral relays bad in health tracker

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -811,14 +811,17 @@ class RelayPool {
     private fun collectRelayFailures(relay: Relay, parentJob: Job) {
         scope.launch(parentJob) {
             relay.failures.collect { failure ->
-                if (appIsActive) {
+                val isEphemeral = ephemeralRelays.containsKey(relay.config.url)
+                // Never mark ephemeral relays bad in the health tracker — they're user-initiated
+                // (search, outbox routing) and already have an in-memory cooldown. Persisting them
+                // as bad would silently block search and outbox queries across sessions.
+                if (appIsActive && !isEphemeral) {
                     when {
                         failure.httpCode == 429 -> healthTracker?.onRateLimitHit(relay.config.url)
                         failure.httpCode != null && failure.httpCode in 500..599 ->
                             healthTracker?.onServerError(relay.config.url, failure.httpCode)
                     }
                 }
-                val isEphemeral = ephemeralRelays.containsKey(relay.config.url)
                 // Only apply cooldowns to ephemeral relays.
                 // Persistent/DM relays just use the default 3s retry in Relay.reconnect()
                 // with no additional cooldown — avoids cascading delays on app resume.


### PR DESCRIPTION
## Summary

- Ephemeral relays (search, outbox routing) were being persisted as "bad" for 24 hours in `RelayHealthTracker` when they returned a 5xx error
- On the next session, `sendToRelayOrEphemeral` silently returned false before even attempting a connection — causing search to produce no results until the user cleared app cache
- Fix: skip health tracker calls for ephemeral relays; they already have an in-memory cooldown and should never be written to the persistent bad-relay store

## Test plan

- [ ] Trigger a search relay 5xx (or manually mark it bad) — confirm search still works next session
- [ ] Confirm persistent relay health tracking is unaffected (5xx on regular relays still marks them bad)

🤖 Generated with [Claude Code](https://claude.com/claude-code)