### PR TITLE
fix: replay inline video after it ends when autoplay is off

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -2368,6 +2368,9 @@ internal fun InlineVideoPlayerWithFullscreen(meta: MediaMeta, onFullScreen: (pos
                     .clickable {
                         activeVideoUrl.value = url
                         userPaused = false
+                        if (exoPlayer.playbackState == Player.STATE_ENDED) {
+                            exoPlayer.seekTo(0)
+                        }
                         exoPlayer.play()
                     },
                 contentAlignment = Alignment.Center
@@ -2591,6 +2594,9 @@ private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
                     .clickable {
                         activeVideoUrl.value = url
                         userPaused = false
+                        if (exoPlayer.playbackState == Player.STATE_ENDED) {
+                            exoPlayer.seekTo(0)
+                        }
                         exoPlayer.play()
                     },
                 contentAlignment = Alignment.Center


### PR DESCRIPTION
## Summary
- With autoplay disabled, an inline video could only be played once — after it finished, tapping the play overlay did nothing.
- Root cause: ExoPlayer stays at its end position after `STATE_ENDED`, so calling `play()` again has no effect. The overlay click now seeks to 0 first if the player has ended.
- Applied to both `InlineVideoPlayerWithFullscreen` and `InlineVideoPlayer` in `RichContent.kt`.

## Test plan
- [ ] Disable video autoplay in settings.
- [ ] Open a note with an inline video, tap play, let it finish.
- [ ] Tap the play overlay again — video should restart from the beginning.
- [ ] Mid-video: tap the pause control, then tap the play overlay — video should resume from the current position (not restart).