### PR TITLE
feat: fullscreen image viewer with save for encrypted DMs

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/DmBubble.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/DmBubble.kt
@@ -88,6 +88,7 @@ import com.wisp.app.nostr.DmMessage
 import com.wisp.app.ui.screen.GroupChatHorizontalChipStrip
 import com.wisp.app.nostr.DmReaction
 import com.wisp.app.nostr.EncryptedMedia
+import com.wisp.app.ui.component.FullScreenEncryptedImageViewer
 import com.wisp.app.repo.EventRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -838,14 +839,29 @@ private fun EncryptedMediaContent(
                 )
             }
             bitmap != null -> {
-                Image(
-                    bitmap = bitmap!!.asImageBitmap(),
-                    contentDescription = "Encrypted image",
+                var showFullscreen by remember { mutableStateOf(false) }
+                
+                Box(
                     modifier = Modifier
                         .widthIn(max = 256.dp)
-                        .clip(RoundedCornerShape(8.dp)),
-                    contentScale = androidx.compose.ui.layout.ContentScale.FillWidth
-                )
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable { showFullscreen = true }
+                ) {
+                    Image(
+                        bitmap = bitmap!!.asImageBitmap(),
+                        contentDescription = "Encrypted image",
+                        modifier = Modifier.fillMaxWidth(),
+                        contentScale = androidx.compose.ui.layout.ContentScale.FillWidth
+                    )
+                }
+                
+                if (showFullscreen) {
+                    FullScreenEncryptedImageViewer(
+                        bitmap = bitmap!!,
+                        imageUrl = metadata.fileUrl,
+                        onDismiss = { showFullscreen = false }
+                    )
+                }
             }
         }
     } else {

--- a/app/src/main/kotlin/com/wisp/app/ui/component/FullScreenEncryptedImageViewer.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/FullScreenEncryptedImageViewer.kt
@@ -1,0 +1,140 @@
+package com.wisp.app.ui.component
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.wisp.app.R
+import com.wisp.app.util.MediaDownloader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+
+@Composable
+fun FullScreenEncryptedImageViewer(
+    bitmap: Bitmap,
+    imageUrl: String?,
+    onDismiss: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        var scale by remember { mutableFloatStateOf(1f) }
+        var offset by remember { mutableStateOf(Offset.Zero) }
+
+        val transformableState = rememberTransformableState { zoomChange, panChange, _ ->
+            scale = (scale * zoomChange).coerceIn(0.5f, 5f)
+            offset = if (scale > 1f) offset + panChange else Offset.Zero
+        }
+
+        val context = LocalContext.current
+        val scope = rememberCoroutineScope()
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = { if (scale <= 1f) onDismiss() }
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = "Full screen encrypted image",
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer(
+                        scaleX = scale,
+                        scaleY = scale,
+                        translationX = offset.x,
+                        translationY = offset.y
+                    )
+                    .transformable(state = transformableState)
+            )
+
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp)
+            ) {
+                val buttonColors = IconButtonDefaults.iconButtonColors(
+                    containerColor = Color.Black.copy(alpha = 0.5f),
+                    contentColor = Color.White
+                )
+
+                IconButton(
+                    onClick = {
+                        scope.launch {
+                            try {
+                                val bytes = withContext(Dispatchers.IO) {
+                                    ByteArrayOutputStream().use { stream ->
+                                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                                        stream.toByteArray()
+                                    }
+                                }
+                                MediaDownloader.saveImageBytes(context, bytes, "png")
+                            } catch (e: Exception) {
+                                // Error already handled in saveImageBytes
+                            }
+                        }
+                    },
+                    colors = buttonColors,
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_download),
+                        contentDescription = "Download"
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                IconButton(
+                    onClick = onDismiss,
+                    colors = buttonColors,
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(Icons.Default.Close, contentDescription = "Close")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/util/MediaDownloader.kt
+++ b/app/src/main/kotlin/com/wisp/app/util/MediaDownloader.kt
@@ -85,4 +85,43 @@ object MediaDownloader {
             }
         }
     }
+
+    suspend fun saveImageBytes(context: Context, bytes: ByteArray, format: String) {
+        try {
+            val fileName = "wisp_image_${System.currentTimeMillis()}.$format"
+            val mimeType = "image/$format"
+
+            withContext(Dispatchers.IO) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    val collection = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+                    val values = ContentValues().apply {
+                        put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
+                        put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
+                        put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
+                        put(MediaStore.MediaColumns.IS_PENDING, 1)
+                    }
+                    val uri = context.contentResolver.insert(collection, values)
+                        ?: error("Failed to create MediaStore entry")
+                    context.contentResolver.openOutputStream(uri)?.use { it.write(bytes) }
+                    values.clear()
+                    values.put(MediaStore.MediaColumns.IS_PENDING, 0)
+                    context.contentResolver.update(uri, values, null, null)
+                } else {
+                    @Suppress("DEPRECATION")
+                    val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+                    dir.mkdirs()
+                    val file = File(dir, fileName)
+                    FileOutputStream(file).use { it.write(bytes) }
+                }
+            }
+
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Saved to Pictures", Toast.LENGTH_SHORT).show()
+            }
+        } catch (e: Exception) {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Save failed: ${e.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds tap-to-fullscreen and download functionality for encrypted images in DMs and group chats.

**Changes**
 - Created FullScreenEncryptedImageViewer — a new fullscreen image viewer for encrypted DM images with:
 - Pinch-to-zoom and pan support
 - Download button to save decrypted images to the device (saved to Pictures folder)
 - Dismiss by tapping when not zoomed in
 - Added MediaDownloader.saveImageBytes() — a new utility method to save decrypted bitmaps directly to the device's media store
 - Updated EncryptedMediaContent in DmBubble.kt to make encrypted images clickable and open the fullscreen viewer

