### PR TITLE
fix: capture neventEncode return value in Nip18

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip18.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip18.kt
@@ -16,7 +16,7 @@ object Nip18 {
     }
 
     fun appendNoteUri(content: String, eventIdHex: String, relayHints: List<String> = emptyList(), authorHex: String? = null): String {
-        Nip19.neventEncode(eventIdHex.hexToByteArray(), relayHints, authorHex?.hexToByteArray())
-        return "$content\nnostr:$id"
+        val nevent = Nip19.neventEncode(eventIdHex.hexToByteArray(), relayHints, authorHex?.hexToByteArray())
+        return "$content\nnostr:$nevent"
     }
 }


### PR DESCRIPTION
## Summary
- `Nip18.appendNoteUri()` was discarding the return value of `neventEncode()` and referencing a nonexistent `id` variable, causing a compilation error
- Now captures the result and interpolates it correctly into the nostr: URI

Blame @fiatjaf for this one 😄

## Test plan
- [ ] Verify `assembleDebug` compiles without errors
- [ ] Test quote reposts include correct `nostr:nevent1...` URIs