### PR TITLE
chore: bump version to 0.17.6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 71
-        versionName = "0.17.5"
+        versionCode = 72
+        versionName = "0.17.6"
 
         ndk {
             abiFilters += "arm64-v8a"


### PR DESCRIPTION
## Summary
- Bump versionName 0.17.5 → 0.17.6
- Bump versionCode 71 → 72

Patch release for the navigation lockup fix (#450).