### PR TITLE
fix: always show zap count on post cards, including 0

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt
@@ -218,7 +218,7 @@ fun ActionBar(
                 )
             }
         }
-        if (!isZapInProgress && zapSats > 0) {
+        if (!isZapInProgress) {
             val context = LocalContext.current
             val fiatPrefs = remember { FiatPreferences.get(context) }
             fiatPrefs.fiatMode.collectAsState().value


### PR DESCRIPTION
## Summary
- Post cards previously hid the zap amount entirely when a note had no zaps, leaving a blank space next to the bolt icon.
- Now the count always renders (showing `0` when there are no zaps), matching how like and repost counts behave.

## Test plan
- [ ] Open the feed and confirm posts with no zaps show `0` next to the bolt icon
- [ ] Confirm posts with zaps still display the formatted total (e.g. `1.2k`)
- [ ] Confirm the count is hidden while a zap is in progress (loading state)