### PR TITLE
fix: resubscribe feed when fresh signup returns empty

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -494,6 +494,21 @@ class StartupCoordinator(
                         feedSub.resubscribeFeed()
                     }
                 }
+            } else {
+                // Safety retry for fresh signup / incomplete routing: when the initial
+                // subscribe fires, author kind 10002 relay lists may not have fully
+                // propagated, so outbox routing falls back to pinned relays that
+                // may not carry the followed authors' posts. If the feed is still
+                // empty after a short wait, resubscribe once — by then relay-list
+                // data has typically arrived and routing targets the correct relays.
+                launch {
+                    delay(5_000)
+                    if (eventRepo.getNewestFeedEventTimestamp() == null) {
+                        Log.d("StartupCoord", "Feed empty after 5s with ${follows.size} follows, resubscribing with updated routing")
+                        feedSub.applyAuthorFilterForFeedType(feedSub.feedType.value)
+                        feedSub.resubscribeFeed()
+                    }
+                }
             }
 
             // Background: fetch relay lists for any new follows (non-blocking)


### PR DESCRIPTION
## Summary

New users reported the feed showing 'No notes found' immediately after completing onboarding. Closing and reopening the app fixed it.

Root cause: when `initRelays()` runs on a fresh signup, the follow list is populated in-memory, but the followed authors' kind 10002 relay lists have not yet propagated back from relays. `OutboxRouter.subscribeByAuthors` falls back to pinned relays for those authors — which may not carry their posts — so the first feed REQ legitimately EOSEs empty. By the time kind 10002 data arrives shortly after, there is no mechanism to re-route the existing subscription.

The existing late-arrival safety net (StartupCoordinator.kt:486) only handled the opposite case where the follow list itself arrives after initial subscribe. This change adds a symmetric retry: when the initial subscribe had a non-empty follow list but the feed is still empty 5s later, `resubscribeFeed()` once so routing uses the now-known per-author relays.

## Test plan
- [ ] Uninstall app, reinstall, sign up, complete onboarding with 5+ follows — feed populates within ~10s on first session without restart
- [ ] `adb logcat -s StartupCoord FeedSub` shows either no retry (happy path) or `Feed empty after 5s ... resubscribing with updated routing` followed by `[FeedSub] resubscribeFeed: N authors` with a successful EOSE
- [ ] Existing-account warm start still works (no unnecessary resubscribe since cached events are seeded)
- [ ] Existing-account cold start with stale cache still works