### PR TITLE
fix: strip nostr: prefix from search queries

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/SearchViewModel.kt
@@ -129,7 +129,7 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
         autoSearchJob?.cancel()
         val pool = relayPool ?: return
         val repo = eventRepoRef ?: return
-        val trimmed = newQuery.trim()
+        val trimmed = newQuery.trim().removePrefix("nostr:")
         if (trimmed.length < 2) return
         autoSearchJob = viewModelScope.launch {
             delay(500)
@@ -153,7 +153,7 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun searchAuthors(query: String, relayPool: RelayPool, eventRepo: EventRepository) {
-        val trimmed = query.trim()
+        val trimmed = query.trim().removePrefix("nostr:")
         if (trimmed.isEmpty()) {
             _authorSearchResults.value = emptyList()
             return
@@ -213,7 +213,7 @@ class SearchViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun search(query: String, relayPool: RelayPool, eventRepo: EventRepository, muteRepo: MuteRepository? = null) {
-        val trimmed = query.trim()
+        val trimmed = query.trim().removePrefix("nostr:")
         if (trimmed.isEmpty()) {
             clear()
             return


### PR DESCRIPTION
## Summary
- Automatically strips the `nostr:` prefix from search queries so users can paste URIs like `nostr:npub1...` or `nostr:nevent1...` directly and get results
- Applied to all three search paths: auto-search, explicit search, and author search

## Test plan
- [ ] Paste a `nostr:npub1...` URI into search — should find the user
- [ ] Paste a `nostr:nevent1...` URI into search — should resolve
- [ ] Search without the prefix still works as before