### PR TITLE
run ktlint after every change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./gradlew assembleRelease     # Build release APK (minified with R8)
 ./gradlew installDebug        # Build and install on connected device/emulator
 ./gradlew clean               # Clean build artifacts
+./gradlew ktlintFormat        # Format Kotlin code
+./gradlew ktlintCheck         # Lint Kotlin code
 ```
 
 No test suite exists yet. JDK 17 and Android SDK 35 are required.
+Run `./gradlew ktlintFormat` then `./gradlew ktlintCheck` after every change.
 
 ## Architecture
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.objectbox)
+    alias(libs.plugins.ktlint)
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.objectbox) apply false
+    alias(libs.plugins.ktlint) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.0.21"
 agp = "8.13.2"
+ktlint = "12.1.1"
 compose-bom = "2024.12.01"
 okhttp = "4.12.0"
 kotlinx-serialization = "1.7.3"
@@ -77,3 +78,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 objectbox = { id = "io.objectbox", version.ref = "objectbox" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }


### PR DESCRIPTION
this is because my editor automatically applies ktlint on save so I can't do normal edits on files before causing tons of meaningless diffs.

it's also good for other reasons to enforce a unique formatting style over the entire codebase.

---

before or immediately after merging this I recommend running ktlint on the entire codebase so it has a uniform start.