### PR TITLE
feat: add BlurHash support and enhance media metadata parsing

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/GalleryCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/GalleryCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.rememberTransformableState
@@ -76,6 +77,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import com.wisp.app.util.BlurHashDecoder
+import coil3.compose.SubcomposeAsyncImage
+import androidx.compose.material3.CircularProgressIndicator
 import coil3.compose.AsyncImage
 import com.wisp.app.R
 import com.wisp.app.nostr.Nip13
@@ -498,13 +504,46 @@ fun GalleryCard(
                         .clip(RoundedCornerShape(12.dp))
                 ) { page ->
                     val entry = imageEntries[page]
-                    AsyncImage(
+                    val blurPainter = remember(entry.blurhash, entry.dim) {
+                        val dims = entry.dim?.split('x')
+                        val w = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                        val h = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                        BlurHashDecoder.decode(entry.blurhash, w, h)?.asImageBitmap()?.let { BitmapPainter(it) }
+                    }
+                    SubcomposeAsyncImage(
                         model = entry.url,
                         contentDescription = entry.alt ?: title,
                         contentScale = ContentScale.Crop,
                         modifier = Modifier
                             .fillMaxSize()
-                            .clickable { fullScreenInitialPage = page }
+                            .clickable { fullScreenInitialPage = page },
+                        loading = {
+                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                if (blurPainter != null) {
+                                    Image(
+                                        painter = blurPainter,
+                                        contentDescription = null,
+                                        contentScale = ContentScale.Crop,
+                                        modifier = Modifier.fillMaxSize()
+                                    )
+                                }
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(24.dp),
+                                    strokeWidth = 2.dp,
+                                    color = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        },
+                        error = {
+                            if (blurPainter != null) {
+                                Image(
+                                    painter = blurPainter,
+                                    contentDescription = null,
+                                    contentScale = ContentScale.Crop,
+                                    modifier = Modifier.fillMaxSize()
+                                )
+                            }
+                        }
                     )
                 }
                 if (imageEntries.size > 1) {
@@ -534,7 +573,12 @@ fun GalleryCard(
             // Video event (kind 21/22) — use inline video player, same as kind 1 feed
             val video = videoEntries[0]
             InlineVideoPlayerWithFullscreen(
-                url = video.url,
+                meta = MediaMeta(
+                    url = video.url,
+                    mime = video.mimeType,
+                    dimension = video.dim,
+                    blurhash = video.blurhash
+                ),
                 onFullScreen = { positionMs ->
                     FullScreenVideoState.enter(video.url, positionMs)
                 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -533,7 +533,7 @@ fun PostCard(
                     contentAlignment = Alignment.TopStart
                 ) {
                     val emojiMap = remember(event.id) { Nip30.parseEmojiTags(event) }
-                    val imetaMap = remember(event.id) { parseImetaTags(event) }
+                    val imetaMap = remember(event.id) { parseImetaTags(event.tags) }
                     RichContent(
                         content = event.content,
                         style = MaterialTheme.typography.bodyLarge,
@@ -633,7 +633,7 @@ fun PostCard(
                                 modifier = Modifier.padding(top = 4.dp, bottom = 2.dp)
                             )
                             val emojiMap = remember(event.id) { Nip30.parseEmojiTags(event) }
-                            val imetaMap = remember(event.id) { parseImetaTags(event) }
+                            val imetaMap = remember(event.id) { parseImetaTags(event.tags) }
                             RichContent(
                                 content = translationState.translatedText,
                                 style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -39,7 +39,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.foundation.Image
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import com.wisp.app.util.BlurHashDecoder
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -93,6 +98,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -163,12 +169,19 @@ data class NoteActions(
     val onPollVote: (String, List<String>) -> Unit = { _, _ -> },
 )
 
+data class MediaMeta(
+    val url: String,
+    val mime: String? = null,
+    val dimension: String? = null,
+    val blurhash: String? = null
+)
+
 internal sealed interface ContentSegment {
     data class TextSegment(val text: String) : ContentSegment
-    data class ImageSegment(val url: String) : ContentSegment
-    data class VideoSegment(val url: String) : ContentSegment
-    data class AudioSegment(val url: String) : ContentSegment
-    data class UnknownMediaSegment(val url: String) : ContentSegment
+    data class ImageSegment(val meta: MediaMeta) : ContentSegment
+    data class VideoSegment(val meta: MediaMeta) : ContentSegment
+    data class AudioSegment(val meta: MediaMeta) : ContentSegment
+    data class UnknownMediaSegment(val meta: MediaMeta) : ContentSegment
     data class LinkSegment(val url: String) : ContentSegment
     data class InlineLinkSegment(val url: String) : ContentSegment
     data class NostrNoteSegment(val eventId: String, val relayHints: List<String> = emptyList()) : ContentSegment
@@ -195,23 +208,29 @@ private val audioMimeTypes = setOf("audio/mpeg", "audio/wav", "audio/ogg", "audi
 private val blossomPathRegex = Regex("""^/[0-9a-f]{64}$""", RegexOption.IGNORE_CASE)
 
 /**
- * Parse NIP-92 imeta tags from an event to build a URL→mime type map.
- * Tag format: ["imeta", "url https://...", "m image/png", ...]
+ * Parse NIP-92 imeta tags from a list of tags to build a URL→metadata map.
+ * Tag format: ["imeta", "url https://...", "m image/png", "dim 1024x768", "blurhash ...", ...]
  */
-internal fun parseImetaTags(event: NostrEvent): Map<String, String> {
-    val map = mutableMapOf<String, String>()
-    for (tag in event.tags) {
+fun parseImetaTags(tags: List<List<String>>): Map<String, MediaMeta> {
+    val map = mutableMapOf<String, MediaMeta>()
+    for (tag in tags) {
         if (tag.firstOrNull() != "imeta" || tag.size < 2) continue
         var url: String? = null
         var mime: String? = null
+        var dim: String? = null
+        var blur: String? = null
         for (i in 1 until tag.size) {
             val entry = tag[i]
             when {
                 entry.startsWith("url ") -> url = entry.removePrefix("url ")
                 entry.startsWith("m ") -> mime = entry.removePrefix("m ")
+                entry.startsWith("dim ") -> dim = entry.removePrefix("dim ")
+                entry.startsWith("blurhash ") -> blur = entry.removePrefix("blurhash ")
             }
         }
-        if (url != null && mime != null) map[url] = mime
+        if (url != null) {
+            map[url] = MediaMeta(url = url, mime = mime, dimension = dim, blurhash = blur)
+        }
     }
     return map
 }
@@ -253,7 +272,7 @@ private fun isStandaloneUrl(content: String, matchRange: IntRange): Boolean {
     return true
 }
 
-internal fun parseContent(content: String, emojiMap: Map<String, String> = emptyMap(), imetaMap: Map<String, String> = emptyMap(), trimBlankLines: Boolean = true): List<ContentSegment> {
+internal fun parseContent(content: String, emojiMap: Map<String, String> = emptyMap(), imetaMap: Map<String, MediaMeta> = emptyMap(), trimBlankLines: Boolean = true): List<ContentSegment> {
     val segments = mutableListOf<ContentSegment>()
     var lastEnd = 0
 
@@ -268,16 +287,17 @@ internal fun parseContent(content: String, emojiMap: Map<String, String> = empty
             segments.add(ContentSegment.HashtagSegment(hashtagCapture))
         } else if (!bareDomainCapture.isNullOrEmpty() && !token.startsWith("http")) {
             val url = "https://$bareDomainCapture"
-            val imetaMime = imetaMap[url]?.let { classifyByMime(it) }
+            val meta = imetaMap[url]
+            val imetaMime = meta?.mime?.let { classifyByMime(it) }
             val ext = url.substringAfterLast('.').substringBefore('?').lowercase()
             when {
-                imetaMime == "image" -> segments.add(ContentSegment.ImageSegment(url))
-                imetaMime == "video" -> segments.add(ContentSegment.VideoSegment(url))
-                imetaMime == "audio" -> segments.add(ContentSegment.AudioSegment(url))
-                ext in imageExtensions -> segments.add(ContentSegment.ImageSegment(url))
-                ext in videoExtensions -> segments.add(ContentSegment.VideoSegment(url))
-                ext in audioExtensions -> segments.add(ContentSegment.AudioSegment(url))
-                isBlossomUrl(url) -> segments.add(ContentSegment.UnknownMediaSegment(url))
+                imetaMime == "image" -> segments.add(ContentSegment.ImageSegment(meta!!))
+                imetaMime == "video" -> segments.add(ContentSegment.VideoSegment(meta!!))
+                imetaMime == "audio" -> segments.add(ContentSegment.AudioSegment(meta!!))
+                ext in imageExtensions -> segments.add(ContentSegment.ImageSegment(meta ?: MediaMeta(url)))
+                ext in videoExtensions -> segments.add(ContentSegment.VideoSegment(meta ?: MediaMeta(url)))
+                ext in audioExtensions -> segments.add(ContentSegment.AudioSegment(meta ?: MediaMeta(url)))
+                isBlossomUrl(url) -> segments.add(ContentSegment.UnknownMediaSegment(meta ?: MediaMeta(url)))
                 isStandaloneUrl(content, match.range) -> segments.add(ContentSegment.LinkSegment(url))
                 else -> segments.add(ContentSegment.InlineLinkSegment(url))
             }
@@ -302,22 +322,23 @@ internal fun parseContent(content: String, emojiMap: Map<String, String> = empty
         } else {
             val url = token.trimEnd('.', ',', ')', ']', ';', ':', '!', '?')
             val isWebSocket = url.startsWith("wss://") || url.startsWith("ws://")
-            val imetaMime = imetaMap[url]?.let { classifyByMime(it) }
+            val meta = imetaMap[url]
+            val imetaMime = meta?.mime?.let { classifyByMime(it) }
             val ext = url.substringAfterLast('.').substringBefore('?').lowercase()
             when {
-                imetaMime == "image" -> segments.add(ContentSegment.ImageSegment(url))
-                imetaMime == "video" -> segments.add(ContentSegment.VideoSegment(url))
-                imetaMime == "audio" -> segments.add(ContentSegment.AudioSegment(url))
-                ext in imageExtensions -> segments.add(ContentSegment.ImageSegment(url))
-                ext in videoExtensions -> segments.add(ContentSegment.VideoSegment(url))
-                ext in audioExtensions -> segments.add(ContentSegment.AudioSegment(url))
+                imetaMime == "image" -> segments.add(ContentSegment.ImageSegment(meta!!))
+                imetaMime == "video" -> segments.add(ContentSegment.VideoSegment(meta!!))
+                imetaMime == "audio" -> segments.add(ContentSegment.AudioSegment(meta!!))
+                ext in imageExtensions -> segments.add(ContentSegment.ImageSegment(meta ?: MediaMeta(url)))
+                ext in videoExtensions -> segments.add(ContentSegment.VideoSegment(meta ?: MediaMeta(url)))
+                ext in audioExtensions -> segments.add(ContentSegment.AudioSegment(meta ?: MediaMeta(url)))
                 isWebSocket && '\'' in url -> {
                     val parsed = Nip29.parseGroupIdentifier(url)
                     if (parsed != null) segments.add(ContentSegment.GroupInviteSegment(parsed.first, parsed.second))
                     else segments.add(ContentSegment.InlineLinkSegment(url))
                 }
                 isWebSocket -> segments.add(ContentSegment.InlineLinkSegment(url))
-                isBlossomUrl(url) -> segments.add(ContentSegment.UnknownMediaSegment(url))
+                isBlossomUrl(url) -> segments.add(ContentSegment.UnknownMediaSegment(meta ?: MediaMeta(url)))
                 isStandaloneUrl(content, match.range) -> segments.add(ContentSegment.LinkSegment(url))
                 else -> segments.add(ContentSegment.InlineLinkSegment(url))
             }
@@ -566,7 +587,7 @@ fun RichContent(
     color: Color = MaterialTheme.colorScheme.onSurface,
     linkColor: Color = Color.Unspecified,
     emojiMap: Map<String, String> = emptyMap(),
-    imetaMap: Map<String, String> = emptyMap(),
+    imetaMap: Map<String, MediaMeta> = emptyMap(),
     plainLinks: Boolean = false,
     eventRepo: EventRepository? = null,
     onProfileClick: ((String) -> Unit)? = null,
@@ -764,27 +785,27 @@ fun RichContent(
                 when (segment) {
                     is ContentSegment.ImageSegment -> {
                         ImageWithContextMenu(
-                            url = segment.url,
-                            onFullScreen = { fullScreenImageUrl = segment.url }
+                            meta = segment.meta,
+                            onFullScreen = { fullScreenImageUrl = segment.meta.url }
                         )
                     }
                     is ContentSegment.VideoSegment -> {
                         InlineVideoPlayerWithFullscreen(
-                            url = segment.url,
+                            meta = segment.meta,
                             onFullScreen = { positionMs ->
-                                FullScreenVideoState.enter(segment.url, positionMs)
+                                FullScreenVideoState.enter(segment.meta.url, positionMs)
                             }
                         )
                     }
                     is ContentSegment.AudioSegment -> {
-                        InlineAudioPlayer(url = segment.url)
+                        InlineAudioPlayer(meta = segment.meta)
                     }
                     is ContentSegment.UnknownMediaSegment -> {
                         UnknownMediaContent(
-                            url = segment.url,
-                            onFullScreenImage = { fullScreenImageUrl = segment.url },
+                            meta = segment.meta,
+                            onFullScreenImage = { fullScreenImageUrl = segment.meta.url },
                             onFullScreenVideo = { positionMs ->
-                                FullScreenVideoState.enter(segment.url, positionMs)
+                                FullScreenVideoState.enter(segment.meta.url, positionMs)
                             }
                         )
                     }
@@ -1125,7 +1146,8 @@ fun QuotedNote(
                     content = event.content,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
-                    eventRepo = eventRepo
+                    eventRepo = eventRepo,
+                    imetaMap = parseImetaTags(event.tags)
                 )
             }
         }
@@ -1300,14 +1322,21 @@ private fun ArticleCard(
         } else {
             Column {
                 if (image != null) {
-                    AsyncImage(
+                    val meta = remember(event.id) { parseImetaTags(event.tags)[image] ?: MediaMeta(url = image) }
+                    val ratio = remember(meta.dimension) { parseAspectRatio(meta.dimension) }
+                    SubcomposeAsyncImage(
                         model = image,
                         contentDescription = title,
                         contentScale = ContentScale.Crop,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .heightIn(max = 180.dp)
-                            .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                            .let { if (ratio != null) it.aspectRatio(ratio) else it.heightIn(max = 180.dp) }
+                            .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
+                        loading = {
+                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                            }
+                        }
                     )
                 }
                 Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
@@ -1460,14 +1489,39 @@ private fun LiveStreamCardContent(
                             .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
                     )
                 } else if (image != null) {
-                    AsyncImage(
+                    val meta = remember(event.id) { parseImetaTags(event.tags)[image] ?: MediaMeta(url = image) }
+                    val ratio = remember(meta.dimension) { parseAspectRatio(meta.dimension) }
+                    val blurPainter = remember(meta.blurhash, meta.dimension) {
+                        val dims = meta.dimension?.split('x')
+                        val w = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                        val h = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                        BlurHashDecoder.decode(meta.blurhash, w, h)?.asImageBitmap()?.let { BitmapPainter(it) }
+                    }
+                    SubcomposeAsyncImage(
                         model = image,
                         contentDescription = title,
                         contentScale = ContentScale.Crop,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .heightIn(max = 180.dp)
-                            .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                            .let { if (ratio != null) it.aspectRatio(ratio) else it.heightIn(max = 180.dp) }
+                            .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
+                        loading = {
+                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                if (blurPainter != null) {
+                                    Image(
+                                        painter = blurPainter,
+                                        contentDescription = null,
+                                        contentScale = ContentScale.Crop,
+                                        modifier = Modifier.fillMaxSize()
+                                    )
+                                }
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(24.dp),
+                                    strokeWidth = 2.dp,
+                                    color = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
                     )
                 }
                 Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
@@ -1748,10 +1802,11 @@ private enum class ResolvedMediaType { IMAGE, VIDEO, LINK }
 
 @Composable
 private fun UnknownMediaContent(
-    url: String,
+    meta: MediaMeta,
     onFullScreenImage: () -> Unit,
     onFullScreenVideo: (positionMs: Long) -> Unit
 ) {
+    val url = meta.url
     var resolved by remember(url) { mutableStateOf(contentTypeCache.get(url)?.let { classifyByMime(it) }) }
     var loading by remember(url) { mutableStateOf(resolved == null) }
 
@@ -1789,33 +1844,49 @@ private fun UnknownMediaContent(
                     .padding(vertical = 4.dp)
                     .clip(RoundedCornerShape(12.dp))
             ) {
+                val blurPainter = remember(meta.blurhash, meta.dimension) {
+                    val dims = meta.dimension?.split('x')
+                    val w = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                    val h = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                    BlurHashDecoder.decode(meta.blurhash, w, h)?.asImageBitmap()?.let { BitmapPainter(it) }
+                }
                 Box(contentAlignment = Alignment.Center) {
+                    if (blurPainter != null) {
+                        Image(
+                            painter = blurPainter,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
                     CircularProgressIndicator(
                         modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp
+                        strokeWidth = 2.dp,
+                        color = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.primary
                     )
                 }
             }
         }
         resolved == "image" -> {
-            ImageWithContextMenu(url = url, onFullScreen = onFullScreenImage)
+            ImageWithContextMenu(meta = meta, onFullScreen = onFullScreenImage)
         }
         resolved == "video" -> {
-            InlineVideoPlayerWithFullscreen(url = url, onFullScreen = onFullScreenVideo)
+            InlineVideoPlayerWithFullscreen(meta = meta, onFullScreen = onFullScreenVideo)
         }
         resolved == "audio" -> {
-            InlineAudioPlayer(url = url)
+            InlineAudioPlayer(meta = meta)
         }
         else -> {
             // Fallback: try loading as image (most blossom content is images)
-            ImageWithContextMenu(url = url, onFullScreen = onFullScreenImage)
+            ImageWithContextMenu(meta = meta, onFullScreen = onFullScreenImage)
         }
     }
 }
 
 @OptIn(UnstableApi::class)
 @Composable
-private fun InlineAudioPlayer(url: String) {
+private fun InlineAudioPlayer(meta: MediaMeta) {
+    val url = meta.url
     val context = LocalContext.current
     val autoLoad = LocalMediaSettings.current.autoLoadMedia
     var loaded by remember { mutableStateOf(autoLoad) }
@@ -1950,7 +2021,8 @@ private fun formatAudioTime(ms: Long): String {
 
 @kotlin.OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun ImageWithContextMenu(url: String, onFullScreen: () -> Unit) {
+private fun ImageWithContextMenu(meta: MediaMeta, onFullScreen: () -> Unit) {
+    val url = meta.url
     val autoLoad = LocalMediaSettings.current.autoLoadMedia
     var loaded by remember { mutableStateOf(autoLoad) }
     var showMenu by remember { mutableStateOf(false) }
@@ -1967,6 +2039,20 @@ private fun ImageWithContextMenu(url: String, onFullScreen: () -> Unit) {
                 .clickable { loaded = true },
             color = MaterialTheme.colorScheme.surfaceVariant
         ) {
+            val blurPainter = remember(meta.blurhash, meta.dimension) {
+                val dims = meta.dimension?.split('x')
+                val w = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                val h = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                BlurHashDecoder.decode(meta.blurhash, w, h)?.asImageBitmap()?.let { BitmapPainter(it) }
+            }
+            if (blurPainter != null) {
+                Image(
+                    painter = blurPainter,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -1976,31 +2062,57 @@ private fun ImageWithContextMenu(url: String, onFullScreen: () -> Unit) {
                     imageVector = Icons.Filled.Image,
                     contentDescription = "Load image",
                     modifier = Modifier.size(40.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    tint = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
                     "Tap to load",
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
         return
     }
 
+    val ratio = remember(meta.dimension) { parseAspectRatio(meta.dimension) }
+    val blurPainter = remember(meta.blurhash, meta.dimension) {
+        val dims = meta.dimension?.split('x')
+        val w = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+        val h = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+        BlurHashDecoder.decode(meta.blurhash, w, h)?.asImageBitmap()?.let { BitmapPainter(it) }
+    }
+
     Box {
-        AsyncImage(
+        SubcomposeAsyncImage(
             model = url,
             contentDescription = "Image",
             contentScale = ContentScale.FillWidth,
             modifier = Modifier
                 .fillMaxWidth()
+                .let { if (ratio != null) it.aspectRatio(ratio) else it }
                 .clip(RoundedCornerShape(12.dp))
                 .combinedClickable(
                     onClick = onFullScreen,
                     onLongClick = { showMenu = true }
-                )
+                ),
+            loading = {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    if (blurPainter != null) {
+                        Image(
+                            painter = blurPainter,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                        color = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
         )
         DropdownMenu(
             expanded = showMenu,
@@ -2026,7 +2138,8 @@ private fun ImageWithContextMenu(url: String, onFullScreen: () -> Unit) {
 
 @OptIn(UnstableApi::class)
 @Composable
-internal fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positionMs: Long) -> Unit) {
+internal fun InlineVideoPlayerWithFullscreen(meta: MediaMeta, onFullScreen: (positionMs: Long) -> Unit) {
+    val url = meta.url
     val mediaSettings = LocalMediaSettings.current
     var loaded by remember { mutableStateOf(mediaSettings.autoLoadMedia) }
 
@@ -2039,6 +2152,20 @@ internal fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positio
                 .clickable { loaded = true },
             color = MaterialTheme.colorScheme.surfaceVariant
         ) {
+            val blurPainter = remember(meta.blurhash, meta.dimension) {
+                val dims = meta.dimension?.split('x')
+                val w = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                val h = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                BlurHashDecoder.decode(meta.blurhash, w, h)?.asImageBitmap()?.let { BitmapPainter(it) }
+            }
+            if (blurPainter != null) {
+                Image(
+                    painter = blurPainter,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -2048,13 +2175,13 @@ internal fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positio
                     imageVector = Icons.Filled.PlayArrow,
                     contentDescription = "Load video",
                     modifier = Modifier.size(48.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    tint = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
                     "Tap to load",
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
@@ -2071,6 +2198,20 @@ internal fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positio
                 .clip(RoundedCornerShape(12.dp)),
             color = MaterialTheme.colorScheme.surfaceVariant
         ) {
+            val blurPainter = remember(meta.blurhash, meta.dimension) {
+                val dims = meta.dimension?.split('x')
+                val w = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                val h = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+                BlurHashDecoder.decode(meta.blurhash, w, h)?.asImageBitmap()?.let { BitmapPainter(it) }
+            }
+            if (blurPainter != null) {
+                Image(
+                    painter = blurPainter,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -2080,13 +2221,13 @@ internal fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positio
                     painter = painterResource(R.drawable.ic_pip),
                     contentDescription = null,
                     modifier = Modifier.size(36.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    tint = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
                     "Playing in mini player",
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = if (blurPainter != null) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
@@ -2095,11 +2236,13 @@ internal fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positio
 
     val context = LocalContext.current
     val view = LocalView.current
-    var videoAspectRatio by remember { mutableFloatStateOf(16f / 9f) }
+    var videoAspectRatio by remember { mutableFloatStateOf(parseAspectRatio(meta.dimension) ?: (16f / 9f)) }
     val isMuted by globalMuted.collectAsState()
     var showControls by remember { mutableStateOf(false) }
     var userPaused by remember { mutableStateOf(false) }
     var isPlaying by remember { mutableStateOf(false) }
+    var isBuffering by remember { mutableStateOf(false) }
+
     val exoPlayer = remember(url) {
         PipController.reclaimPlayer(url)
             ?: HttpClientFactory.createExoPlayer(context).apply {
@@ -2127,6 +2270,9 @@ internal fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positio
                 if (!playing && exoPlayer.playbackState == Player.STATE_READY) {
                     userPaused = true
                 }
+            }
+            override fun onPlaybackStateChanged(state: Int) {
+                isBuffering = state == Player.STATE_BUFFERING
             }
         }
         exoPlayer.addListener(listener)
@@ -2190,6 +2336,13 @@ internal fun InlineVideoPlayerWithFullscreen(url: String, onFullScreen: (positio
             },
             modifier = Modifier.fillMaxSize()
         )
+
+        if (isBuffering) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = Color.White.copy(alpha = 0.7f), strokeWidth = 2.dp)
+            }
+        }
+
         AnimatedVisibility(
             visible = showControls,
             enter = fadeIn(),
@@ -2350,6 +2503,7 @@ private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
     var showControls by remember { mutableStateOf(false) }
     var userPaused by remember { mutableStateOf(false) }
     var isPlaying by remember { mutableStateOf(false) }
+    var isBuffering by remember { mutableStateOf(false) }
     val exoPlayer = remember(url) {
         PipController.reclaimPlayer(url)
             ?: HttpClientFactory.createExoPlayer(context).apply {
@@ -2376,6 +2530,9 @@ private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
                 if (!playing && exoPlayer.playbackState == Player.STATE_READY) {
                     userPaused = true
                 }
+            }
+            override fun onPlaybackStateChanged(state: Int) {
+                isBuffering = state == Player.STATE_BUFFERING
             }
         }
         exoPlayer.addListener(listener)
@@ -2433,6 +2590,13 @@ private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
             },
             modifier = Modifier.fillMaxSize()
         )
+
+        if (isBuffering) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = Color.White.copy(alpha = 0.7f), strokeWidth = 2.dp)
+            }
+        }
+
         AnimatedVisibility(
             visible = showControls,
             enter = fadeIn(),
@@ -2483,6 +2647,15 @@ private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
             }
         }
     }
+}
+
+private fun parseAspectRatio(dim: String?): Float? {
+    if (dim == null) return null
+    val parts = dim.split('x')
+    if (parts.size != 2) return null
+    val w = parts[0].toFloatOrNull() ?: return null
+    val h = parts[1].toFloatOrNull() ?: return null
+    return if (h > 0) w / h else null
 }
 
 // --- Link Preview (OG tags) ---

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DraftsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DraftsScreen.kt
@@ -199,8 +199,8 @@ private fun DraftItem(
 ) {
     val isReply = draft.tags.any { it.size >= 2 && it[0] == "e" }
     val displayName = userProfile?.displayString ?: stringResource(R.string.draft_label)
-    val emojiMap = remember(draft.dTag) { emptyMap<String, String>() }
-    val imetaMap = remember(draft.dTag) { emptyMap<String, String>() }
+    val emojiMap = remember(draft.dTag) { Nip30.parseEmojiTags(draft.tags) }
+    val imetaMap = remember(draft.dTag) { parseImetaTags(draft.tags) }
 
     Column(
         modifier = Modifier
@@ -287,7 +287,7 @@ private fun ScheduledPostItem(
     val publishTime = post.created_at
     val isFuture = publishTime > System.currentTimeMillis() / 1000
     val emojiMap = remember(post.id) { Nip30.parseEmojiTags(post) }
-    val imetaMap = remember(post.id) { parseImetaTags(post) }
+    val imetaMap = remember(post.id) { parseImetaTags(post.tags) }
 
     Column(
         modifier = Modifier

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt
@@ -90,6 +90,7 @@ import com.wisp.app.repo.LiveChatMessage
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.ui.component.EmojiReactionPopup
 import com.wisp.app.ui.component.InlineVideoPlayerWithFullscreen
+import com.wisp.app.ui.component.MediaMeta
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.component.RichContent
 import com.wisp.app.viewmodel.LiveStreamViewModel
@@ -163,7 +164,12 @@ fun LiveStreamScreen(
                     .aspectRatio(16f / 9f)
             ) {
                 InlineVideoPlayerWithFullscreen(
-                    url = streamUrl,
+                    meta = MediaMeta(
+                        url = streamUrl,
+                        mime = "video/mp4", // Default to video for stream
+                        dimension = null,
+                        blurhash = null
+                    ),
                     onFullScreen = { posMs ->
                         onFullScreenVideo?.invoke(streamUrl, posMs)
                     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -40,7 +40,10 @@ import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
+import com.wisp.app.nostr.Nip30
 import com.wisp.app.ui.component.Nip05Badge
+import com.wisp.app.ui.component.RichContent
+import com.wisp.app.ui.component.parseImetaTags
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -491,12 +494,12 @@ fun UserProfileScreen(
             else (rootNotes + replies)
                 .sortedByDescending { it.created_at }
                 .flatMap { event ->
-                    val imeta = parseImetaTags(event)
+                    val imeta = parseImetaTags(event.tags)
                     parseContent(event.content, imetaMap = imeta).mapNotNull { segment ->
                         when (segment) {
-                            is ContentSegment.ImageSegment -> MediaItem(segment.url, MediaType.IMAGE)
-                            is ContentSegment.VideoSegment -> MediaItem(segment.url, MediaType.VIDEO)
-                            is ContentSegment.UnknownMediaSegment -> MediaItem(segment.url, MediaType.IMAGE)
+                            is ContentSegment.ImageSegment -> MediaItem(segment.meta.url, MediaType.IMAGE)
+                            is ContentSegment.VideoSegment -> MediaItem(segment.meta.url, MediaType.VIDEO)
+                            is ContentSegment.UnknownMediaSegment -> MediaItem(segment.meta.url, MediaType.IMAGE)
                             else -> null
                         }
                     }
@@ -1249,12 +1252,16 @@ private fun ProfileHeader(
         }
 
         profile?.about?.let { about ->
+            val emojiMap = remember(pubkey) { Nip30.parseEmojiTags(emptyList()) } // Profiles use inline or alternate tags usually not available here easily without event
+            val imetaMap = remember(pubkey) { parseImetaTags(emptyList()) }
             Spacer(Modifier.height(8.dp))
             RichContent(
                 content = about,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 plainLinks = true,
+                emojiMap = emojiMap,
+                imetaMap = imetaMap,
                 eventRepo = eventRepo,
                 onProfileClick = onNavigateToProfile
             )

--- a/app/src/main/kotlin/com/wisp/app/util/BlurHashDecoder.kt
+++ b/app/src/main/kotlin/com/wisp/app/util/BlurHashDecoder.kt
@@ -1,0 +1,109 @@
+package com.wisp.app.util
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.withSign
+
+object BlurHashDecoder {
+
+    fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f): Bitmap? {
+        if (blurHash == null || blurHash.length < 6) return null
+
+        val numComponents = decode83(blurHash, 0, 1)
+        val nx = (numComponents % 9) + 1
+        val ny = (numComponents / 9) + 1
+
+        if (blurHash.length != 4 + 2 * nx * ny) return null
+
+        val maxAc = (decode83(blurHash, 1, 2) + 1) / 166f
+        val colors = Array(nx * ny) { i ->
+            if (i == 0) {
+                val color83 = decode83(blurHash, 2, 6)
+                decodeDc(color83)
+            } else {
+                val color83 = decode83(blurHash, 4 + i * 2, 4 + i * 2 + 2)
+                decodeAc(color83, maxAc * punch)
+            }
+        }
+
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val pixels = IntArray(width * height)
+
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                var r = 0f
+                var g = 0f
+                var b = 0f
+
+                for (j in 0 until ny) {
+                    for (i in 0 until nx) {
+                        val basis = cos(Math.PI * x * i / width) * cos(Math.PI * y * j / height)
+                        val color = colors[j * nx + i]
+                        r += color[0] * basis.toFloat()
+                        g += color[1] * basis.toFloat()
+                        b += color[2] * basis.toFloat()
+                    }
+                }
+
+                val red = linearToSrgb(r)
+                val green = linearToSrgb(g)
+                val blue = linearToSrgb(b)
+
+                pixels[y * width + x] = Color.rgb(red, green, blue)
+            }
+        }
+
+        bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+        return bitmap
+    }
+
+    private fun decode83(str: String, start: Int, end: Int): Int {
+        var res = 0
+        for (i in start until end) {
+            val c = str[i]
+            val digit = charMap[c] ?: 0
+            res = res * 83 + digit
+        }
+        return res
+    }
+
+    private fun decodeDc(color83: Int): FloatArray {
+        val r = (color83 shr 16) / 255f
+        val g = ((color83 shr 8) and 255) / 255f
+        val b = (color83 and 255) / 255f
+        return floatArrayOf(srgbToLinear(r), srgbToLinear(g), srgbToLinear(b))
+    }
+
+    private fun decodeAc(value: Int, maxAc: Float): FloatArray {
+        val r = value / (19 * 19)
+        val g = (value / 19) % 19
+        val b = value % 19
+        return floatArrayOf(
+            signedPow2((r - 9) / 9f) * maxAc,
+            signedPow2((g - 9) / 9f) * maxAc,
+            signedPow2((b - 9) / 9f) * maxAc
+        )
+    }
+
+    private fun srgbToLinear(v: Float): Float {
+        val f = v / 255f
+        return if (f <= 0.04045f) f / 12.92f else ((f + 0.055f) / 1.055f).pow(2.4f)
+    }
+
+    private fun linearToSrgb(v: Float): Int {
+        val f = v.coerceIn(0f, 1f)
+        return if (f <= 0.0031308f) {
+            (f * 12.92f * 255f + 0.5f).toInt()
+        } else {
+            ((1.055f * f.pow(1f / 2.4f) - 0.055f) * 255f + 0.5f).toInt()
+        }
+    }
+
+    private fun signedPow2(v: Float) = v.pow(2f).withSign(v)
+
+    private val charMap = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~"
+        .mapIndexed { i, c -> c to i }
+        .toMap()
+}


### PR DESCRIPTION
- Introduce `BlurHashDecoder` for decoding BlurHash strings into blurred placeholder bitmaps.
- Update `parseImetaTags` to extract `dimension` and `blurhash` from NIP-92 tags.
- Refactor `RichContent` segments to use a new `MediaMeta` data class instead of raw URL strings.
- Implement blurred placeholders and aspect-ratio-aware loading states in `RichContent`, `PostCard`, and `GalleryCard`.
- Add buffering indicators to `InlineVideoPlayerWithFullscreen`.
- Ensure `imeta` and emoji tags are correctly parsed and passed to `RichContent` in `DraftsScreen` and `UserProfileScreen`.