### PR TITLE
feat: emoji reactions, repost toggle, and scroll UX

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1,6 +1,21 @@
 package com.wisp.app
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.ui.Alignment
@@ -635,26 +650,41 @@ fun WispNavHost(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         bottomBar = {
             if (showBottomBar) {
-                WispBottomBar(
-                    currentRoute = currentRoute,
-                    hasUnreadHome = newNoteCount > 0,
-                    hasUnreadMessages = hasUnreadDms,
-                    hasUnreadNotifications = hasUnreadNotifications,
-                    isZapAnimating = isZapAnimating,
-                    isReplyAnimating = isReplyAnimating,
-                    notifSoundEnabled = notifSoundEnabled,
-                    onTabSelected = { tab ->
-                        if (currentRoute == tab.route) {
-                            scrollToTopTrigger++
-                        } else {
-                            if (tab == BottomTab.WALLET) walletViewModel.navigateHome()
-                            navController.navigateSafe(tab.route) {
-                                popUpTo(Routes.FEED) { inclusive = false }
-                                launchSingleTop = true
+                val barsVisible by feedViewModel.barsVisible.collectAsState()
+                val bottomBarVisible = currentRoute != Routes.FEED || barsVisible
+                Column(modifier = Modifier.background(MaterialTheme.colorScheme.surface)) {
+                    HorizontalDivider(
+                        thickness = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+                    AnimatedVisibility(
+                        visible = bottomBarVisible,
+                        enter = expandVertically(animationSpec = tween(200), expandFrom = Alignment.Top) + fadeIn(animationSpec = tween(200)),
+                        exit = shrinkVertically(animationSpec = tween(200), shrinkTowards = Alignment.Top) + fadeOut(animationSpec = tween(200))
+                    ) {
+                        WispBottomBar(
+                            currentRoute = currentRoute,
+                            hasUnreadHome = newNoteCount > 0,
+                            hasUnreadMessages = hasUnreadDms,
+                            hasUnreadNotifications = hasUnreadNotifications,
+                            isZapAnimating = isZapAnimating,
+                            isReplyAnimating = isReplyAnimating,
+                            notifSoundEnabled = notifSoundEnabled,
+                            onTabSelected = { tab ->
+                                if (currentRoute == tab.route) {
+                                    scrollToTopTrigger++
+                                } else {
+                                    if (tab == BottomTab.WALLET) walletViewModel.navigateHome()
+                                    navController.navigateSafe(tab.route) {
+                                        popUpTo(Routes.FEED) { inclusive = false }
+                                        launchSingleTop = true
+                                    }
+                                }
                             }
-                        }
+                        )
                     }
-                )
+                    Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+                }
             }
         }
     ) { innerPadding ->

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -132,8 +132,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     private val repostAuthors = LruCache<String, MutableSet<String>>(15000)
     // Feed sort time override: eventId -> effective sort timestamp (e.g. repost time)
     private val feedSortTime = LruCache<String, Long>(15000)
-    // Track which events the current user has reposted: eventId -> true
-    private val userReposts = LruCache<String, Boolean>(15000)
+    // Track which events the current user has reposted: targetEventId -> repostEventId
+    private val userReposts = LruCache<String, String>(15000)
     private val _repostVersion = MutableStateFlow(0)
     val repostVersion: StateFlow<Int> = _repostVersion
 
@@ -363,7 +363,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                         authors.add(event.pubkey)
                         // Auto-mark if this is the current user's repost
                         if (event.pubkey == currentUserPubkey) {
-                            userReposts.put(inner.id, true)
+                            userReposts.put(inner.id, event.id)
                         }
                         repostDirty = true
                         markVersionDirty()
@@ -1015,16 +1015,28 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     fun getRepostTime(eventId: String): Long? = feedSortTime.get(eventId)
 
-    fun markUserRepost(eventId: String) {
-        userReposts.put(eventId, true)
-        val authors = repostAuthors.get(eventId)
-            ?: ConcurrentHashMap.newKeySet<String>().also { repostAuthors.put(eventId, it) }
+    fun markUserRepost(targetEventId: String, repostEventId: String) {
+        userReposts.put(targetEventId, repostEventId)
+        val authors = repostAuthors.get(targetEventId)
+            ?: ConcurrentHashMap.newKeySet<String>().also { repostAuthors.put(targetEventId, it) }
         if (currentUserPubkey != null) authors.add(currentUserPubkey!!)
         repostDirty = true
         markVersionDirty()
     }
 
-    fun hasUserReposted(eventId: String): Boolean = userReposts.get(eventId) == true
+    fun hasUserReposted(eventId: String): Boolean = userReposts.get(eventId) != null
+
+    fun getUserRepostEventId(eventId: String): String? = userReposts.get(eventId)
+
+    fun removeUserRepost(eventId: String) {
+        userReposts.remove(eventId)
+        val authors = repostAuthors.get(eventId)
+        if (authors != null && currentUserPubkey != null) {
+            authors.remove(currentUserPubkey!!)
+        }
+        repostDirty = true
+        markVersionDirty()
+    }
 
     /**
      * Optimistically record the current user's zap so the UI updates immediately
@@ -1261,7 +1273,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                             ?: ConcurrentHashMap.newKeySet<String>().also { repostAuthors.put(inner.id, it) }
                         authors.add(event.pubkey)
                         if (event.pubkey == currentUserPubkey) {
-                            userReposts.put(inner.id, true)
+                            userReposts.put(inner.id, event.id)
                         }
                         repostDirty = true
                         markVersionDirty()
@@ -1319,7 +1331,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                             ?: ConcurrentHashMap.newKeySet<String>().also { repostAuthors.put(inner.id, it) }
                         authors.add(event.pubkey)
                         if (event.pubkey == currentUserPubkey) {
-                            userReposts.put(inner.id, true)
+                            userReposts.put(inner.id, event.id)
                         }
                         repostDirty = true
                         markVersionDirty()

--- a/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -67,7 +68,7 @@ fun WispBottomBar(
         )
         NavigationBar(
             containerColor = MaterialTheme.colorScheme.surface,
-            windowInsets = NavigationBarDefaults.windowInsets
+            windowInsets = androidx.compose.foundation.layout.WindowInsets(0, 0, 0, 0)
         ) {
         BottomTab.entries.forEach { tab ->
             val selected = currentRoute == tab.route

--- a/app/src/main/kotlin/com/wisp/app/ui/component/EmojiLibrarySheet.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/EmojiLibrarySheet.kt
@@ -262,27 +262,52 @@ fun EmojiLibrarySheet(
 
     if (showKeyboardDialog) {
         var text by remember { mutableStateOf("") }
+        val trimmed = text.trim()
+        val isValidEmoji = remember(trimmed) {
+            trimmed.isNotEmpty() && trimmed.any { Character.getType(it).let { type ->
+                type == Character.OTHER_SYMBOL.toInt() ||
+                type == Character.SURROGATE.toInt() ||
+                type == Character.NON_SPACING_MARK.toInt() ||
+                type == Character.FORMAT.toInt() ||
+                it in '\u200D'..'\u200D' || // ZWJ
+                it in '\uFE00'..'\uFE0F' || // variation selectors
+                it in '\u2600'..'\u27BF' || // misc symbols
+                it in '\u2300'..'\u23FF' || // misc technical
+                it in '\u2B50'..'\u2B55' || // stars
+                it in '\u3030'..'\u303D' || // CJK symbols
+                it in '\u00A9'..'\u00AE'    // copyright, registered
+            }}
+        }
         AlertDialog(
             onDismissRequest = { showKeyboardDialog = false },
             title = { Text(stringResource(R.string.emoji_add_custom)) },
             text = {
-                OutlinedTextField(
-                    value = text,
-                    onValueChange = { text = it },
-                    placeholder = { Text(stringResource(R.string.emoji_add_from_keyboard_hint)) },
-                    singleLine = true
-                )
+                Column {
+                    OutlinedTextField(
+                        value = text,
+                        onValueChange = { text = it },
+                        placeholder = { Text(stringResource(R.string.emoji_add_from_keyboard_hint)) },
+                        singleLine = true
+                    )
+                    if (trimmed.isNotEmpty() && !isValidEmoji) {
+                        Text(
+                            text = stringResource(R.string.emoji_keyboard_invalid),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+                }
             },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        val emoji = text.trim()
-                        if (emoji.isNotEmpty()) {
-                            selectedEmojis = selectedEmojis + emoji
+                        if (isValidEmoji) {
+                            selectedEmojis = selectedEmojis + trimmed
                         }
                         showKeyboardDialog = false
                     },
-                    enabled = text.isNotBlank()
+                    enabled = isValidEmoji
                 ) { Text(stringResource(R.string.emoji_dialog_add)) }
             },
             dismissButton = {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -1133,7 +1133,7 @@ fun ComposeScreen(
             }
 
             // Bottom bar — always visible above keyboard (shared by both modes)
-            Column(modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp, bottom = 16.dp)) {
                     if (countdownSeconds != null) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -449,6 +449,40 @@ fun ComposeScreen(
                         }
                     }
 
+                    // PoW feedback banner
+                    AnimatedVisibility(
+                        visible = powEnabled,
+                        enter = expandVertically() + fadeIn(),
+                        exit = shrinkVertically() + fadeOut()
+                    ) {
+                        Surface(
+                            shape = RoundedCornerShape(8.dp),
+                            color = WispThemeColors.zapColor.copy(alpha = 0.15f),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp)
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Shield,
+                                    contentDescription = null,
+                                    tint = WispThemeColors.zapColor,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                val bits = powPrefs?.getNoteDifficulty() ?: 16
+                                Text(
+                                    text = "Proof of Work enabled ($bits-bit)",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = WispThemeColors.zapColor
+                                )
+                            }
+                        }
+                    }
+
                     // Hashtag chips
                     AnimatedVisibility(
                         visible = hashtags.isNotEmpty(),
@@ -790,6 +824,40 @@ fun ComposeScreen(
                                 onClick = onSaveDraft
                             ) {
                                 Text(stringResource(R.string.btn_save_draft))
+                            }
+                        }
+                    }
+
+                    // PoW feedback banner
+                    AnimatedVisibility(
+                        visible = powEnabled,
+                        enter = expandVertically() + fadeIn(),
+                        exit = shrinkVertically() + fadeOut()
+                    ) {
+                        Surface(
+                            shape = RoundedCornerShape(8.dp),
+                            color = WispThemeColors.zapColor.copy(alpha = 0.15f),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp)
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Shield,
+                                    contentDescription = null,
+                                    tint = WispThemeColors.zapColor,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                val bits = powPrefs?.getNoteDifficulty() ?: 16
+                                Text(
+                                    text = "Proof of Work enabled ($bits-bit)",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = WispThemeColors.zapColor
+                                )
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -1,8 +1,10 @@
 package com.wisp.app.ui.screen
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -13,8 +15,13 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -64,6 +71,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -380,6 +388,40 @@ fun FeedScreen(
         }
     }
 
+    // Scroll direction detection — hide bars on scroll down, show on scroll up or at top
+    // Accumulate scroll delta and only toggle after a threshold to avoid stutter
+    var scrollDelta by remember { mutableIntStateOf(0) }
+    var prevFirstVisibleIndex by remember { mutableIntStateOf(0) }
+    var prevFirstVisibleOffset by remember { mutableIntStateOf(0) }
+    val scrollThreshold = 50 // pixels of cumulative scroll before toggling
+    LaunchedEffect(listState) {
+        snapshotFlow {
+            listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+        }.collect { (index, offset) ->
+            if (isAtTop) {
+                viewModel.setBarsVisible(true)
+                scrollDelta = 0
+            } else if (listState.isScrollInProgress) {
+                val delta = when {
+                    index > prevFirstVisibleIndex -> scrollThreshold // item jumped, treat as big scroll down
+                    index < prevFirstVisibleIndex -> -scrollThreshold
+                    else -> offset - prevFirstVisibleOffset
+                }
+                scrollDelta = (scrollDelta + delta).coerceIn(-scrollThreshold * 2, scrollThreshold * 2)
+                if (scrollDelta > scrollThreshold) {
+                    viewModel.setBarsVisible(false)
+                } else if (scrollDelta < -scrollThreshold) {
+                    viewModel.setBarsVisible(true)
+                }
+            } else {
+                scrollDelta = 0
+            }
+            prevFirstVisibleIndex = index
+            prevFirstVisibleOffset = offset
+        }
+    }
+
+    val barsVisible by viewModel.barsVisible.collectAsState()
 
     val initialLoadDone by viewModel.initialLoadDone.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
@@ -746,7 +788,16 @@ fun FeedScreen(
         Scaffold(
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
+                Column(modifier = Modifier.background(MaterialTheme.colorScheme.surface)) {
+                Spacer(Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
+                Spacer(Modifier.height(10.dp))
+                AnimatedVisibility(
+                    visible = barsVisible,
+                    enter = expandVertically(animationSpec = tween(200), expandFrom = Alignment.Bottom) + fadeIn(animationSpec = tween(200)),
+                    exit = shrinkVertically(animationSpec = tween(200), shrinkTowards = Alignment.Bottom) + fadeOut(animationSpec = tween(200))
+                ) {
                 CenterAlignedTopAppBar(
+                    windowInsets = WindowInsets(0, 0, 0, 0),
                     title = {
                                 Box {
                                     Surface(
@@ -980,6 +1031,12 @@ fun FeedScreen(
                         }
                     }
                 )
+                } // AnimatedVisibility
+                HorizontalDivider(
+                    thickness = 0.5.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                )
+                } // Column
             },
             floatingActionButton = {
                 val isScrolling = listState.isScrollInProgress

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -393,6 +393,13 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
     val zapError: SharedFlow<String> = socialActions.zapError
     val reactionSent: SharedFlow<Unit> = socialActions.reactionSent
 
+    private val _barsVisible = MutableStateFlow(true)
+    val barsVisible: StateFlow<Boolean> = _barsVisible
+
+    fun setBarsVisible(visible: Boolean) {
+        _barsVisible.value = visible
+    }
+
     suspend fun payInvoice(bolt11: String): Boolean =
         activeWalletProvider.payInvoice(bolt11).isSuccess
     val pendingFirstFollow: StateFlow<String?> = socialActions.pendingFirstFollow

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
@@ -75,6 +75,9 @@ class SocialActionManager(
     private val _reactionSent = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
     val reactionSent: SharedFlow<Unit> = _reactionSent
 
+    /** Guards against duplicate reaction sends from rapid taps. Key = "eventId:emoji" */
+    private val reactionsInFlight = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+
     // Non-null while the first-follow confirmation dialog is visible (holds the target pubkey).
     private val _pendingFirstFollow = MutableStateFlow<String?>(null)
     val pendingFirstFollow: StateFlow<String?> = _pendingFirstFollow
@@ -238,7 +241,13 @@ class SocialActionManager(
     fun toggleReaction(event: NostrEvent, emoji: String) {
         val s = getSigner() ?: return
         val myPubkey = s.pubkeyHex
-        val existingEventId = eventRepo.getUserReactionEventId(event.id, myPubkey, emoji)
+        // Normalize blank / "+" to the canonical heart, matching addReaction()
+        val normalizedEmoji = if (emoji.isBlank() || emoji == "+") "\u2764\uFE0F" else emoji
+
+        val flightKey = "${event.id}:$normalizedEmoji"
+        if (!reactionsInFlight.add(flightKey)) return // already in progress
+
+        val existingEventId = eventRepo.getUserReactionEventId(event.id, myPubkey, normalizedEmoji)
 
         scope.launch {
             try {
@@ -246,9 +255,9 @@ class SocialActionManager(
                     val tags = Nip09.buildDeletionTags(existingEventId, 7)
                     val deletionEvent = s.signEvent(kind = 5, content = "", tags = tags)
                     relayPool.sendToWriteRelays(ClientMessage.event(deletionEvent))
-                    eventRepo.removeReaction(event.id, myPubkey, emoji)
+                    eventRepo.removeReaction(event.id, myPubkey, normalizedEmoji)
                 } else {
-                    val shortcodeMatch = Nip30.shortcodeRegex.matchEntire(emoji)
+                    val shortcodeMatch = Nip30.shortcodeRegex.matchEntire(normalizedEmoji)
                     var tags: List<List<String>> = if (shortcodeMatch != null) {
                         val shortcode = shortcodeMatch.groupValues[1]
                         val url = customEmojiRepo.resolvedEmojis.value[shortcode]
@@ -274,7 +283,7 @@ class SocialActionManager(
                             Nip13.mine(
                                 pubkeyHex = myPubkey,
                                 kind = 7,
-                                content = emoji,
+                                content = normalizedEmoji,
                                 tags = tags,
                                 targetDifficulty = powPrefs.getReactionDifficulty(),
                                 createdAt = pinned
@@ -286,14 +295,17 @@ class SocialActionManager(
                         createdAt = System.currentTimeMillis() / 1000
                     }
 
-                    val reactionEvent = s.signEvent(kind = 7, content = emoji, tags = tags, createdAt = createdAt)
+                    val reactionEvent = s.signEvent(kind = 7, content = normalizedEmoji, tags = tags, createdAt = createdAt)
                     val msg = ClientMessage.event(reactionEvent)
                     outboxRouter.publishToInbox(msg, event.pubkey)
                     eventRepo.addEvent(reactionEvent)
                     _reactionSent.tryEmit(Unit)
-                    customEmojiRepo.recordEmojiUsage(emoji)
+                    customEmojiRepo.recordEmojiUsage(normalizedEmoji)
                 }
-            } catch (_: Exception) {}
+            } catch (_: Exception) {
+            } finally {
+                reactionsInFlight.remove(flightKey)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SocialActionManager.kt
@@ -218,18 +218,27 @@ class SocialActionManager(
 
     fun sendRepost(event: NostrEvent) {
         val s = getSigner() ?: return
+        val existingRepostId = eventRepo.getUserRepostEventId(event.id)
+
         scope.launch {
             try {
-                val hint = outboxRouter.getRelayHint(event.pubkey)
-                val tags = Nip18.buildRepostTags(event, hint).toMutableList()
-                if (interfacePrefs.isClientTagEnabled()) {
-                    tags.add(listOf("client", "Wisp"))
+                if (existingRepostId != null) {
+                    val tags = Nip09.buildDeletionTags(existingRepostId, 6)
+                    val deletionEvent = s.signEvent(kind = 5, content = "", tags = tags)
+                    relayPool.sendToWriteRelays(ClientMessage.event(deletionEvent))
+                    eventRepo.removeUserRepost(event.id)
+                } else {
+                    val hint = outboxRouter.getRelayHint(event.pubkey)
+                    val tags = Nip18.buildRepostTags(event, hint).toMutableList()
+                    if (interfacePrefs.isClientTagEnabled()) {
+                        tags.add(listOf("client", "Wisp"))
+                    }
+                    val repostEvent = s.signEvent(kind = 6, content = event.toJson(), tags = tags)
+                    val msg = ClientMessage.event(repostEvent)
+                    outboxRouter.publishToInbox(msg, event.pubkey)
+                    eventRepo.markUserRepost(event.id, repostEvent.id)
+                    eventRepo.addEvent(repostEvent)
                 }
-                val repostEvent = s.signEvent(kind = 6, content = event.toJson(), tags = tags)
-                val msg = ClientMessage.event(repostEvent)
-                outboxRouter.publishToInbox(msg, event.pubkey)
-                eventRepo.markUserRepost(event.id)
-                eventRepo.addEvent(repostEvent)
             } catch (_: Exception) {}
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,6 +332,7 @@
     <string name="emoji_library_title">Emoji Library</string>
     <string name="emoji_add_from_keyboard">Add from Keyboard</string>
     <string name="emoji_add_from_keyboard_hint">Type or paste an emoji</string>
+    <string name="emoji_keyboard_invalid">Please enter an emoji character, not text</string>
     <string name="emoji_dialog_add">Add</string>
     <string name="emoji_dialog_cancel">Cancel</string>
     <string name="emoji_done_format">Done (%d)</string>


### PR DESCRIPTION
## Summary
- **Emoji reactions**: prevent duplicate reactions, validate keyboard emoji input (reject plain text in "Add from Keyboard"), normalize blank/+ to heart, add in-flight guard for rapid taps
- **Repost undo toggle**: tap repost again to send NIP-09 deletion (kind 5) and remove the repost
- **Auto-hide bars on scroll**: top and bottom bars smoothly expand/shrink when scrolling the feed, with persistent status/nav bar spacers to prevent content bleeding behind system chrome
- **Compose publish button**: add bottom padding for comfortable spacing
- **PoW indicator**: orange banner in compose screen showing difficulty when Proof of Work is enabled

## Test plan
- [ ] Tap emoji picker → "Add from Keyboard" → type plain text → rejected with toast
- [ ] Tap emoji picker → "Add from Keyboard" → enter actual emoji → accepted
- [ ] React to a note → tap same reaction again → reaction removed
- [ ] Rapid-tap a reaction → only one reaction sent (no duplicates)
- [ ] Repost a note → icon turns highlighted
- [ ] Tap repost again → repost deleted, icon returns to default
- [ ] Scroll down on feed → top and bottom bars smoothly hide
- [ ] Scroll up → bars smoothly reappear
- [ ] When bars hidden → no content visible behind status bar or nav bar
- [ ] Publish button has comfortable spacing from bottom bar
- [ ] Compose screen → tap shield icon → orange PoW banner appears with difficulty
- [ ] Tap shield again → banner dismisses