### PR TITLE
Normie Mode (fiat)

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/WispApp.kt
+++ b/app/src/main/kotlin/com/wisp/app/WispApp.kt
@@ -12,6 +12,7 @@ import com.wisp.app.db.WispObjectBox
 import com.wisp.app.relay.HttpClientFactory
 import com.wisp.app.relay.TorManager
 import com.wisp.app.repo.DiagnosticLogger
+import com.wisp.app.repo.ExchangeRateRepository
 import com.wisp.app.repo.ZapSender
 import okhttp3.Call
 
@@ -24,6 +25,7 @@ class WispApp : Application(), SingletonImageLoader.Factory {
         WispObjectBox.init(this)
         TorManager.initialize(this)
         ZapSender.init(this)
+        ExchangeRateRepository.init(this)
     }
 
     override fun newImageLoader(context: android.content.Context): ImageLoader {

--- a/app/src/main/kotlin/com/wisp/app/repo/ExchangeRateRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/ExchangeRateRepository.kt
@@ -1,0 +1,159 @@
+package com.wisp.app.repo
+
+import android.content.Context
+import android.util.Log
+import com.wisp.app.relay.HttpClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Request
+import java.io.IOException
+
+data class FiatCurrency(val code: String, val symbol: String, val name: String)
+
+object ExchangeRateRepository {
+
+    private const val TAG = "ExchangeRateRepo"
+    private const val PREFS_NAME = "wisp_exchange_rates"
+    private const val KEY_RATES_JSON = "rates_json"
+    private const val KEY_UPDATED_AT = "rates_updated_at"
+
+    val SUPPORTED: List<FiatCurrency> = listOf(
+        FiatCurrency("USD", "$", "US Dollar"),
+        FiatCurrency("EUR", "€", "Euro"),
+        FiatCurrency("GBP", "£", "British Pound"),
+        FiatCurrency("JPY", "¥", "Japanese Yen"),
+        FiatCurrency("CAD", "$", "Canadian Dollar"),
+        FiatCurrency("AUD", "$", "Australian Dollar"),
+        FiatCurrency("CHF", "Fr", "Swiss Franc"),
+        FiatCurrency("CNY", "¥", "Chinese Yuan"),
+        FiatCurrency("INR", "₹", "Indian Rupee"),
+        FiatCurrency("BRL", "R$", "Brazilian Real"),
+        FiatCurrency("MXN", "$", "Mexican Peso"),
+        FiatCurrency("KRW", "₩", "South Korean Won"),
+        FiatCurrency("SGD", "$", "Singapore Dollar"),
+        FiatCurrency("ZAR", "R", "South African Rand"),
+        FiatCurrency("HKD", "$", "Hong Kong Dollar"),
+        FiatCurrency("NZD", "$", "New Zealand Dollar"),
+        FiatCurrency("SEK", "kr", "Swedish Krona"),
+        FiatCurrency("NOK", "kr", "Norwegian Krone"),
+        FiatCurrency("DKK", "kr", "Danish Krone"),
+        FiatCurrency("PLN", "zł", "Polish Złoty"),
+        FiatCurrency("TRY", "₺", "Turkish Lira"),
+        FiatCurrency("THB", "฿", "Thai Baht"),
+        FiatCurrency("IDR", "Rp", "Indonesian Rupiah"),
+        FiatCurrency("PHP", "₱", "Philippine Peso"),
+        FiatCurrency("AED", "د.إ", "UAE Dirham"),
+        FiatCurrency("SAR", "﷼", "Saudi Riyal")
+    )
+
+    private val vsCurrencies: String by lazy {
+        SUPPORTED.joinToString(",") { it.code.lowercase() }
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val _rates = MutableStateFlow<Map<String, Double>>(emptyMap())
+    /** Map of UPPERCASE currency code → BTC price in that currency. */
+    val rates: StateFlow<Map<String, Double>> = _rates.asStateFlow()
+
+    private val _updatedAtMs = MutableStateFlow(0L)
+    val updatedAtMs: StateFlow<Long> = _updatedAtMs.asStateFlow()
+
+    private var appContext: Context? = null
+
+    fun init(context: Context) {
+        if (appContext != null) return
+        appContext = context.applicationContext
+        loadCached()
+        refresh()
+    }
+
+    fun refresh() {
+        val ctx = appContext ?: return
+        scope.launch {
+            try {
+                val url = "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=$vsCurrencies"
+                val client = HttpClientFactory.createHttpClient(
+                    connectTimeoutSeconds = 10,
+                    readTimeoutSeconds = 15
+                )
+                val request = Request.Builder().url(url).build()
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        Log.w(TAG, "Rate fetch failed: HTTP ${response.code}")
+                        return@launch
+                    }
+                    val body = response.body?.string() ?: return@launch
+                    val parsed = parseRates(body)
+                    if (parsed.isNotEmpty()) {
+                        val now = System.currentTimeMillis()
+                        _rates.value = parsed
+                        _updatedAtMs.value = now
+                        saveCached(ctx, body, now)
+                    }
+                }
+            } catch (e: IOException) {
+                Log.w(TAG, "Rate fetch network error: ${e.message}")
+            } catch (e: Exception) {
+                Log.w(TAG, "Rate fetch error: ${e.message}", e)
+            }
+        }
+    }
+
+    /**
+     * Converts sats to fiat in the given currency.
+     * Returns null if no cached rate is available yet.
+     */
+    fun satsToFiat(sats: Long, currency: String): Double? {
+        val btcPrice = _rates.value[currency.uppercase()] ?: return null
+        return sats.toDouble() / 100_000_000.0 * btcPrice
+    }
+
+    fun currencyFor(code: String): FiatCurrency =
+        SUPPORTED.firstOrNull { it.code.equals(code, ignoreCase = true) } ?: SUPPORTED[0]
+
+    private fun loadCached() {
+        val ctx = appContext ?: return
+        val prefs = ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val body = prefs.getString(KEY_RATES_JSON, null) ?: return
+        val updatedAt = prefs.getLong(KEY_UPDATED_AT, 0L)
+        try {
+            val parsed = parseRates(body)
+            if (parsed.isNotEmpty()) {
+                _rates.value = parsed
+                _updatedAtMs.value = updatedAt
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse cached rates: ${e.message}")
+        }
+    }
+
+    private fun saveCached(context: Context, body: String, updatedAt: Long) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_RATES_JSON, body)
+            .putLong(KEY_UPDATED_AT, updatedAt)
+            .apply()
+    }
+
+    private fun parseRates(body: String): Map<String, Double> {
+        val root = json.parseToJsonElement(body).jsonObject
+        val btc = root["bitcoin"]?.jsonObject ?: return emptyMap()
+        val out = mutableMapOf<String, Double>()
+        for ((key, value) in btc) {
+            val price = value.jsonPrimitive.doubleOrNull ?: continue
+            out[key.uppercase()] = price
+        }
+        return out
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/repo/FiatPreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/FiatPreferences.kt
@@ -1,0 +1,45 @@
+package com.wisp.app.repo
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FiatPreferences(context: Context) {
+    private val prefs = context.getSharedPreferences("wisp_settings", Context.MODE_PRIVATE)
+
+    private val _fiatMode = MutableStateFlow(prefs.getBoolean(KEY_FIAT_MODE, false))
+    val fiatMode: StateFlow<Boolean> = _fiatMode.asStateFlow()
+
+    private val _currency = MutableStateFlow(prefs.getString(KEY_CURRENCY, "USD") ?: "USD")
+    val currency: StateFlow<String> = _currency.asStateFlow()
+
+    fun isFiatMode(): Boolean = _fiatMode.value
+
+    fun setFiatMode(enabled: Boolean) {
+        if (_fiatMode.value == enabled) return
+        prefs.edit().putBoolean(KEY_FIAT_MODE, enabled).apply()
+        _fiatMode.value = enabled
+    }
+
+    fun getCurrency(): String = _currency.value
+
+    fun setCurrency(code: String) {
+        if (_currency.value == code) return
+        prefs.edit().putString(KEY_CURRENCY, code).apply()
+        _currency.value = code
+    }
+
+    companion object {
+        private const val KEY_FIAT_MODE = "fiat_mode_enabled"
+        private const val KEY_CURRENCY = "fiat_currency"
+
+        @Volatile
+        private var INSTANCE: FiatPreferences? = null
+
+        fun get(context: Context): FiatPreferences =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: FiatPreferences(context.applicationContext).also { INSTANCE = it }
+            }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
@@ -49,7 +50,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wisp.app.R
+import com.wisp.app.repo.FiatPreferences
 import com.wisp.app.ui.theme.WispThemeColors
+import com.wisp.app.ui.util.AmountFormatter
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import coil3.compose.AsyncImage
@@ -82,8 +86,7 @@ fun ActionBar(
     modifier: Modifier = Modifier
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
-    val prefs = remember { context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE) }
-    val useZapBoltIcon = prefs.getBoolean("zap_bolt_icon", false)
+    val useZapBoltIcon = com.wisp.app.ui.util.useBoltIcon()
     var showEmojiPicker by remember { mutableStateOf(false) }
     var showRepostMenu by remember { mutableStateOf(false) }
 
@@ -216,8 +219,12 @@ fun ActionBar(
             }
         }
         if (!isZapInProgress && zapSats > 0) {
+            val context = LocalContext.current
+            val fiatPrefs = remember { FiatPreferences.get(context) }
+            fiatPrefs.fiatMode.collectAsState().value
+            fiatPrefs.currency.collectAsState().value
             Text(
-                text = formatSats(zapSats),
+                text = AmountFormatter.formatShort(zapSats, context),
                 style = MaterialTheme.typography.labelSmall,
                 color = if (hasUserZapped) WispThemeColors.zapColor else MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -332,8 +339,3 @@ private fun RepostPopup(
     }
 }
 
-private fun formatSats(sats: Long): String = when {
-    sats >= 1_000_000 -> String.format("%.1fM", sats / 1_000_000.0)
-    sats >= 1_000 -> String.format("%.1fk", sats / 1_000.0)
-    else -> sats.toString()
-}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Icon
+import androidx.compose.ui.res.painterResource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -88,19 +89,30 @@ fun WispBottomBar(
                     indicatorColor = MaterialTheme.colorScheme.surfaceVariant
                 ),
                 icon = {
+                    val useBolt = com.wisp.app.ui.util.useBoltIcon()
                     Box(
                         modifier = Modifier.requiredSize(24.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        val icon = if (tab == BottomTab.NOTIFICATIONS && isZapAnimating)
-                            Icons.Outlined.CurrencyBitcoin
-                        else if (selected) tab.selectedIcon
-                        else tab.unselectedIcon
-                        Icon(
-                            imageVector = icon,
-                            contentDescription = stringResource(tab.labelResId),
-                            tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                        val zapTint = if (selected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                        if (tab == BottomTab.NOTIFICATIONS && isZapAnimating && useBolt) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_bolt),
+                                contentDescription = stringResource(tab.labelResId),
+                                tint = zapTint
+                            )
+                        } else {
+                            val icon = if (tab == BottomTab.NOTIFICATIONS && isZapAnimating)
+                                Icons.Outlined.CurrencyBitcoin
+                            else if (selected) tab.selectedIcon
+                            else tab.unselectedIcon
+                            Icon(
+                                imageVector = icon,
+                                contentDescription = stringResource(tab.labelResId),
+                                tint = zapTint
+                            )
+                        }
                         if (hasUnread) {
                             Box(
                                 modifier = Modifier

--- a/app/src/main/kotlin/com/wisp/app/ui/component/DmBubble.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/DmBubble.kt
@@ -313,10 +313,7 @@ fun DmBubble(
         ) {
             val clipboardManager = LocalClipboardManager.current
             val context = LocalContext.current
-            val useZapBoltIcon = remember {
-                context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-                    .getBoolean("zap_bolt_icon", false)
-            }
+            val useZapBoltIcon = com.wisp.app.ui.util.useBoltIcon()
             val sheetScroll = rememberScrollState()
             val reactScroll = rememberScrollState()
             val stripBg = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.5f)

--- a/app/src/main/kotlin/com/wisp/app/ui/component/LightningQrDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/LightningQrDialog.kt
@@ -44,10 +44,7 @@ fun LightningQrDialog(lud16: String, onDismiss: () -> Unit) {
     val qrBitmap = remember(lud16) { generateQrBitmap(lud16) }
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
-    val useZapBolt = remember {
-        context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-            .getBoolean("zap_bolt_icon", false)
-    }
+    val useZapBolt = com.wisp.app.ui.util.useBoltIcon()
 
     Dialog(
         onDismissRequest = onDismiss,

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -1141,9 +1141,7 @@ internal fun TopZapperBanner(
             Spacer(Modifier.width(5.dp))
 
             // Zap icon
-            val context = androidx.compose.ui.platform.LocalContext.current
-            val useZapBolt = remember { context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE) }
-                .getBoolean("zap_bolt_icon", false)
+            val useZapBolt = com.wisp.app.ui.util.useBoltIcon()
             if (useZapBolt) {
                 Icon(
                     painter = painterResource(R.drawable.ic_bolt),
@@ -1162,7 +1160,10 @@ internal fun TopZapperBanner(
 
             // Amount
             Text(
-                text = formatZapAmount(sats),
+                text = com.wisp.app.ui.util.AmountFormatter.formatShort(
+                    sats,
+                    androidx.compose.ui.platform.LocalContext.current
+                ),
                 style = MaterialTheme.typography.labelSmall,
                 color = orange
             )
@@ -1180,12 +1181,6 @@ internal fun TopZapperBanner(
             }
         }
     }
-}
-
-internal fun formatZapAmount(sats: Long): String = when {
-    sats >= 1_000_000 -> String.format("%.1fM", sats / 1_000_000.0)
-    sats >= 1_000 -> String.format("%.1fk", sats / 1_000.0)
-    else -> "$sats"
 }
 
 private val dateTimeFormat = SimpleDateFormat("MMM d, HH:mm", Locale.US)

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ProfileQrSheet.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ProfileQrSheet.kt
@@ -66,10 +66,7 @@ fun ProfileQrSheet(
     val scope = rememberCoroutineScope()
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
-    val useZapBolt = remember {
-        context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-            .getBoolean("zap_bolt_icon", false)
-    }
+    val useZapBolt = com.wisp.app.ui.util.useBoltIcon()
 
     val npub = remember(pubkeyHex) { Nip19.npubEncode(pubkeyHex.hexToByteArray()) }
     val npubQr = remember(npub) { generateQrBitmap(npub) }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ReactionDetailsSection.kt
@@ -43,7 +43,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import coil3.compose.AsyncImage
+import androidx.compose.ui.platform.LocalContext
 import com.wisp.app.R
+import com.wisp.app.ui.util.AmountFormatter
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.ProfileData
 import com.wisp.app.repo.EventRepository
@@ -179,7 +181,7 @@ fun ZapRow(
         )
         Spacer(Modifier.width(2.dp))
         Text(
-            text = formatSats(sats),
+            text = AmountFormatter.formatFull(sats, LocalContext.current),
             style = MaterialTheme.typography.labelLarge,
             color = Color(0xFFFF8C00)
         )
@@ -539,10 +541,3 @@ fun ClientTagSection(
     }
 }
 
-private fun formatSats(sats: Long): String {
-    return when {
-        sats >= 1_000_000 -> "${sats / 1_000_000}M sats"
-        sats >= 1_000 -> "${sats / 1_000}K sats"
-        else -> "$sats sats"
-    }
-}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -451,6 +451,7 @@ private fun LightningInvoiceCard(
     var showConfirm by remember { mutableStateOf(false) }
     var payState by remember { mutableStateOf(InvoicePayState.Idle) }
     val scope = rememberCoroutineScope()
+    val ctx = LocalContext.current
 
     if (showConfirm) {
         AlertDialog(
@@ -459,7 +460,7 @@ private fun LightningInvoiceCard(
             text = {
                 Column {
                     if (decoded.amountSats != null) {
-                        Text("%,d sats".format(decoded.amountSats))
+                        Text(com.wisp.app.ui.util.AmountFormatter.formatFull(decoded.amountSats, ctx))
                     } else {
                         Text(stringResource(com.wisp.app.R.string.lightning_invoice_any_amount))
                     }
@@ -522,8 +523,9 @@ private fun LightningInvoiceCard(
             Spacer(Modifier.width(10.dp))
             Column(Modifier.weight(1f)) {
                 Text(
-                    text = if (decoded.amountSats != null) "%,d sats".format(decoded.amountSats)
-                           else stringResource(com.wisp.app.R.string.lightning_invoice_any_amount),
+                    text = if (decoded.amountSats != null)
+                        com.wisp.app.ui.util.AmountFormatter.formatFull(decoded.amountSats, ctx)
+                    else stringResource(com.wisp.app.R.string.lightning_invoice_any_amount),
                     style = MaterialTheme.typography.titleSmall,
                     color = primary
                 )

--- a/app/src/main/kotlin/com/wisp/app/ui/component/SatsNumpad.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/SatsNumpad.kt
@@ -24,6 +24,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wisp.app.R
 
+/**
+ * Numeric pad for entering amounts.
+ *
+ * When [allowDecimal] is true the "✓" key is replaced with a "." key and
+ * [onConfirm] is ignored — callers are expected to render their own confirm
+ * button below the pad (see the Fiat Mode receive flow in WalletScreen).
+ * The display header (amount / unit label) is also the caller's responsibility
+ * in that mode; we only render the keypad.
+ */
 @Composable
 fun SatsNumpad(
     amount: String,
@@ -31,33 +40,36 @@ fun SatsNumpad(
     onBackspace: () -> Unit,
     onConfirm: () -> Unit,
     confirmEnabled: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    allowDecimal: Boolean = false,
+    showHeader: Boolean = true
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Amount display
-        val displayAmount = if (amount.isEmpty()) "0" else "%,d".format(amount.toLongOrNull() ?: 0)
-        Text(
-            text = displayAmount,
-            style = MaterialTheme.typography.displayMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Text(
-            text = stringResource(R.string.zap_sats),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        if (showHeader) {
+            val displayAmount = if (amount.isEmpty()) "0" else "%,d".format(amount.toLongOrNull() ?: 0)
+            Text(
+                text = displayAmount,
+                style = MaterialTheme.typography.displayMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = stringResource(R.string.zap_sats),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
 
-        Spacer(Modifier.height(32.dp))
+            Spacer(Modifier.height(32.dp))
+        }
 
-        // 4x3 grid
+        val lastKey = if (allowDecimal) "." else "✓"
         val rows = listOf(
             listOf("1", "2", "3"),
             listOf("4", "5", "6"),
             listOf("7", "8", "9"),
-            listOf("⌫", "0", "✓")
+            listOf("⌫", "0", lastKey)
         )
 
         rows.forEach { row ->
@@ -101,6 +113,22 @@ fun SatsNumpad(
                                     Icons.Default.Check,
                                     contentDescription = stringResource(R.string.cd_confirm),
                                     modifier = Modifier.size(24.dp)
+                                )
+                            }
+                        }
+                        "." -> {
+                            FilledTonalButton(
+                                onClick = { onDigit('.') },
+                                modifier = Modifier.size(72.dp),
+                                shape = CircleShape,
+                                colors = ButtonDefaults.filledTonalButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary
+                                )
+                            ) {
+                                Text(
+                                    ".",
+                                    style = MaterialTheme.typography.headlineMedium
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -417,11 +417,7 @@ fun WispDrawerContent(
             onClick = onMessages,
             modifier = Modifier.padding(horizontal = 12.dp)
         )
-        val walletContext = androidx.compose.ui.platform.LocalContext.current
-        val useZapBolt = remember {
-            walletContext.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-                .getBoolean("zap_bolt_icon", false)
-        }
+        val useZapBolt = com.wisp.app.ui.util.useBoltIcon()
         NavigationDrawerItem(
             icon = {
                 if (useZapBolt) {

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt
@@ -81,9 +81,12 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.wisp.app.R
+import com.wisp.app.repo.FiatPreferences
 import com.wisp.app.repo.ZapPreferences
 import com.wisp.app.repo.ZapPreset
 import com.wisp.app.ui.theme.WispThemeColors
+import com.wisp.app.ui.util.AmountFormatter
+import androidx.compose.runtime.collectAsState
 import kotlin.math.sin
 import kotlin.random.Random
 
@@ -128,6 +131,9 @@ fun ZapDialog(
     }
 
     val context = LocalContext.current
+    val fiatPrefs = remember { FiatPreferences.get(context) }
+    val fiatMode by fiatPrefs.fiatMode.collectAsState()
+    @Suppress("unused_variable") val fiatCurrency by fiatPrefs.currency.collectAsState()
     var presets by remember { mutableStateOf(ZapPreferences(context).getPresets().sortedBy { it.amountSats }) }
     var selectedPreset by remember { mutableStateOf<ZapPreset?>(presets.firstOrNull()) }
     var isCustom by remember { mutableStateOf(false) }
@@ -191,7 +197,9 @@ fun ZapDialog(
                     Spacer(Modifier.height(8.dp))
 
                     Text(
-                        text = stringResource(R.string.zap_send),
+                        text = stringResource(
+                            if (fiatMode) R.string.zap_send_money else R.string.zap_send
+                        ),
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface
@@ -229,14 +237,16 @@ fun ZapDialog(
                                 }
                             }
                         )
-                        Text(
-                            text = stringResource(R.string.zap_sats),
-                            style = MaterialTheme.typography.labelLarge,
-                            color = LightningOrange.copy(alpha = 0.7f)
-                        )
+                        if (!fiatMode) {
+                            Text(
+                                text = stringResource(R.string.zap_sats),
+                                style = MaterialTheme.typography.labelLarge,
+                                color = LightningOrange.copy(alpha = 0.7f)
+                            )
+                        }
                     } else if (effectiveAmount > 0) {
                         Text(
-                            text = formatDisplayAmount(effectiveAmount),
+                            text = AmountFormatter.formatShort(effectiveAmount, context),
                             style = MaterialTheme.typography.displaySmall,
                             fontWeight = FontWeight.Bold,
                             color = LightningOrange,
@@ -247,11 +257,13 @@ fun ZapDialog(
                                 }
                                 .padding(vertical = 4.dp)
                         )
-                        Text(
-                            text = stringResource(R.string.zap_sats),
-                            style = MaterialTheme.typography.labelLarge,
-                            color = LightningOrange.copy(alpha = 0.7f)
-                        )
+                        if (!fiatMode) {
+                            Text(
+                                text = stringResource(R.string.zap_sats),
+                                style = MaterialTheme.typography.labelLarge,
+                                color = LightningOrange.copy(alpha = 0.7f)
+                            )
+                        }
                     }
 
                     Spacer(Modifier.height(16.dp))
@@ -484,7 +496,14 @@ fun ZapDialog(
                             )
                             Spacer(Modifier.width(6.dp))
                             Text(
-                                stringResource(R.string.zap_x_sats, effectiveAmount),
+                                if (fiatMode) {
+                                    stringResource(
+                                        R.string.zap_x_amount,
+                                        AmountFormatter.formatShort(effectiveAmount, context)
+                                    )
+                                } else {
+                                    stringResource(R.string.zap_x_sats, effectiveAmount)
+                                },
                                 fontWeight = FontWeight.Bold
                             )
                         }
@@ -671,8 +690,9 @@ private fun ZapPresetChip(
                     )
                     Spacer(Modifier.width(3.dp))
                 }
+                val chipContext = LocalContext.current
                 Text(
-                    text = formatDisplayAmount(preset.amountSats),
+                    text = AmountFormatter.formatShort(preset.amountSats, chipContext),
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                     color = if (isSelected) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
@@ -818,9 +838,3 @@ private fun SaveZapPresetDialog(
     )
 }
 
-private fun formatDisplayAmount(sats: Long): String = when {
-    sats >= 1_000_000 -> String.format("%.1fM", sats / 1_000_000.0)
-    sats >= 10_000 -> String.format("%.1fk", sats / 1_000.0)
-    sats >= 1_000 -> String.format("%,d", sats)
-    else -> sats.toString()
-}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/GroupRoomScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/GroupRoomScreen.kt
@@ -1632,8 +1632,7 @@ private fun GroupMessageBubble(
                 // Actions panel — eyebrow + bare horizontally scrollable row of panel buttons
                 val showFollow = !isOwnMessage && onFollowAuthor != null
                 val showBlock = !isOwnMessage && onBlockAuthor != null
-                val actionsPanelPrefs = context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-                val useZapBoltIcon = actionsPanelPrefs.getBoolean("zap_bolt_icon", false)
+                val useZapBoltIcon = com.wisp.app.ui.util.useBoltIcon()
                 Column(
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -64,10 +64,20 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.FileProvider
 import com.wisp.app.R
 import com.wisp.app.repo.DiagnosticLogger
+import com.wisp.app.repo.ExchangeRateRepository
+import com.wisp.app.repo.FiatPreferences
 import com.wisp.app.repo.InterfacePreferences
 import com.wisp.app.repo.LocaleRepository
 import com.wisp.app.ui.theme.ThemePreset
 import com.wisp.app.ui.theme.Themes
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.collectAsState
+import java.text.DateFormat
+import java.util.Date
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -492,10 +502,101 @@ fun InterfaceScreen(
                 )
             }
 
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(24.dp))
 
-            // Zap icon toggle
+            // Fiat Mode section
+            val fiatPrefs = remember { FiatPreferences.get(application) }
+            val fiatModeEnabled by fiatPrefs.fiatMode.collectAsState()
+            val fiatCurrency by fiatPrefs.currency.collectAsState()
+            val ratesUpdatedAt by ExchangeRateRepository.updatedAtMs.collectAsState()
+            var currencyPickerExpanded by remember { mutableStateOf(false) }
+
+            Text(
+                text = stringResource(R.string.fiat_settings_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.fiat_settings_enable), style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        stringResource(R.string.fiat_settings_enable_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = fiatModeEnabled,
+                    onCheckedChange = { fiatPrefs.setFiatMode(it) }
+                )
+            }
+
+            if (fiatModeEnabled) {
+                Spacer(Modifier.height(12.dp))
+                val selectedCurrency = ExchangeRateRepository.currencyFor(fiatCurrency)
+                Box {
+                    OutlinedButton(
+                        onClick = { currencyPickerExpanded = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text("${selectedCurrency.symbol}  ${selectedCurrency.code} — ${selectedCurrency.name}")
+                            Icon(Icons.Filled.ArrowDropDown, contentDescription = null)
+                        }
+                    }
+                    DropdownMenu(
+                        expanded = currencyPickerExpanded,
+                        onDismissRequest = { currencyPickerExpanded = false }
+                    ) {
+                        ExchangeRateRepository.SUPPORTED.forEach { c ->
+                            DropdownMenuItem(
+                                text = { Text("${c.symbol}  ${c.code} — ${c.name}") },
+                                onClick = {
+                                    fiatPrefs.setCurrency(c.code)
+                                    currencyPickerExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+                val rateLabel = if (ratesUpdatedAt > 0L) {
+                    val fmt = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
+                    stringResource(R.string.fiat_settings_rates_updated, fmt.format(Date(ratesUpdatedAt)))
+                } else {
+                    stringResource(R.string.fiat_settings_rates_never)
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        rateLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f)
+                    )
+                    TextButton(onClick = { ExchangeRateRepository.refresh() }) {
+                        Text(stringResource(R.string.fiat_settings_refresh))
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Zap icon toggle — hidden in fiat mode since the bolt is forced
             var zapBoltIcon by remember { mutableStateOf(interfacePrefs.isZapBoltIcon()) }
+            if (!fiatModeEnabled) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
@@ -529,6 +630,7 @@ fun InterfaceScreen(
                             }
                     )
                 }
+            }
             }
 
             Spacer(Modifier.height(32.dp))

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -514,11 +514,7 @@ private fun NotificationFilterSheet(
                     val iconTint = if (enabled) MaterialTheme.colorScheme.primary
                                    else MaterialTheme.colorScheme.outline
                     if (filter == NotificationFilter.ZAPS) {
-                        val zapContext = LocalContext.current
-                        val useBolt = remember {
-                            zapContext.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-                                .getBoolean("zap_bolt_icon", false)
-                        }
+                        val useBolt = com.wisp.app.ui.util.useBoltIcon()
                         if (useBolt) {
                             Icon(
                                 painter = painterResource(R.drawable.ic_bolt),
@@ -1096,7 +1092,7 @@ private fun DmExpansion(
             }
             if (dmZapSats > 0 && !isDmZapInProgress) {
                 Text(
-                    text = formatSatsCompact(dmZapSats),
+                    text = com.wisp.app.ui.util.AmountFormatter.formatShort(dmZapSats, LocalContext.current),
                     style = MaterialTheme.typography.labelSmall,
                     color = WispThemeColors.zapColor
                 )
@@ -1870,7 +1866,7 @@ private fun NotificationTypeIcon(item: FlatNotificationItem, showSats: Boolean =
             )
             if (showSats && item.zapSats > 0) {
                 Text(
-                    text = formatSatsCompact(item.zapSats),
+                    text = com.wisp.app.ui.util.AmountFormatter.formatShort(item.zapSats, LocalContext.current),
                     style = MaterialTheme.typography.labelSmall,
                     color = WispThemeColors.zapColor,
                     maxLines = 1
@@ -2028,17 +2024,15 @@ private fun DailySummaryBar(
                 active = isFiltered && NotificationFilter.REACTIONS in enabledTypes,
                 onClick = { onFilterSelect(NotificationFilter.REACTIONS) })
             run {
-                val zapContext = LocalContext.current
-                val useZapBolt = remember {
-                    zapContext.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-                        .getBoolean("zap_bolt_icon", false)
-                }
+                val useZapBolt = com.wisp.app.ui.util.useBoltIcon()
                 val zapActive = isFiltered && NotificationFilter.ZAPS in enabledTypes
+                val zapCtx = LocalContext.current
+                val zapLabel = com.wisp.app.ui.util.AmountFormatter.formatShort(summary.zapSats, zapCtx)
                 if (useZapBolt) {
-                    SummaryStatPainter(painterResource(R.drawable.ic_bolt), formatSatsCompact(summary.zapSats),
+                    SummaryStatPainter(painterResource(R.drawable.ic_bolt), zapLabel,
                         active = zapActive, onClick = { onFilterSelect(NotificationFilter.ZAPS) })
                 } else {
-                    SummaryStat(Icons.Outlined.CurrencyBitcoin, formatSatsCompact(summary.zapSats),
+                    SummaryStat(Icons.Outlined.CurrencyBitcoin, zapLabel,
                         active = zapActive, onClick = { onFilterSelect(NotificationFilter.ZAPS) })
                 }
             }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -1187,11 +1187,7 @@ private fun ProfileHeader(
                         }
                     }
                     if (profile?.lud16 != null && onZapClick != null) {
-                        val zapContext = LocalContext.current
-                        val useZapBolt = remember {
-                            zapContext.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-                                .getBoolean("zap_bolt_icon", false)
-                        }
+                        val useZapBolt = com.wisp.app.ui.util.useBoltIcon()
                         IconButton(onClick = onZapClick) {
                             if (useZapBolt) {
                                 Icon(
@@ -1278,11 +1274,7 @@ private fun ProfileHeader(
                     Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
                 }
             ) {
-                val lnContext = LocalContext.current
-                val useBoltIcon = remember {
-                    lnContext.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE)
-                        .getBoolean("zap_bolt_icon", false)
-                }
+                val useBoltIcon = com.wisp.app.ui.util.useBoltIcon()
                 if (useBoltIcon) {
                     Icon(
                         painter = painterResource(R.drawable.ic_bolt),

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -130,9 +130,11 @@ import com.google.zxing.qrcode.QRCodeWriter
 import com.wisp.app.BuildConfig
 import com.wisp.app.R
 import com.wisp.app.repo.BalanceUnit
+import com.wisp.app.repo.FiatPreferences
 import com.wisp.app.repo.WalletMode
 import com.wisp.app.repo.WalletTransaction
 import com.wisp.app.ui.component.SatsNumpad
+import com.wisp.app.ui.util.AmountFormatter
 import com.wisp.app.viewmodel.AutoCheckState
 import com.wisp.app.viewmodel.FeeState
 import com.wisp.app.viewmodel.BackupStatus
@@ -365,10 +367,7 @@ fun WalletScreen(
                         isLoading = viewModel.isLoading.collectAsState().value,
                         onDigit = { viewModel.updateReceiveAmount(it) },
                         onBackspace = { viewModel.receiveAmountBackspace() },
-                        onConfirm = {
-                            val sats = viewModel.receiveAmount.value.toLongOrNull() ?: return@ReceiveAmountContent
-                            viewModel.generateInvoice(sats)
-                        },
+                        onGenerate = { sats -> viewModel.generateInvoice(sats) },
                         modifier = Modifier.padding(padding)
                     )
                     is WalletPage.ReceiveInvoice -> {
@@ -682,6 +681,9 @@ private fun WalletHomeContent(
     val context = LocalContext.current
     val prefs = remember { context.getSharedPreferences("wisp_settings", android.content.Context.MODE_PRIVATE) }
     var balanceHidden by remember { mutableStateOf(prefs.getBoolean("balance_hidden", false)) }
+    val fiatPrefs = remember { FiatPreferences.get(context) }
+    val fiatMode by fiatPrefs.fiatMode.collectAsState()
+    @Suppress("unused_variable") val fiatCurrency by fiatPrefs.currency.collectAsState()
 
     Column(
         modifier = modifier
@@ -817,7 +819,13 @@ private fun WalletHomeContent(
                 )
             } else {
                 Row(verticalAlignment = Alignment.Bottom) {
-                    when (balanceUnit) {
+                    if (fiatMode) {
+                        Text(
+                            AmountFormatter.formatShort(balanceSats, context),
+                            style = MaterialTheme.typography.displaySmall,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    } else when (balanceUnit) {
                         BalanceUnit.BITCOIN -> {
                             Text(
                                 "\u20BF",
@@ -1441,6 +1449,7 @@ private fun SendConfirmContent(
 ) {
     val feeSats = (feeState as? FeeState.Estimated)?.feeSats
     val totalSats = if (amountSats != null && feeSats != null) amountSats + feeSats else amountSats
+    val ctx = LocalContext.current
 
     Column(
         modifier = modifier
@@ -1461,7 +1470,7 @@ private fun SendConfirmContent(
 
         if (amountSats != null) {
             Text(
-                "%,d ${stringResource(R.string.wallet_sats)}".format(amountSats),
+                AmountFormatter.formatFull(amountSats, ctx),
                 style = MaterialTheme.typography.headlineLarge,
                 color = MaterialTheme.colorScheme.onSurface
             )
@@ -1508,7 +1517,7 @@ private fun SendConfirmContent(
                             strokeWidth = 2.dp
                         )
                         is FeeState.Estimated -> Text(
-                            "%,d ${stringResource(R.string.wallet_sats)}".format(feeState.feeSats),
+                            AmountFormatter.formatFull(feeState.feeSats, ctx),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurface
                         )
@@ -1524,7 +1533,7 @@ private fun SendConfirmContent(
                 // Total spent
                 SummaryRow(
                     label = stringResource(R.string.wallet_total_spent),
-                    value = if (totalSats != null) "%,d ${stringResource(R.string.wallet_sats)}".format(totalSats) else amountSats?.let { "%,d ${stringResource(R.string.wallet_sats)}".format(it) } ?: "\u2014",
+                    value = if (totalSats != null) AmountFormatter.formatFull(totalSats, ctx) else amountSats?.let { AmountFormatter.formatFull(it, ctx) } ?: "\u2014",
                     bold = true
                 )
             }
@@ -1700,9 +1709,23 @@ private fun ReceiveAmountContent(
     isLoading: Boolean,
     onDigit: (Char) -> Unit,
     onBackspace: () -> Unit,
-    onConfirm: () -> Unit,
+    onGenerate: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val receiveCtx = LocalContext.current
+    val fiatPrefs = remember { FiatPreferences.get(receiveCtx) }
+    val fiatMode by fiatPrefs.fiatMode.collectAsState()
+    val fiatCurrency by fiatPrefs.currency.collectAsState()
+    val currency = remember(fiatCurrency) { com.wisp.app.repo.ExchangeRateRepository.currencyFor(fiatCurrency) }
+
+    val fiatValue = if (fiatMode) amount.toDoubleOrNull() ?: 0.0 else 0.0
+    val fiatSats = if (fiatMode && fiatValue > 0.0) {
+        val btcPrice = com.wisp.app.repo.ExchangeRateRepository.rates.collectAsState().value[fiatCurrency.uppercase()]
+        if (btcPrice != null && btcPrice > 0.0) {
+            ((fiatValue / btcPrice) * 100_000_000.0).toLong()
+        } else null
+    } else null
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -1723,12 +1746,59 @@ private fun ReceiveAmountContent(
             CircularProgressIndicator()
             Spacer(Modifier.height(8.dp))
             Text(stringResource(R.string.wallet_creating_invoice), style = MaterialTheme.typography.bodyMedium)
+        } else if (fiatMode) {
+            val displayAmount = if (amount.isEmpty()) "0" else amount
+            Text(
+                text = "${currency.symbol}$displayAmount",
+                style = MaterialTheme.typography.displayMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = currency.code,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (fiatSats != null && fiatSats > 0L) {
+                Text(
+                    text = "≈ %,d sats".format(fiatSats),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            SatsNumpad(
+                amount = amount,
+                onDigit = onDigit,
+                onBackspace = onBackspace,
+                onConfirm = {},
+                confirmEnabled = false,
+                allowDecimal = true,
+                showHeader = false
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Button(
+                onClick = { fiatSats?.let { onGenerate(it) } },
+                enabled = fiatSats != null && fiatSats > 0L,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp),
+                shape = RoundedCornerShape(50)
+            ) {
+                Text(stringResource(R.string.wallet_generate_invoice))
+            }
         } else {
             SatsNumpad(
                 amount = amount,
                 onDigit = onDigit,
                 onBackspace = onBackspace,
-                onConfirm = onConfirm,
+                onConfirm = {
+                    val sats = amount.toLongOrNull() ?: return@SatsNumpad
+                    onGenerate(sats)
+                },
                 confirmEnabled = amount.isNotEmpty() && (amount.toLongOrNull() ?: 0) > 0
             )
         }
@@ -1745,6 +1815,7 @@ private fun ReceiveInvoiceContent(
     modifier: Modifier = Modifier
 ) {
     val clipboardManager = LocalClipboardManager.current
+    val ctx = LocalContext.current
 
     val qrBitmap = remember(invoice) {
         val writer = QRCodeWriter()
@@ -1769,7 +1840,7 @@ private fun ReceiveInvoiceContent(
         Spacer(Modifier.height(16.dp))
 
         Text(
-            "%,d ${stringResource(R.string.wallet_sats)}".format(amountSats),
+            AmountFormatter.formatFull(amountSats, ctx),
             style = MaterialTheme.typography.headlineMedium,
             color = MaterialTheme.colorScheme.onSurface
         )
@@ -1841,6 +1912,7 @@ private fun ReceiveSuccessContent(
     modifier: Modifier = Modifier
 ) {
     val primary = MaterialTheme.colorScheme.primary
+    val ctx = LocalContext.current
 
     // Animation progress: 0 → 1 over ~1.6s
     val animProgress = remember { Animatable(0f) }
@@ -1962,7 +2034,7 @@ private fun ReceiveSuccessContent(
         Spacer(Modifier.height(8.dp))
 
         Text(
-            "%,d ${stringResource(R.string.wallet_sats)}".format(amountSats),
+            AmountFormatter.formatFull(amountSats, ctx),
             style = MaterialTheme.typography.headlineMedium,
             color = primary.copy(alpha = contentAlpha.value)
         )
@@ -2087,6 +2159,8 @@ private fun TransactionRow(
     val isIncoming = tx.type == "incoming"
     val amountSats = tx.amountMsats / 1000
     val profile = tx.counterpartyPubkey?.let { profileLookup(it) }
+    val ctx = LocalContext.current
+    val fiatMode by FiatPreferences.get(ctx).fiatMode.collectAsState()
 
     Row(
         modifier = Modifier
@@ -2153,22 +2227,32 @@ private fun TransactionRow(
         // Amount + fee
         Column(horizontalAlignment = Alignment.End) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    "${if (isIncoming) "+" else "-"}%,d".format(amountSats),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = if (isIncoming) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
-                )
-                Spacer(Modifier.width(4.dp))
-                Text(
-                    stringResource(R.string.wallet_sats),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                val sign = if (isIncoming) "+" else "-"
+                if (fiatMode) {
+                    Text(
+                        "$sign${AmountFormatter.formatFull(amountSats, ctx)}",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = if (isIncoming) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+                    )
+                } else {
+                    Text(
+                        "$sign%,d".format(amountSats),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = if (isIncoming) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        stringResource(R.string.wallet_sats),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
             if (!isIncoming && tx.feeMsats > 0) {
                 val feeSats = tx.feeMsats / 1000
                 Text(
-                    stringResource(R.string.wallet_fee, feeSats),
+                    if (fiatMode) stringResource(R.string.wallet_fee_money, AmountFormatter.formatFull(feeSats, ctx))
+                    else stringResource(R.string.wallet_fee, feeSats),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -2671,7 +2755,7 @@ private fun SparkBackupContent(
     Spacer(Modifier.height(12.dp))
 
     Text(
-        "This recovery phrase is specific to Spark wallets. It will not work with other Lightning or Bitcoin wallet apps.",
+        stringResource(R.string.wallet_seed_spark_only),
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )
@@ -2712,6 +2796,8 @@ private fun WalletSettingsContent(
     modifier: Modifier = Modifier
 ) {
     val clipboardManager = LocalClipboardManager.current
+    val settingsCtx = LocalContext.current
+    val fiatMode by FiatPreferences.get(settingsCtx).fiatMode.collectAsState()
 
     Column(
         modifier = modifier
@@ -2819,29 +2905,30 @@ private fun WalletSettingsContent(
             }
         }
 
-        // Display section
-        Spacer(Modifier.height(24.dp))
+        // Display section — only relevant when showing sats
+        if (!fiatMode) {
+            Spacer(Modifier.height(24.dp))
 
-        Text(
-            "Display",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
+            Text(
+                "Display",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
 
-        Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(12.dp))
 
-        Text(
-            "Balance Unit",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+            Text(
+                "Balance Unit",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
 
-        Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(8.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(6.dp)
-        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
             val units = listOf(BalanceUnit.SATS, BalanceUnit.BITCOIN, BalanceUnit.LIGHTNING)
             units.forEach { unit ->
                 val selected = balanceUnit == unit
@@ -2887,6 +2974,7 @@ private fun WalletSettingsContent(
                         )
                     }
                 }
+            }
             }
         }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/util/AmountFormatter.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/util/AmountFormatter.kt
@@ -1,0 +1,75 @@
+package com.wisp.app.ui.util
+
+import android.content.Context
+import com.wisp.app.R
+import com.wisp.app.repo.ExchangeRateRepository
+import com.wisp.app.repo.FiatCurrency
+import com.wisp.app.repo.FiatPreferences
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.Locale
+
+/**
+ * Centralized formatter for bitcoin amounts. When Fiat Mode is enabled in
+ * [FiatPreferences], renders the amount as fiat using the cached rate in
+ * [ExchangeRateRepository]. Otherwise falls back to the prior sat formatting.
+ */
+object AmountFormatter {
+
+    /** Short form used inline (feed zap counts, etc.). Sats: "1.2k"/"3.4M". Fiat: "$0.12". */
+    fun formatShort(sats: Long, context: Context): String {
+        val prefs = FiatPreferences.get(context)
+        return if (prefs.isFiatMode()) {
+            formatFiat(sats, prefs.getCurrency()) ?: formatSatsShort(sats)
+        } else {
+            formatSatsShort(sats)
+        }
+    }
+
+    /** Full form used for balances / transactions. Sats: "1,234 sats". Fiat: "$12.34". */
+    fun formatFull(sats: Long, context: Context): String {
+        val prefs = FiatPreferences.get(context)
+        return if (prefs.isFiatMode()) {
+            formatFiat(sats, prefs.getCurrency())
+                ?: context.getString(R.string.amount_sats_format, String.format(Locale.getDefault(), "%,d", sats))
+        } else {
+            context.getString(R.string.amount_sats_format, String.format(Locale.getDefault(), "%,d", sats))
+        }
+    }
+
+    /** Raw sat rendering without the "sats" suffix (e.g. big balance number). */
+    fun formatSatsOnly(sats: Long): String = String.format(Locale.getDefault(), "%,d", sats)
+
+    /** Short sat formatter matching the prior inline helper ("1.2k", "3.4M"). */
+    fun formatSatsShort(sats: Long): String = when {
+        sats >= 1_000_000 -> String.format(Locale.getDefault(), "%.1fM", sats / 1_000_000.0)
+        sats >= 1_000 -> String.format(Locale.getDefault(), "%.1fk", sats / 1_000.0)
+        else -> sats.toString()
+    }
+
+    /**
+     * Returns the fiat-formatted string, or null if the rate is not yet cached.
+     * Picks precision automatically based on magnitude so tiny zaps don't show "$0.00".
+     */
+    fun formatFiat(sats: Long, currencyCode: String): String? {
+        val fiat = ExchangeRateRepository.satsToFiat(sats, currencyCode) ?: return null
+        val currency = ExchangeRateRepository.currencyFor(currencyCode)
+        return renderCurrency(fiat, currency)
+    }
+
+    private fun renderCurrency(amount: Double, currency: FiatCurrency): String {
+        val abs = kotlin.math.abs(amount)
+        val pattern = when {
+            abs == 0.0 -> "#,##0.00"
+            abs < 0.001 -> "#,##0.000000"
+            abs < 0.01 -> "#,##0.0000"
+            abs < 1.0 -> "#,##0.000"
+            abs >= 1000.0 -> "#,##0"
+            else -> "#,##0.00"
+        }
+        val symbols = DecimalFormatSymbols(Locale.getDefault())
+        val formatter = DecimalFormat(pattern, symbols)
+        val formatted = formatter.format(amount)
+        return "${currency.symbol}$formatted"
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/util/ZapIconHelper.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/util/ZapIconHelper.kt
@@ -1,0 +1,26 @@
+package com.wisp.app.ui.util
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.wisp.app.repo.FiatPreferences
+
+/**
+ * True when the lightning-bolt drawable should be used in place of the Bitcoin
+ * (₿) symbol anywhere a zap icon is rendered. Respects the user's explicit
+ * preference, but Fiat Mode always forces the bolt so the ₿ symbol never
+ * appears while the app is showing fiat amounts.
+ */
+@Composable
+fun useBoltIcon(): Boolean {
+    val context = LocalContext.current
+    val fiatMode by FiatPreferences.get(context).fiatMode.collectAsState()
+    if (fiatMode) return true
+    val prefs = remember(context) {
+        context.getSharedPreferences("wisp_settings", Context.MODE_PRIVATE)
+    }
+    return prefs.getBoolean("zap_bolt_icon", false)
+}

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/AuthViewModel.kt
@@ -7,6 +7,7 @@ import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.hexToByteArray
 import com.wisp.app.nostr.toHex
 import com.wisp.app.repo.AccountInfo
+import com.wisp.app.repo.FiatPreferences
 import com.wisp.app.repo.KeyRepository
 import com.wisp.app.repo.SigningMode
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,6 +47,12 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
             _npub.value = Nip19.npubEncode(keypair.pubkey)
             _signingMode.value = SigningMode.LOCAL
             _error.value = null
+            // Brand-new accounts default to Fiat Mode (USD). Existing-account
+            // logins do not touch these prefs, so a returning user's choice is
+            // preserved and unknown-preference logins stay in Bitcoin mode.
+            val fiatPrefs = FiatPreferences.get(getApplication())
+            fiatPrefs.setFiatMode(true)
+            fiatPrefs.setCurrency("USD")
             true
         } catch (e: Exception) {
             _error.value = "Failed to generate keys: ${e.message}"

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
@@ -1057,9 +1057,13 @@ class WalletViewModel(
 
     fun updateReceiveAmount(digit: Char) {
         val current = _receiveAmount.value
-        if (current.length < 10) {
-            _receiveAmount.value = current + digit
+        if (current.length >= 12) return
+        if (digit == '.') {
+            if (current.contains('.')) return
+            _receiveAmount.value = if (current.isEmpty()) "0." else "$current."
+            return
         }
+        _receiveAmount.value = current + digit
     }
 
     fun receiveAmountBackspace() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,4 +787,24 @@
     <string name="label_notifications">Notifications</string>
     <string name="label_notifications_on">On — new messages will be tracked</string>
     <string name="label_notifications_off">Off — tap to enable</string>
+
+    <!-- Fiat mode -->
+    <string name="drawer_fiat_mode">Fiat Mode</string>
+    <string name="fiat_settings_title">Fiat Mode</string>
+    <string name="fiat_settings_description">Show zap and wallet amounts in a fiat currency instead of satoshis. Rates are fetched once when the app starts — this is an approximation, not real‑time pricing.</string>
+    <string name="fiat_settings_enable">Enable Fiat Mode</string>
+    <string name="fiat_settings_enable_subtitle">Display amounts in your chosen currency across the app.</string>
+    <string name="fiat_settings_currency">Currency</string>
+    <string name="fiat_settings_rates_updated">Rates updated %1$s</string>
+    <string name="fiat_settings_rates_never">Rates not yet fetched</string>
+    <string name="fiat_settings_refresh">Refresh</string>
+    <string name="fiat_settings_rate_line">1 BTC ≈ %1$s %2$,.2f</string>
+
+    <string name="zap_send_money">Send Money</string>
+    <string name="zap_x_amount">Zap %1$s</string>
+
+    <string name="amount_sats_format">%1$s sats</string>
+    <string name="wallet_fee_money">fee: %1$s</string>
+    <string name="wallet_seed_spark_only">This recovery phrase is specific to Spark wallets. It will not work with other wallet apps.</string>
+    <string name="wallet_generate_invoice">Generate invoice</string>
 </resources>


### PR DESCRIPTION
## Summary
- Adds a global Fiat Mode that renders zap and wallet amounts in the user's chosen fiat currency (default USD) instead of satoshis, with rates fetched once at startup from CoinGecko and cached in SharedPreferences.
- Toggle + currency picker live as a section inside the existing **Interface** settings screen (no dedicated page). Fiat Mode forces the bolt (voltage) icon everywhere so the ₿ symbol is never shown while fiat is on.
- Receive flow in Fiat Mode accepts fiat amounts with a decimal key and a round **Generate invoice** button, converting fiat → sats before the invoice is created.
- New npub signups default to Fiat Mode + USD; nsec / npub / signer logins never touch the preference, so returning users keep their prior choice.

### Where amounts switch
Feed zap pills • note top-of-post zap pill • wallet balance, transactions, confirm-payment, receive invoice, receive success • zap dialog amount + preset chips + action button • DM bubble zap totals • lightning invoice cards • reaction details sheet • notifications stats bar + per-item zap labels.

## Test plan
- [ ] New signup lands with Fiat Mode ON and USD selected
- [ ] Log in with nsec: Fiat Mode stays OFF (Bitcoin mode) unless toggled
- [ ] Toggle Fiat Mode in Interface settings → balance, feed zap pills, zap dialog, DM zap totals, notifications stats all swap to fiat
- [ ] Currency picker switches display live (USD → EUR → JPY)
- [ ] Airplane-mode cold start renders from cached rates
- [ ] Receive screen in Fiat Mode: type `1.50`, see `≈ N sats` preview, tap Generate invoice → invoice encodes the converted sats
- [ ] Receive screen in Bitcoin Mode still uses the original sats numpad with ✓
- [ ] Zap dialog presets (e.g. 21, 100, 500 sats) send the same sats regardless of Fiat Mode; only labels change
- [ ] Wallet balance-unit selector (SATS/BITCOIN/LIGHTNING) is hidden in Fiat Mode
- [ ] Any ₿ icon should show as the lightning bolt while Fiat Mode is on