### PR TITLE
fix: allow back button to minimize app from FEED

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -610,20 +610,15 @@ fun WispNavHost(
         )
     }
 
-    // Prevent the system back button from ever closing the app.
-    // On FEED: consume the press (nowhere to go).
-    // On any other app screen: pop the back stack, falling back to FEED if empty.
+    // On non-FEED app screens: pop the back stack, falling back to FEED if empty.
+    // On FEED: let the system handle back (minimizes the app).
     val isAppRoute = currentRoute != null && currentRoute !in nonAppRoutes
-    BackHandler(enabled = isAppRoute) {
-        if (currentRoute == Routes.FEED) {
-            // Already on home — do nothing
-        } else {
-            val popped = navController.popBackStack()
-            if (!popped) {
-                navController.navigate(Routes.FEED) {
-                    popUpTo(0) { inclusive = true }
-                    launchSingleTop = true
-                }
+    BackHandler(enabled = isAppRoute && currentRoute != Routes.FEED) {
+        val popped = navController.popBackStack()
+        if (!popped) {
+            navController.navigate(Routes.FEED) {
+                popUpTo(0) { inclusive = true }
+                launchSingleTop = true
             }
         }
     }


### PR DESCRIPTION
## Summary
- Users have complained that pressing the system back button on the home screen does nothing. The `BackHandler` in `Navigation.kt` was consuming the press on FEED to keep the app open.
- Disable the handler on FEED so Android's default behavior (minimize to background) runs. Non-FEED app routes still pop the back stack, falling back to FEED when empty.

## Test plan
- [ ] On FEED, press the system back button — app minimizes to background (task remains in recents)
- [ ] From a non-FEED screen (e.g. PROFILE_EDIT, DM_CONVERSATION), back pops to the previous screen as before
- [ ] From a deep-linked non-FEED screen with empty back stack, back navigates to FEED