### PR TITLE
feat: UI polish round 3

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -827,6 +827,7 @@ fun WispNavHost(
                 accounts = accounts,
                 onSwitchAccount = onSwitchAccount,
                 onAddAccount = onAddAccount,
+                hasEmbeddedWallet = walletViewModel.walletMode.collectAsState().value == com.wisp.app.repo.WalletMode.SPARK,
                 onLogout = {
                     feedViewModel.clearSigner()
                     feedViewModel.resetForAccountSwitch()
@@ -844,6 +845,9 @@ fun WispNavHost(
                             popUpTo(0) { inclusive = true }
                         }
                     } else {
+                        // Full logout — reset UI preferences and refresh in-memory theme state
+                        com.wisp.app.repo.InterfacePreferences(context).reset()
+                        onInterfaceChanged()
                         navController.navigateSafe(Routes.SPLASH) {
                             popUpTo(0) { inclusive = true }
                         }

--- a/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
@@ -31,4 +31,17 @@ class InterfacePreferences(context: Context) {
 
     fun isZapBoltIcon(): Boolean = prefs.getBoolean("zap_bolt_icon", false)
     fun setZapBoltIcon(enabled: Boolean) = prefs.edit().putBoolean("zap_bolt_icon", enabled).apply()
+
+    /** Reset all interface preferences to defaults (called on full logout). */
+    fun reset() {
+        prefs.edit()
+            .remove("accent_color")
+            .remove("theme")
+            .remove("large_text")
+            .remove("new_notes_button_hidden")
+            .remove("zap_bolt_icon")
+            .remove("dark_theme")
+            .remove("balance_hidden")
+            .apply()
+    }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
@@ -19,6 +19,8 @@ import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarDefaults
@@ -58,10 +60,15 @@ fun WispBottomBar(
     notifSoundEnabled: Boolean = true,
     onTabSelected: (BottomTab) -> Unit
 ) {
-    NavigationBar(
-        containerColor = MaterialTheme.colorScheme.surface,
-        windowInsets = NavigationBarDefaults.windowInsets
-    ) {
+    Column {
+        HorizontalDivider(
+            thickness = 0.5.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+        )
+        NavigationBar(
+            containerColor = MaterialTheme.colorScheme.surface,
+            windowInsets = NavigationBarDefaults.windowInsets
+        ) {
         BottomTab.entries.forEach { tab ->
             val selected = currentRoute == tab.route
             val hasUnread = when (tab) {
@@ -139,5 +146,6 @@ fun WispBottomBar(
                 label = null
             )
         }
+    }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/LightningQrDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/LightningQrDialog.kt
@@ -1,10 +1,9 @@
 package com.wisp.app.ui.component
 
-import android.graphics.Bitmap
-import android.graphics.Color
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,10 +11,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -25,31 +26,28 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.google.zxing.BarcodeFormat
-import com.google.zxing.qrcode.QRCodeWriter
+import com.wisp.app.R
+import com.wisp.app.ui.theme.WispThemeColors
 
 @Composable
 fun LightningQrDialog(lud16: String, onDismiss: () -> Unit) {
-    val qrBitmap = remember(lud16) {
-        val writer = QRCodeWriter()
-        val matrix = writer.encode(lud16, BarcodeFormat.QR_CODE, 512, 512)
-        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
-        for (x in 0 until matrix.width) {
-            for (y in 0 until matrix.height) {
-                bitmap.setPixel(x, y, if (matrix.get(x, y)) Color.BLACK else Color.WHITE)
-            }
-        }
-        bitmap
-    }
-
+    val qrBitmap = remember(lud16) { generateQrBitmap(lud16) }
     val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    val useZapBolt = remember {
+        context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
+            .getBoolean("zap_bolt_icon", false)
+    }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -75,14 +73,46 @@ fun LightningQrDialog(lud16: String, onDismiss: () -> Unit) {
                     }
                 }
 
-                Image(
-                    bitmap = qrBitmap.asImageBitmap(),
-                    contentDescription = "Lightning QR Code",
+                // QR code with rounded corners and center icon
+                Box(
+                    contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .size(256.dp)
+                        .clip(RoundedCornerShape(16.dp))
                         .background(androidx.compose.ui.graphics.Color.White)
                         .padding(8.dp)
-                )
+                ) {
+                    Image(
+                        bitmap = qrBitmap.asImageBitmap(),
+                        contentDescription = "Lightning QR Code",
+                        modifier = Modifier.matchParentSize()
+                    )
+                    // Center overlay: bolt or bitcoin icon
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .size(44.dp)
+                            .clip(CircleShape)
+                            .background(androidx.compose.ui.graphics.Color.White)
+                            .padding(4.dp)
+                    ) {
+                        if (useZapBolt) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_bolt),
+                                contentDescription = "Lightning",
+                                tint = WispThemeColors.zapColor,
+                                modifier = Modifier.size(28.dp)
+                            )
+                        } else {
+                            Icon(
+                                Icons.Outlined.CurrencyBitcoin,
+                                contentDescription = "Bitcoin",
+                                tint = WispThemeColors.zapColor,
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
+                    }
+                }
 
                 Spacer(Modifier.height(20.dp))
 

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ProfileQrSheet.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ProfileQrSheet.kt
@@ -1,0 +1,274 @@
+package com.wisp.app.ui.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.outlined.CurrencyBitcoin
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.wisp.app.R
+import com.wisp.app.nostr.Nip19
+import com.wisp.app.nostr.hexToByteArray
+import com.wisp.app.ui.theme.WispThemeColors
+import kotlinx.coroutines.launch
+
+/**
+ * Consolidated QR sheet showing Nostr identity and Lightning address
+ * in a tabbed bottom sheet with swipeable pages.
+ */
+@OptIn(ExperimentalMaterial3Api::class, androidx.compose.foundation.ExperimentalFoundationApi::class)
+@Composable
+fun ProfileQrSheet(
+    pubkeyHex: String,
+    avatarUrl: String? = null,
+    lud16: String? = null,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    val useZapBolt = remember {
+        context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
+            .getBoolean("zap_bolt_icon", false)
+    }
+
+    val npub = remember(pubkeyHex) { Nip19.npubEncode(pubkeyHex.hexToByteArray()) }
+    val npubQr = remember(npub) { generateQrBitmap(npub) }
+    val lightningQr = remember(lud16) { lud16?.let { generateQrBitmap(it) } }
+
+    val hasLightning = lud16 != null
+    val pageCount = if (hasLightning) 2 else 1
+    val pagerState = rememberPagerState(pageCount = { pageCount })
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp)
+        ) {
+            // Tabs
+            if (hasLightning) {
+                TabRow(
+                    selectedTabIndex = pagerState.currentPage,
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    contentColor = MaterialTheme.colorScheme.primary,
+                    divider = {}
+                ) {
+                    Tab(
+                        selected = pagerState.currentPage == 0,
+                        onClick = { scope.launch { pagerState.animateScrollToPage(0) } },
+                        text = { Text("Nostr") },
+                        icon = { Icon(Icons.Outlined.Person, null, modifier = Modifier.size(18.dp)) }
+                    )
+                    Tab(
+                        selected = pagerState.currentPage == 1,
+                        onClick = { scope.launch { pagerState.animateScrollToPage(1) } },
+                        text = { Text("Lightning") },
+                        icon = {
+                            if (useZapBolt) {
+                                Icon(painterResource(R.drawable.ic_bolt), null, modifier = Modifier.size(18.dp))
+                            } else {
+                                Icon(Icons.Outlined.CurrencyBitcoin, null, modifier = Modifier.size(18.dp))
+                            }
+                        }
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Pages
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxWidth()
+            ) { page ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                ) {
+                    when (page) {
+                        0 -> {
+                            // Nostr QR
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier
+                                    .size(240.dp)
+                                    .clip(RoundedCornerShape(16.dp))
+                                    .background(androidx.compose.ui.graphics.Color.White)
+                                    .padding(8.dp)
+                            ) {
+                                Image(
+                                    bitmap = npubQr.asImageBitmap(),
+                                    contentDescription = stringResource(R.string.cd_qr_code),
+                                    modifier = Modifier.matchParentSize()
+                                )
+                                Box(
+                                    modifier = Modifier
+                                        .size(44.dp)
+                                        .clip(CircleShape)
+                                        .background(androidx.compose.ui.graphics.Color.White)
+                                        .padding(3.dp)
+                                ) {
+                                    if (avatarUrl != null) {
+                                        AsyncImage(
+                                            model = avatarUrl,
+                                            contentDescription = "Avatar",
+                                            contentScale = ContentScale.Crop,
+                                            modifier = Modifier.matchParentSize().clip(CircleShape)
+                                        )
+                                    } else {
+                                        Icon(
+                                            painter = painterResource(R.drawable.ic_wisp_logo),
+                                            contentDescription = "Wisp",
+                                            tint = androidx.compose.ui.graphics.Color.Unspecified,
+                                            modifier = Modifier.matchParentSize()
+                                        )
+                                    }
+                                }
+                            }
+
+                            Spacer(Modifier.height(16.dp))
+
+                            Text(
+                                "npub",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            CopyableRow(text = npub, onCopy = {
+                                clipboardManager.setText(AnnotatedString(npub))
+                            })
+                        }
+                        1 -> {
+                            // Lightning QR
+                            if (lightningQr != null && lud16 != null) {
+                                Box(
+                                    contentAlignment = Alignment.Center,
+                                    modifier = Modifier
+                                        .size(240.dp)
+                                        .clip(RoundedCornerShape(16.dp))
+                                        .background(androidx.compose.ui.graphics.Color.White)
+                                        .padding(8.dp)
+                                ) {
+                                    Image(
+                                        bitmap = lightningQr.asImageBitmap(),
+                                        contentDescription = "Lightning QR Code",
+                                        modifier = Modifier.matchParentSize()
+                                    )
+                                    Box(
+                                        contentAlignment = Alignment.Center,
+                                        modifier = Modifier
+                                            .size(44.dp)
+                                            .clip(CircleShape)
+                                            .background(androidx.compose.ui.graphics.Color.White)
+                                            .padding(4.dp)
+                                    ) {
+                                        if (useZapBolt) {
+                                            Icon(
+                                                painter = painterResource(R.drawable.ic_bolt),
+                                                contentDescription = "Lightning",
+                                                tint = WispThemeColors.zapColor,
+                                                modifier = Modifier.size(28.dp)
+                                            )
+                                        } else {
+                                            Icon(
+                                                Icons.Outlined.CurrencyBitcoin,
+                                                contentDescription = "Bitcoin",
+                                                tint = WispThemeColors.zapColor,
+                                                modifier = Modifier.size(28.dp)
+                                            )
+                                        }
+                                    }
+                                }
+
+                                Spacer(Modifier.height(16.dp))
+
+                                Text(
+                                    "Lightning Address",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Spacer(Modifier.height(4.dp))
+                                CopyableRow(text = lud16, onCopy = {
+                                    clipboardManager.setText(AnnotatedString(lud16))
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CopyableRow(text: String, onCopy: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+        Spacer(Modifier.width(4.dp))
+        IconButton(onClick = onCopy) {
+            Icon(
+                Icons.Default.ContentCopy,
+                contentDescription = "Copy",
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/QrCodeDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/QrCodeDialog.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -25,38 +27,33 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import coil3.compose.AsyncImage
 import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.hexToByteArray
 import com.wisp.app.R
 
 @Composable
-fun QrCodeDialog(pubkeyHex: String, onDismiss: () -> Unit) {
+fun QrCodeDialog(pubkeyHex: String, avatarUrl: String? = null, onDismiss: () -> Unit) {
     val npub = remember(pubkeyHex) {
         Nip19.npubEncode(pubkeyHex.hexToByteArray())
     }
 
-    val qrBitmap = remember(npub) {
-        val writer = QRCodeWriter()
-        val matrix = writer.encode(npub, BarcodeFormat.QR_CODE, 512, 512)
-        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
-        for (x in 0 until matrix.width) {
-            for (y in 0 until matrix.height) {
-                bitmap.setPixel(x, y, if (matrix.get(x, y)) Color.BLACK else Color.WHITE)
-            }
-        }
-        bitmap
-    }
-
+    val qrBitmap = remember(npub) { generateQrBitmap(npub) }
     val clipboardManager = LocalClipboardManager.current
 
     Dialog(
@@ -83,14 +80,47 @@ fun QrCodeDialog(pubkeyHex: String, onDismiss: () -> Unit) {
                     }
                 }
 
-                Image(
-                    bitmap = qrBitmap.asImageBitmap(),
-                    contentDescription = stringResource(R.string.cd_qr_code),
+                // QR code with rounded corners and center overlay
+                Box(
+                    contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .size(256.dp)
+                        .clip(RoundedCornerShape(16.dp))
                         .background(androidx.compose.ui.graphics.Color.White)
                         .padding(8.dp)
-                )
+                ) {
+                    Image(
+                        bitmap = qrBitmap.asImageBitmap(),
+                        contentDescription = stringResource(R.string.cd_qr_code),
+                        modifier = Modifier.matchParentSize()
+                    )
+                    // Center overlay: user avatar or wisp logo
+                    Box(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .clip(CircleShape)
+                            .background(androidx.compose.ui.graphics.Color.White)
+                            .padding(3.dp)
+                    ) {
+                        if (avatarUrl != null) {
+                            AsyncImage(
+                                model = avatarUrl,
+                                contentDescription = "Avatar",
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .clip(CircleShape)
+                            )
+                        } else {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_wisp_logo),
+                                contentDescription = "Wisp",
+                                tint = androidx.compose.ui.graphics.Color.Unspecified,
+                                modifier = Modifier.matchParentSize()
+                            )
+                        }
+                    }
+                }
 
                 Spacer(Modifier.height(20.dp))
 
@@ -154,4 +184,18 @@ fun QrCodeDialog(pubkeyHex: String, onDismiss: () -> Unit) {
             }
         }
     }
+}
+
+/** Generate a QR bitmap with high error correction (supports center overlay). */
+internal fun generateQrBitmap(content: String, size: Int = 512): Bitmap {
+    val hints = mapOf(EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.H)
+    val writer = QRCodeWriter()
+    val matrix = writer.encode(content, BarcodeFormat.QR_CODE, size, size, hints)
+    val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
+    for (x in 0 until matrix.width) {
+        for (y in 0 until matrix.height) {
+            bitmap.setPixel(x, y, if (matrix.get(x, y)) Color.BLACK else Color.WHITE)
+        }
+    }
+    return bitmap
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -716,7 +716,7 @@ fun RichContent(
                                     }
                                 ) {
                                     withStyle(SpanStyle(color = effectiveLinkColor, textDecoration = linkDecoration)) {
-                                        append("@$displayName")
+                                        append("@${displayName.trimEnd()}")
                                     }
                                 }
                             }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -1,6 +1,9 @@
 package com.wisp.app.ui.component
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -32,9 +35,10 @@ import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.DarkMode
 import androidx.compose.material.icons.outlined.LightMode
-import androidx.compose.material.icons.outlined.QrCode2
+import androidx.compose.material.icons.outlined.QrCodeScanner
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.FavoriteBorder
@@ -104,6 +108,7 @@ fun WispDrawerContent(
     onRelaySettings: () -> Unit,
     onInterfaceSettings: () -> Unit = {},
     onLogout: () -> Unit,
+    hasEmbeddedWallet: Boolean = false,
     userStatus: String? = null,
     onUpdateStatus: ((String) -> Unit)? = null
 ) {
@@ -176,7 +181,7 @@ fun WispDrawerContent(
                 }
                 IconButton(onClick = { showQrDialog = true }) {
                     Icon(
-                        Icons.Outlined.QrCode2,
+                        Icons.Outlined.QrCodeScanner,
                         contentDescription = stringResource(R.string.cd_show_qr_code),
                         modifier = Modifier.size(24.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
@@ -398,7 +403,7 @@ fun WispDrawerContent(
         }
 
         if (showQrDialog && pubkey != null) {
-            QrCodeDialog(pubkeyHex = pubkey, onDismiss = { showQrDialog = false })
+            QrCodeDialog(pubkeyHex = pubkey, avatarUrl = profile?.picture, onDismiss = { showQrDialog = false })
         }
         if (showLightningDialog && profile?.lud16 != null) {
             LightningQrDialog(lud16 = profile.lud16, onDismiss = { showLightningDialog = false })
@@ -591,7 +596,39 @@ fun WispDrawerContent(
                 onDismissRequest = { showLogoutDialog = false },
                 title = { Text(stringResource(R.string.btn_logout)) },
                 text = {
-                    Text(stringResource(R.string.logout_warning))
+                    Column {
+                        Row(verticalAlignment = Alignment.Top) {
+                            Icon(
+                                Icons.Outlined.Key,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                            Spacer(Modifier.width(10.dp))
+                            Text(
+                                "Back up your private key before logging out. Without it, your Nostr account cannot be recovered.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                        if (hasEmbeddedWallet) {
+                            Spacer(Modifier.height(14.dp))
+                            Row(verticalAlignment = Alignment.Top) {
+                                Icon(
+                                    Icons.Outlined.AccountBalanceWallet,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(20.dp),
+                                    tint = MaterialTheme.colorScheme.error
+                                )
+                                Spacer(Modifier.width(10.dp))
+                                Text(
+                                    "Back up your wallet recovery phrase. Without it, your funds cannot be recovered.",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+                        }
+                    }
                 },
                 confirmButton = {
                     TextButton(onClick = {
@@ -610,6 +647,34 @@ fun WispDrawerContent(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
+
+        // Version info with wisp logo
+        val versionContext = androidx.compose.ui.platform.LocalContext.current
+        val versionName = remember {
+            try {
+                versionContext.packageManager.getPackageInfo(versionContext.packageName, 0).versionName ?: "?"
+            } catch (_: Exception) { "?" }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_wisp_logo),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                modifier = Modifier.size(16.dp)
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = "wisp v$versionName",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+            )
+        }
         }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -123,8 +123,7 @@ fun WispDrawerContent(
             .statusBarsPadding()
             .verticalScroll(scrollState)
         ) {
-        var showQrDialog by remember { mutableStateOf(false) }
-        var showLightningDialog by remember { mutableStateOf(false) }
+        var showProfileQr by remember { mutableStateOf(false) }
         var accountPickerExpanded by remember { mutableStateOf(false) }
 
         Column(modifier = Modifier.padding(16.dp)) {
@@ -179,37 +178,13 @@ fun WispDrawerContent(
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-                IconButton(onClick = { showQrDialog = true }) {
+                IconButton(onClick = { showProfileQr = true }) {
                     Icon(
                         Icons.Outlined.QrCodeScanner,
                         contentDescription = stringResource(R.string.cd_show_qr_code),
                         modifier = Modifier.size(24.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                }
-                if (profile?.lud16 != null) {
-                    val lnContext = androidx.compose.ui.platform.LocalContext.current
-                    val useBoltIcon = remember {
-                        lnContext.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-                            .getBoolean("zap_bolt_icon", false)
-                    }
-                    IconButton(onClick = { showLightningDialog = true }) {
-                        if (useBoltIcon) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_bolt),
-                                contentDescription = stringResource(R.string.cd_lightning_address),
-                                modifier = Modifier.size(24.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        } else {
-                            Icon(
-                                Icons.Outlined.CurrencyBitcoin,
-                                contentDescription = stringResource(R.string.cd_lightning_address),
-                                modifier = Modifier.size(24.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
                 }
             }
             Row(
@@ -236,6 +211,7 @@ fun WispDrawerContent(
                     )
                 }
             }
+            Spacer(Modifier.height(2.dp))
             if (!profile?.nip05.isNullOrBlank()) {
                 Text(
                     text = profile!!.nip05!!,
@@ -402,11 +378,13 @@ fun WispDrawerContent(
             }
         }
 
-        if (showQrDialog && pubkey != null) {
-            QrCodeDialog(pubkeyHex = pubkey, avatarUrl = profile?.picture, onDismiss = { showQrDialog = false })
-        }
-        if (showLightningDialog && profile?.lud16 != null) {
-            LightningQrDialog(lud16 = profile.lud16, onDismiss = { showLightningDialog = false })
+        if (showProfileQr && pubkey != null) {
+            ProfileQrSheet(
+                pubkeyHex = pubkey,
+                avatarUrl = profile?.picture,
+                lud16 = profile?.lud16,
+                onDismiss = { showProfileQr = false }
+            )
         }
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -658,7 +636,7 @@ fun WispDrawerContent(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(horizontal = 16.dp, vertical = 16.dp),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/BlossomServersScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/BlossomServersScreen.kt
@@ -67,6 +67,7 @@ fun BlossomServersScreen(
     val density = LocalDensity.current
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.blossom_title)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/BookmarkSetScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/BookmarkSetScreen.kt
@@ -66,6 +66,7 @@ fun BookmarkSetScreen(
     var menuExpanded by remember { mutableStateOf(false) }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(bookmarkSet?.name ?: "List") },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/CommunityScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/CommunityScreen.kt
@@ -59,6 +59,7 @@ fun CommunityScreen(
     val isLoading by viewModel.isLoading.collectAsState()
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ConsoleScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ConsoleScreen.kt
@@ -45,6 +45,7 @@ fun ConsoleScreen(
     val entries by viewModel.consoleLog.collectAsState()
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.drawer_console)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/CustomEmojiScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/CustomEmojiScreen.kt
@@ -91,6 +91,7 @@ fun CustomEmojiScreen(
     var removedShortcodes by remember { mutableStateOf(emptySet<String>()) }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text("Custom Emojis") },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DraftsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DraftsScreen.kt
@@ -76,6 +76,7 @@ fun DraftsScreen(
     var selectedTab by remember { mutableIntStateOf(initialTab) }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.drafts_scheduled_title)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -168,6 +168,7 @@ fun FeedScreen(
     onSwitchAccount: (String) -> Unit = {},
     onAddAccount: () -> Unit = {},
     onLogout: () -> Unit = {},
+    hasEmbeddedWallet: Boolean = false,
     onMediaServers: () -> Unit = {},
     onWallet: () -> Unit = {},
     onLists: () -> Unit = {},
@@ -734,6 +735,7 @@ fun FeedScreen(
                     scope.launch { drawerState.close() }
                     onLogout()
                 },
+                hasEmbeddedWallet = hasEmbeddedWallet,
                 userStatus = statusVersion.let { userPubkey?.let { viewModel.eventRepo.getUserStatus(it) } },
                 onUpdateStatus = { status ->
                     viewModel.publishUserStatus(status)

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -102,6 +102,7 @@ fun InterfaceScreen(
     }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.title_interface)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/KeysScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/KeysScreen.kt
@@ -78,6 +78,7 @@ fun KeysScreen(
     }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.title_keys)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ListScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ListScreen.kt
@@ -125,6 +125,7 @@ fun ListScreen(
     }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ListsHubScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ListsHubScreen.kt
@@ -122,6 +122,7 @@ fun ListsHubScreen(
     val notesLists = remember(ownSets) { ownSets.sortedBy { it.name } }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.drawer_lists)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -127,6 +127,7 @@ import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.theme.WispThemeColors
 import com.wisp.app.viewmodel.NotificationFilter
 import com.wisp.app.viewmodel.NotificationsViewModel
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import com.wisp.app.R
@@ -300,10 +301,17 @@ fun NotificationsScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Text(
-                        stringResource(R.string.nav_notifications),
-                        style = MaterialTheme.typography.titleMedium
-                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            stringResource(R.string.nav_notifications),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = "  |  24h",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                        )
+                    }
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
@@ -503,13 +511,27 @@ private fun NotificationFilterSheet(
                         .padding(horizontal = 24.dp, vertical = 10.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        filter.icon(),
-                        contentDescription = null,
-                        tint = if (enabled) MaterialTheme.colorScheme.primary
-                               else MaterialTheme.colorScheme.outline,
-                        modifier = Modifier.size(22.dp)
-                    )
+                    val iconTint = if (enabled) MaterialTheme.colorScheme.primary
+                                   else MaterialTheme.colorScheme.outline
+                    if (filter == NotificationFilter.ZAPS) {
+                        val zapContext = LocalContext.current
+                        val useBolt = remember {
+                            zapContext.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
+                                .getBoolean("zap_bolt_icon", false)
+                        }
+                        if (useBolt) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_bolt),
+                                contentDescription = null,
+                                tint = iconTint,
+                                modifier = Modifier.size(22.dp)
+                            )
+                        } else {
+                            Icon(filter.icon(), contentDescription = null, tint = iconTint, modifier = Modifier.size(22.dp))
+                        }
+                    } else {
+                        Icon(filter.icon(), contentDescription = null, tint = iconTint, modifier = Modifier.size(22.dp))
+                    }
                     Spacer(Modifier.width(14.dp))
                     Text(
                         stringResource(filter.labelResId),
@@ -520,7 +542,12 @@ private fun NotificationFilterSheet(
                     Spacer(Modifier.weight(1f))
                     androidx.compose.material3.Switch(
                         checked = enabled,
-                        onCheckedChange = { onToggleType(filter) }
+                        onCheckedChange = { onToggleType(filter) },
+                        colors = SwitchDefaults.colors(
+                            uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+                            uncheckedBorderColor = MaterialTheme.colorScheme.outline
+                        )
                     )
                 }
             }
@@ -555,7 +582,12 @@ private fun NotificationFilterSheet(
                 Spacer(Modifier.weight(1f))
                 androidx.compose.material3.Switch(
                     checked = chatRoomsEnabled,
-                    onCheckedChange = { onToggleChatRooms() }
+                    onCheckedChange = { onToggleChatRooms() },
+                    colors = SwitchDefaults.colors(
+                        uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+                        uncheckedBorderColor = MaterialTheme.colorScheme.outline
+                    )
                 )
             }
 
@@ -1989,11 +2021,6 @@ private fun DailySummaryBar(
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = "24h",
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
             SummaryStat(Icons.Outlined.ChatBubbleOutline, summary.replyCount.toString(),
                 active = isFiltered && NotificationFilter.REPLIES in enabledTypes,
                 onClick = { onFilterSelect(NotificationFilter.REPLIES) })

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/PowSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/PowSettingsScreen.kt
@@ -49,6 +49,7 @@ fun PowSettingsScreen(
     var dmDifficulty by remember { mutableIntStateOf(powPrefs.getDmDifficulty()) }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.drawer_proof_of_work)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ProfileEditScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ProfileEditScreen.kt
@@ -89,6 +89,7 @@ fun ProfileEditScreen(
     }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.title_edit_profile)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/RelayDetailScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/RelayDetailScreen.kt
@@ -94,6 +94,7 @@ fun RelayDetailScreen(
     }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/RelayHealthScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/RelayHealthScreen.kt
@@ -61,6 +61,7 @@ fun RelayHealthScreen(
     val state by viewModel.state.collectAsState()
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.title_relay_health)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/RelayScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/RelayScreen.kt
@@ -73,6 +73,7 @@ fun RelayScreen(
     val tabs = RelaySetType.entries
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.title_relays)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyScreen.kt
@@ -53,6 +53,7 @@ fun SafetyScreen(
     var selectedTab by remember { mutableIntStateOf(0) }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.title_safety)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SocialGraphScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SocialGraphScreen.kt
@@ -135,6 +135,7 @@ fun SocialGraphScreen(
     }
 
     Scaffold(
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.drawer_social_graph)) },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.MoreVert
 
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.QrCode2
+import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
@@ -334,6 +334,7 @@ fun UserProfileScreen(
     if (showQrDialog) {
         QrCodeDialog(
             pubkeyHex = profilePubkey,
+            avatarUrl = profile?.picture,
             onDismiss = { showQrDialog = false }
         )
     }
@@ -419,7 +420,7 @@ fun UserProfileScreen(
                         }
                     }
                     IconButton(onClick = { showQrDialog = true }) {
-                        Icon(Icons.Default.QrCode2, stringResource(R.string.cd_show_qr_code))
+                        Icon(Icons.Default.QrCodeScanner, stringResource(R.string.cd_show_qr_code))
                     }
                     var menuExpanded by remember { mutableStateOf(false) }
                     IconButton(onClick = { menuExpanded = true }) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -100,7 +100,7 @@ import com.wisp.app.ui.component.isGalleryEvent
 import com.wisp.app.ui.component.PostCard
 import com.wisp.app.ui.component.parseContent
 import com.wisp.app.ui.component.parseImetaTags
-import com.wisp.app.ui.component.QrCodeDialog
+import com.wisp.app.ui.component.ProfileQrSheet
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.component.RichContent
 import com.wisp.app.ui.component.ZapDialog
@@ -332,9 +332,10 @@ fun UserProfileScreen(
     var showAddToListDialog by remember { mutableStateOf(false) }
 
     if (showQrDialog) {
-        QrCodeDialog(
+        ProfileQrSheet(
             pubkeyHex = profilePubkey,
             avatarUrl = profile?.picture,
+            lud16 = profile?.lud16,
             onDismiss = { showQrDialog = false }
         )
     }


### PR DESCRIPTION
  ## Summary

  ### Logout & Theme Reset
  - Reset all UI preferences on full logout so splash screen returns to default
  - Refresh in-memory Compose theme state immediately
  - Add wallet backup warning to logout dialog with key and wallet icons (Spark wallet only)

  ### Drawer Polish
  - Consolidate npub and lightning QR dialogs into a single **tabbed bottom sheet** (ProfileQrSheet) — swipeable Nostr/Lightning tabs, Lightning tab only shown when lud16 exists
  - Remove separate lightning address icon from drawer header, simplifying icon row
  - Add version number with monochrome wisp logo at bottom of drawer
  - Increase spacing between username and nip05
  - Replace QrCode2 with simpler QrCodeScanner icon

  ### QR Code Dialogs
  - Round QR code corners (16dp) with high error correction (Level H)
  - Npub QR: user avatar in center (wisp logo fallback)
  - Lightning QR: bolt or bitcoin icon based on user preference

  ### Bottom Navigation & Screen Gaps
  - Add thin 0.5dp separator line at top of bottom nav bar
  - Zero out contentWindowInsets on ALL screens inside NavHost (Console, Relay Health, Custom Emojis, Blossom Servers, Bookmark Set, Community, Drafts, Interface, Keys, Lists, Lists Hub, PoW Settings,
  Profile Edit, Relay Detail, Relay, Safety, Social Graph)

  ### Notification Improvements
  - Move "24h" into title bar as "Notifications | 24h"
  - Stats bar items are tappable filters with atomic isolateType()
  - Zap icon in stats bar and filter sheet respects bolt/bitcoin toggle
  - Improve off-state switch contrast in filter sheet

  ### Content Display
  - Trim trailing whitespace from profile display names in @mentions

  ## Test plan
  - [ ] Tap QR icon in drawer → bottom sheet with Nostr tab (QR + npub + copy)
  - [ ] Swipe to Lightning tab → QR with bolt/bitcoin icon + lud16 + copy
  - [ ] No Lightning tab when user has no lud16
  - [ ] No separate lightning icon in drawer header
  - [ ] Change theme → logout → splash screen shows default orange
  - [ ] Logout with Spark wallet → both key and wallet warnings shown
  - [ ] Drawer shows version + wisp logo at bottom
  - [ ] Thin line at top of bottom nav bar
  - [ ] No bottom gap on any screen
  - [ ] Notification stat filters work, no flash on switch
  - [ ] @mention + punctuation has no extra space

  🤖 Generated with [Claude Code](https://claude.com/claude-code)