### PR TITLE
feat: Web of Trust global content filter

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -2620,7 +2620,8 @@ fun WispNavHost(
                 safetyPrefs = feedViewModel.safetyPrefs,
                 cachedNetwork = feedViewModel.extendedNetworkRepo.cachedNetwork,
                 isNetworkReady = { feedViewModel.extendedNetworkRepo.isNetworkReady() },
-                onNavigateToSocialGraph = { navController.navigate(Routes.SOCIAL_GRAPH) }
+                onNavigateToSocialGraph = { navController.navigate(Routes.SOCIAL_GRAPH) },
+                onWotToggled = { feedViewModel.eventRepo.rebuildFeedFromCache() }
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -37,6 +37,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     var currentUserPubkey: String? = null
     var eventPersistence: EventPersistence? = null
     var contactRepo: ContactRepository? = null
+    var safetyPrefs: SafetyPreferences? = null
+    var extendedNetworkRepo: ExtendedNetworkRepository? = null
     /** Set of current user's DM relay URLs — used to detect private zaps. */
     var dmRelayUrls: Set<String> = emptySet()
     private val eventCache = ConcurrentHashMap<String, NostrEvent>()
@@ -294,6 +296,17 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         versionDirty.trySend(Unit)
     }
 
+    private val WOT_EXEMPT_KINDS = intArrayOf(0, 3, 4, 10002, 10050, 1059, 13, 14)
+
+    private fun isWotFiltered(pubkey: String, kind: Int): Boolean {
+        if (safetyPrefs?.wotFilterEnabled?.value != true) return false
+        val netRepo = extendedNetworkRepo ?: return false
+        if (!netRepo.isNetworkReady()) return false
+        if (kind in WOT_EXEMPT_KINDS) return false
+        if (pubkey == currentUserPubkey) return false
+        return !netRepo.isInQualifiedNetwork(pubkey)
+    }
+
     fun addEvent(event: NostrEvent) {
         if (event.kind == Nip88.KIND_POLL_RESPONSE) {
             val isNew = event.id !in seenEventIds
@@ -311,6 +324,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             if (muteRepo?.isThreadMuted(threadRoot) == true) return
         }
         if (deletedEventsRepo?.isDeleted(event.id) == true) return
+        if (isWotFiltered(event.pubkey, event.kind)) return
         // Track liveness: only count followed authors with recent active-content kinds,
         // so historical fetches, profile metadata, and strangers don't inflate the online count.
         if (event.kind == 1 || event.kind == 6 || event.kind == 7 || event.kind == 30023 || event.kind == 20 || event.kind == 21 || event.kind == 22) {
@@ -358,6 +372,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                         val inner = fromJson(event.content)
                         if (muteRepo?.isBlocked(inner.pubkey) == true) return
                         if (muteRepo?.containsMutedWord(inner.content) == true) return
+                        if (isWotFiltered(event.pubkey, 6) && isWotFiltered(inner.pubkey, 1)) return
                         val authors = repostAuthors.get(inner.id)
                             ?: ConcurrentHashMap.newKeySet<String>().also { repostAuthors.put(inner.id, it) }
                         authors.add(event.pubkey)
@@ -419,6 +434,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             7 -> addReaction(event)
             30315 -> processUserStatus(event)
             9735 -> {
+                val zapperPk = Nip57.getZapperPubkey(event)
+                if (zapperPk != null && isWotFiltered(zapperPk, 9735)) return
                 val targetId = Nip57.getZappedEventId(event)
                     ?: resolveAddressableTarget(event)
                     ?: return
@@ -463,6 +480,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     }
 
     private fun addReaction(event: NostrEvent) {
+        if (isWotFiltered(event.pubkey, event.kind)) return
         val targetEventId = event.tags.lastOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
             ?: resolveAddressableTarget(event)
             ?: return
@@ -1196,6 +1214,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             if (event.created_at > System.currentTimeMillis() / 1000 + 30) continue  // skip future-dated (scheduled) notes
             if (muteRepo?.isBlocked(event.pubkey) == true) continue
             if (deletedEventsRepo?.isDeleted(event.id) == true) continue
+            if (isWotFiltered(event.pubkey, event.kind)) continue
             val threadRoot = Nip10.getRootId(event) ?: Nip10.getReplyTarget(event) ?: event.id
             if (muteRepo?.isThreadMuted(threadRoot) == true) continue
             val isReply = Nip10.isReply(event)

--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -29,6 +29,7 @@ class NotificationRepository(
     var spamAuthorCache: SpamAuthorCache? = null
     var safetyPrefs: SafetyPreferences? = null
     var contactRepo: ContactRepository? = null
+    var extendedNetworkRepo: com.wisp.app.repo.ExtendedNetworkRepository? = null
 
     private val prefs: SharedPreferences =
         context.getSharedPreferences("wisp_notif_${pubkeyHex ?: "anon"}", Context.MODE_PRIVATE)
@@ -142,6 +143,15 @@ class NotificationRepository(
         if (event.kind == 9735) {
             val zapperPubkey = Nip57.getZapperPubkey(event)
             if (zapperPubkey != null && muteRepo?.isBlocked(zapperPubkey) == true) return
+        }
+        if (safetyPrefs?.wotFilterEnabled?.value == true) {
+            val netRepo = extendedNetworkRepo
+            if (netRepo != null && netRepo.isNetworkReady()) {
+                val pubkeyToCheck = if (event.kind == 9735) {
+                    Nip57.getZapperPubkey(event) ?: event.pubkey
+                } else event.pubkey
+                if (!netRepo.isInQualifiedNetwork(pubkeyToCheck)) return
+            }
         }
         val hasPTag = event.tags.any { it.size >= 2 && it[0] == "p" && it[1] == myPubkey }
         // Kind 6 reposts may omit the p-tag; callers must pre-filter kind 6 ownership.

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyFiltersTab.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyFiltersTab.kt
@@ -33,7 +33,8 @@ fun SafetyFiltersTab(
     safetyPrefs: SafetyPreferences,
     cachedNetwork: StateFlow<ExtendedNetworkCache?>,
     isNetworkReady: () -> Boolean,
-    onNavigateToSocialGraph: () -> Unit
+    onNavigateToSocialGraph: () -> Unit,
+    onWotToggled: () -> Unit = {}
 ) {
     val spamEnabled by safetyPrefs.spamFilterEnabled.collectAsState()
     val wotEnabled by safetyPrefs.wotFilterEnabled.collectAsState()
@@ -86,7 +87,10 @@ fun SafetyFiltersTab(
             }
             Switch(
                 checked = wotEnabled,
-                onCheckedChange = { safetyPrefs.setWotFilterEnabled(it) }
+                onCheckedChange = {
+                    safetyPrefs.setWotFilterEnabled(it)
+                    onWotToggled()
+                }
             )
         }
         Text(

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyScreen.kt
@@ -58,7 +58,8 @@ fun SafetyScreen(
     safetyPrefs: SafetyPreferences? = null,
     cachedNetwork: StateFlow<ExtendedNetworkCache?>? = null,
     isNetworkReady: () -> Boolean = { false },
-    onNavigateToSocialGraph: () -> Unit = {}
+    onNavigateToSocialGraph: () -> Unit = {},
+    onWotToggled: () -> Unit = {}
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
 
@@ -107,7 +108,8 @@ fun SafetyScreen(
                         safetyPrefs = safetyPrefs,
                         cachedNetwork = cachedNetwork,
                         isNetworkReady = isNetworkReady,
-                        onNavigateToSocialGraph = onNavigateToSocialGraph
+                        onNavigateToSocialGraph = onNavigateToSocialGraph,
+                        onWotToggled = onWotToggled
                     )
                 }
                 1 -> MutedWordsTab(muteRepo, onChanged)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -243,10 +243,13 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         null
     }
     init {
+        eventRepo.safetyPrefs = safetyPrefs
+        eventRepo.extendedNetworkRepo = extendedNetworkRepo
         notifRepo.spamClassifier = nspamClassifier
         notifRepo.spamAuthorCache = spamAuthorCache
         notifRepo.safetyPrefs = safetyPrefs
         notifRepo.contactRepo = contactRepo
+        notifRepo.extendedNetworkRepo = extendedNetworkRepo
     }
     val customEmojiRepo = CustomEmojiRepository(app, pubkeyHex)
     val translationRepo = TranslationRepository()


### PR DESCRIPTION
## Summary

- When **Web of Trust** is enabled in Settings → Safety → Filters, events from pubkeys outside the user's qualified social graph are dropped globally
- The qualified set = user's own pubkey + first-degree follows + extended network pubkeys (computed via the existing Social Graph screen)
- Filtering applies to **all event types**: notes (kind 1), reactions (kind 7), zaps (kind 9735, checked against zapper pubkey), and reposts (kind 6, checked against both reposter and inner author)
- **Exempt kinds**: profiles (0), contact lists (3), relay lists (10002), DM-related kinds (4, 1059, 13, 14), DM relay lists (10050) — these always pass through
- **Fail-open**: filter is inactive when the social graph hasn't been computed or is stale
- Toggling the filter triggers an immediate feed rebuild from cache
- Filter also applies at the notification ingestion layer

## Modified files

| File | Change |
|---|---|
| `EventRepository.kt` | Added `isWotFiltered()` helper; WoT check in `addEvent()`, `addReaction()`, zap path, repost path, and `rebuildFeedFromCache()` |
| `NotificationRepository.kt` | WoT check in `addEvent()` for notifications |
| `FeedViewModel.kt` | Wire `safetyPrefs` and `extendedNetworkRepo` into `EventRepository` and `NotificationRepository` |
| `SafetyFiltersTab.kt` | Added `onWotToggled` callback when WoT switch is toggled |
| `SafetyScreen.kt` | Pass through `onWotToggled` |
| `Navigation.kt` | Wire `onWotToggled` → `rebuildFeedFromCache()` |

## Test plan

- [ ] Without computing social graph, enable WoT → feed still shows everything (fail-open), Filters tab shows "Social graph not computed" warning
- [ ] Compute social graph (Drawer → Social Graph → Compute)
- [ ] Enable WoT → feed collapses to only qualified-network authors; reaction counts and zap amounts drop to only in-network engagement
- [ ] Disable WoT → everything reappears without restart
- [ ] Follow a previously-hidden account → their content appears immediately (follows are always in-network)
- [ ] DMs from out-of-network accounts still arrive
- [ ] Notifications from out-of-network accounts are filtered when WoT is on