### PR TITLE
feat: NIP-29 group config — flags, invites, roles, AUTH prompts

### DIFF
--- a/app/objectbox-models/default.json
+++ b/app/objectbox-models/default.json
@@ -115,7 +115,7 @@
     },
     {
       "id": "3:4980149860826606366",
-      "lastPropertyId": "13:2695266999059672518",
+      "lastPropertyId": "15:5858957648151141575",
       "name": "GroupMetaEntity",
       "properties": [
         {
@@ -187,6 +187,16 @@
           "id": "13:2695266999059672518",
           "name": "lastMessageAt",
           "type": 6
+        },
+        {
+          "id": "14:2327490369406932737",
+          "name": "isRestricted",
+          "type": 1
+        },
+        {
+          "id": "15:5858957648151141575",
+          "name": "isHidden",
+          "type": 1
         }
       ],
       "relations": []

--- a/app/objectbox-models/default.json.bak
+++ b/app/objectbox-models/default.json.bak
@@ -62,10 +62,138 @@
         }
       ],
       "relations": []
+    },
+    {
+      "id": "2:2141392782912771445",
+      "lastPropertyId": "7:7365873607391821510",
+      "name": "GroupMessageEntity",
+      "properties": [
+        {
+          "id": "1:2786703443318537442",
+          "name": "dbId",
+          "type": 6,
+          "flags": 1
+        },
+        {
+          "id": "2:4361531533672154727",
+          "name": "eventId",
+          "indexId": "4:730659032884888490",
+          "type": 9,
+          "flags": 2080
+        },
+        {
+          "id": "3:7859248255243614592",
+          "name": "roomKey",
+          "indexId": "5:3530430297049641744",
+          "type": 9,
+          "flags": 2048
+        },
+        {
+          "id": "4:837629569078174530",
+          "name": "senderPubkey",
+          "type": 9
+        },
+        {
+          "id": "5:3750175271752362304",
+          "name": "content",
+          "type": 9
+        },
+        {
+          "id": "6:6662940452783824722",
+          "name": "createdAt",
+          "indexId": "6:1136372787810734727",
+          "type": 6,
+          "flags": 8
+        },
+        {
+          "id": "7:7365873607391821510",
+          "name": "replyToId",
+          "type": 9
+        }
+      ],
+      "relations": []
+    },
+    {
+      "id": "3:4980149860826606366",
+      "lastPropertyId": "13:2695266999059672518",
+      "name": "GroupMetaEntity",
+      "properties": [
+        {
+          "id": "1:5225892304526232633",
+          "name": "dbId",
+          "type": 6,
+          "flags": 1
+        },
+        {
+          "id": "2:6348721888394645385",
+          "name": "roomKey",
+          "indexId": "7:1738310882621967860",
+          "type": 9,
+          "flags": 2080
+        },
+        {
+          "id": "3:6719232897229027439",
+          "name": "ownerPubkey",
+          "indexId": "8:8850647956925906315",
+          "type": 9,
+          "flags": 2048
+        },
+        {
+          "id": "4:79535940316799387",
+          "name": "relayUrl",
+          "type": 9
+        },
+        {
+          "id": "5:8901948487462359440",
+          "name": "groupId",
+          "type": 9
+        },
+        {
+          "id": "6:2179320965985223770",
+          "name": "name",
+          "type": 9
+        },
+        {
+          "id": "7:6603501369966295752",
+          "name": "picture",
+          "type": 9
+        },
+        {
+          "id": "8:1188652615133508647",
+          "name": "about",
+          "type": 9
+        },
+        {
+          "id": "9:1784012010631279003",
+          "name": "isPrivate",
+          "type": 1
+        },
+        {
+          "id": "10:4501155107145786277",
+          "name": "isClosed",
+          "type": 1
+        },
+        {
+          "id": "11:3330465102865895006",
+          "name": "adminsJson",
+          "type": 9
+        },
+        {
+          "id": "12:2841542968064092828",
+          "name": "membersJson",
+          "type": 9
+        },
+        {
+          "id": "13:2695266999059672518",
+          "name": "lastMessageAt",
+          "type": 6
+        }
+      ],
+      "relations": []
     }
   ],
-  "lastEntityId": "1:8041604479547442110",
-  "lastIndexId": "3:8412262979559058976",
+  "lastEntityId": "3:4980149860826606366",
+  "lastIndexId": "8:8850647956925906315",
   "lastRelationId": "0:0",
   "lastSequenceId": "0:0",
   "modelVersion": 5,

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -600,7 +600,8 @@ fun WispNavHost(
         )
     }
 
-    // NIP-42 AUTH approval dialog — shown when a DM delivery relay requests authentication
+    // NIP-42 AUTH approval dialog — shown when a tier-2 relay (DM delivery or joined chat relay)
+    // requests authentication so the user can decide whether to reveal their pubkey.
     val pendingAuth by feedViewModel.relayPool.pendingAuthRequest.collectAsState()
     pendingAuth?.let { request ->
         AuthApprovalDialog(

--- a/app/src/main/kotlin/com/wisp/app/db/GroupMetaEntity.kt
+++ b/app/src/main/kotlin/com/wisp/app/db/GroupMetaEntity.kt
@@ -18,6 +18,8 @@ data class GroupMetaEntity(
     val about: String? = null,
     val isPrivate: Boolean = false,
     val isClosed: Boolean = false,
+    val isRestricted: Boolean = false,
+    val isHidden: Boolean = false,
     val adminsJson: String = "[]",
     val membersJson: String = "[]",
     val lastMessageAt: Long = 0L

--- a/app/src/main/kotlin/com/wisp/app/db/GroupPersistence.kt
+++ b/app/src/main/kotlin/com/wisp/app/db/GroupPersistence.kt
@@ -48,6 +48,8 @@ class GroupPersistence {
         val about: String?,
         val isPrivate: Boolean,
         val isClosed: Boolean,
+        val isRestricted: Boolean,
+        val isHidden: Boolean,
         val admins: List<String>,
         val members: List<String>,
         val lastMessageAt: Long,
@@ -82,6 +84,8 @@ class GroupPersistence {
                     about = meta.about,
                     isPrivate = meta.isPrivate,
                     isClosed = meta.isClosed,
+                    isRestricted = meta.isRestricted,
+                    isHidden = meta.isHidden,
                     admins = admins,
                     members = members,
                     // Derive lastMessageAt from newest stored message; fall back to stored value
@@ -114,6 +118,8 @@ class GroupPersistence {
                     about = room.metadata?.about,
                     isPrivate = room.metadata?.isPrivate ?: false,
                     isClosed = room.metadata?.isClosed ?: false,
+                    isRestricted = room.metadata?.isRestricted ?: false,
+                    isHidden = room.metadata?.isHidden ?: false,
                     adminsJson = json.encodeToString(room.admins),
                     membersJson = json.encodeToString(room.members),
                     lastMessageAt = room.lastMessageAt

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip29.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip29.kt
@@ -2,9 +2,11 @@ package com.wisp.app.nostr
 
 object Nip29 {
     const val KIND_CHAT_MESSAGE = 9
+    const val KIND_PUT_USER = 9000
     const val KIND_EDIT_METADATA = 9002
     const val KIND_CREATE_GROUP = 9007
     const val KIND_DELETE_GROUP = 9008
+    const val KIND_CREATE_INVITE = 9009
     const val KIND_JOIN_REQUEST = 9021
     const val KIND_LEAVE_REQUEST = 9022
     const val KIND_GROUP_METADATA = 39000
@@ -17,23 +19,44 @@ object Nip29 {
         val picture: String?,
         val about: String?,
         val isPrivate: Boolean,
-        val isClosed: Boolean
+        val isClosed: Boolean,
+        val isRestricted: Boolean = false,
+        val isHidden: Boolean = false
     )
+
+    /** One admin's pubkey and the role strings attached to it on a kind 39001 event. */
+    data class AdminEntry(val pubkey: String, val roles: List<String>)
 
     /**
      * Parse a group identifier string like "groups.nostr.com'mygroup" into
      * (relayUrl, groupId). Returns null if the format is invalid.
      */
     fun parseGroupIdentifier(identifier: String): Pair<String, String>? {
-        val idx = identifier.indexOf('\'')
+        val withoutQuery = identifier.substringBefore('?')
+        val idx = withoutQuery.indexOf('\'')
         if (idx < 0) return null
         // Normalize to lowercase — relay URLs are case-insensitive but used as map keys
-        val host = identifier.substring(0, idx).trimStart('/').lowercase()
+        val host = withoutQuery.substring(0, idx).trimStart('/').lowercase()
         if (host.isEmpty()) return null  // bare apostrophe or leading slash only
-        val groupId = identifier.substring(idx + 1).ifEmpty { "_" }
+        val groupId = withoutQuery.substring(idx + 1).ifEmpty { "_" }
         val relayUrl = (if (host.startsWith("wss://") || host.startsWith("ws://")) host
                         else "wss://$host").trimEnd('/')
         return Pair(relayUrl, groupId)
+    }
+
+    /**
+     * Parse an invite link `<relay>'<groupId>[?code=<code>]`, returning relay, groupId, and
+     * an optional invite code. Returns null if the basic identifier is invalid.
+     */
+    fun parseInviteLink(input: String): Triple<String, String, String?>? {
+        val (relay, groupId) = parseGroupIdentifier(input) ?: return null
+        val qIdx = input.indexOf('?')
+        if (qIdx < 0) return Triple(relay, groupId, null)
+        val code = input.substring(qIdx + 1).split('&')
+            .firstOrNull { it.startsWith("code=") }
+            ?.removePrefix("code=")
+            ?.takeIf { it.isNotEmpty() }
+        return Triple(relay, groupId, code)
     }
 
     fun parseGroupMetadata(event: NostrEvent): GroupMetadata? {
@@ -44,7 +67,9 @@ object Nip29 {
         val about = event.tags.firstOrNull { it.size >= 2 && it[0] == "about" }?.get(1)
         val isPrivate = event.tags.any { it.isNotEmpty() && it[0] == "private" }
         val isClosed = event.tags.any { it.isNotEmpty() && it[0] == "closed" }
-        return GroupMetadata(groupId, name, picture, about, isPrivate, isClosed)
+        val isRestricted = event.tags.any { it.isNotEmpty() && it[0] == "restricted" }
+        val isHidden = event.tags.any { it.isNotEmpty() && it[0] == "hidden" }
+        return GroupMetadata(groupId, name, picture, about, isPrivate, isClosed, isRestricted, isHidden)
     }
 
     fun buildChatMessage(
@@ -63,14 +88,19 @@ object Nip29 {
     fun buildJoinRequest(
         privkey: ByteArray,
         pubkey: ByteArray,
-        groupId: String
-    ): NostrEvent = NostrEvent.create(
-        privkey = privkey,
-        pubkey = pubkey,
-        kind = KIND_JOIN_REQUEST,
-        content = "",
-        tags = listOf(listOf("h", groupId))
-    )
+        groupId: String,
+        inviteCode: String? = null
+    ): NostrEvent {
+        val tags = mutableListOf(listOf("h", groupId))
+        inviteCode?.takeIf { it.isNotEmpty() }?.let { tags.add(listOf("code", it)) }
+        return NostrEvent.create(
+            privkey = privkey,
+            pubkey = pubkey,
+            kind = KIND_JOIN_REQUEST,
+            content = "",
+            tags = tags
+        )
+    }
 
     fun buildCreateGroup(
         privkey: ByteArray,
@@ -84,16 +114,32 @@ object Nip29 {
         tags = listOf(listOf("h", groupId))
     )
 
+    /**
+     * Build a kind 9002 edit-metadata event. For each flag that is non-null, emits either the
+     * positive tag (e.g. `["private"]`) when true or the inverse tag (e.g. `["public"]`) when
+     * false — this way a single event can deterministically set every flag regardless of the
+     * relay's default posture.
+     */
     fun buildEditMetadata(
         privkey: ByteArray,
         pubkey: ByteArray,
         groupId: String,
         name: String? = null,
-        about: String? = null
+        about: String? = null,
+        picture: String? = null,
+        isPrivate: Boolean? = null,
+        isClosed: Boolean? = null,
+        isRestricted: Boolean? = null,
+        isHidden: Boolean? = null
     ): NostrEvent {
         val tags = mutableListOf(listOf("h", groupId))
-        name?.let { tags.add(listOf("name", it)) }
-        about?.let { tags.add(listOf("about", it)) }
+        name?.takeIf { it.isNotBlank() }?.let { tags.add(listOf("name", it.trim())) }
+        about?.takeIf { it.isNotBlank() }?.let { tags.add(listOf("about", it.trim())) }
+        picture?.takeIf { it.isNotBlank() }?.let { tags.add(listOf("picture", it.trim())) }
+        isPrivate?.let { tags.add(listOf(if (it) "private" else "public")) }
+        isClosed?.let { tags.add(listOf(if (it) "closed" else "open")) }
+        isRestricted?.let { tags.add(listOf(if (it) "restricted" else "unrestricted")) }
+        isHidden?.let { tags.add(listOf(if (it) "hidden" else "visible")) }
         return NostrEvent.create(
             privkey = privkey,
             pubkey = pubkey,
@@ -103,16 +149,61 @@ object Nip29 {
         )
     }
 
+    /** Build a kind 9000 event that assigns the given roles to `targetPubkey` in the group. */
+    fun buildPutUser(
+        privkey: ByteArray,
+        pubkey: ByteArray,
+        groupId: String,
+        targetPubkey: String,
+        roles: List<String>
+    ): NostrEvent {
+        val pTag = mutableListOf("p", targetPubkey).apply { addAll(roles.filter { it.isNotBlank() }) }
+        return NostrEvent.create(
+            privkey = privkey,
+            pubkey = pubkey,
+            kind = KIND_PUT_USER,
+            content = "",
+            tags = listOf(listOf("h", groupId), pTag)
+        )
+    }
+
+    /** Build a kind 9009 create-invite event with the given code. */
+    fun buildCreateInvite(
+        privkey: ByteArray,
+        pubkey: ByteArray,
+        groupId: String,
+        code: String
+    ): NostrEvent = NostrEvent.create(
+        privkey = privkey,
+        pubkey = pubkey,
+        kind = KIND_CREATE_INVITE,
+        content = "",
+        tags = listOf(listOf("h", groupId), listOf("code", code))
+    )
+
     /** Generates a random NIP-29 compliant group ID (lowercase alphanumeric, 12 chars). */
     fun generateGroupId(): String {
         val chars = "abcdefghijklmnopqrstuvwxyz0123456789"
         return (1..12).map { chars.random() }.joinToString("")
     }
 
-    fun parseGroupAdmins(event: NostrEvent): List<String> {
-        if (event.kind != KIND_GROUP_ADMINS) return emptyList()
-        return event.tags.filter { it.size >= 2 && it[0] == "p" }.map { it[1] }
+    /** Generates a random 16-char alphanumeric invite code. */
+    fun generateInviteCode(): String {
+        val chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+        return (1..16).map { chars.random() }.joinToString("")
     }
+
+    /** Returns admin entries (pubkey + role strings) from a kind 39001 event. */
+    fun parseGroupAdmins(event: NostrEvent): List<AdminEntry> {
+        if (event.kind != KIND_GROUP_ADMINS) return emptyList()
+        return event.tags
+            .filter { it.size >= 2 && it[0] == "p" }
+            .map { AdminEntry(pubkey = it[1], roles = it.drop(2)) }
+    }
+
+    /** Convenience shim: just the pubkeys from kind 39001. */
+    fun parseGroupAdminPubkeys(event: NostrEvent): List<String> =
+        parseGroupAdmins(event).map { it.pubkey }
 
     fun parseGroupMembers(event: NostrEvent): List<String> {
         if (event.kind != KIND_GROUP_MEMBERS) return emptyList()
@@ -135,5 +226,9 @@ object Nip29 {
     /** Returns the canonical invite link string, e.g. "wss://groups.0xchat.com'abc123" */
     fun inviteLink(relayUrl: String, groupId: String): String = "${relayUrl.lowercase()}'$groupId"
 
-    val DEFAULT_GROUP_RELAYS = listOf("wss://groups.0xchat.com")
+    /** Invite link with a one-time code, e.g. "wss://groups.0xchat.com'abc123?code=xyz". */
+    fun inviteLink(relayUrl: String, groupId: String, code: String): String =
+        "${inviteLink(relayUrl, groupId)}?code=$code"
+
+    val DEFAULT_GROUP_RELAYS = listOf("wss://chat.wisp.talk")
 }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -59,6 +59,11 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
     /** Mark a relay URL as a DM delivery target (tier 2 AUTH). */
     fun markDmDeliveryTarget(url: String) { dmDeliveryTargets.add(url) }
 
+    /** URLs of NIP-29 chat relays the user has intentionally joined (tier 2 for AUTH).
+     *  Populated by [ensureGroupRelay] — AUTH challenges from these relays trigger a
+     *  one-time user approval prompt and are persisted via [userApprovedAuthRelays]. */
+    private val groupRelayAuthTargets: MutableSet<String> = java.util.concurrent.ConcurrentHashMap.newKeySet()
+
     /** Relay URLs the user has approved for AUTH — persisted across sessions. */
     private val userApprovedAuthRelays: MutableSet<String> = java.util.concurrent.ConcurrentHashMap.newKeySet<String>().also { set ->
         prefs?.getStringSet(PREF_APPROVED_AUTH_RELAYS, emptySet())?.let { set.addAll(it) }
@@ -67,7 +72,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
     data class PendingAuthRequest(val relayUrl: String, val challenge: String)
 
     private val _pendingAuthRequest = MutableStateFlow<PendingAuthRequest?>(null)
-    /** Emitted when a tier-2 (DM delivery) relay needs user approval to authenticate. */
+    /** Emitted when a tier-2 relay (DM delivery or joined chat relay) needs user approval to authenticate. */
     val pendingAuthRequest: StateFlow<PendingAuthRequest?> = _pendingAuthRequest
 
     /** Approve a pending AUTH request — signs and sends AUTH, persists approval. */
@@ -321,6 +326,9 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
     fun ensureGroupRelay(url: String) {
         ensureClientCurrent()
         if (url in blockedUrls || !RelayConfig.isConnectableUrl(url)) return
+        // Chat relay AUTH challenges route through the tier-2 prompt flow so the user
+        // can decide to reveal their pubkey for private/hidden group access.
+        groupRelayAuthTargets.add(url)
         if (groupRelays.containsKey(url)) return
         // Remove any stale ephemeral relay for this URL — otherwise sendToRelayOrEphemeral
         // will skip the group relay fast-path and send REQs on the disconnected ephemeral.
@@ -556,20 +564,21 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
                     return@collect
                 }
 
-                // Tier 2: Recipient DM delivery relays — prompt user (or auto-sign if already approved)
-                if (url in dmDeliveryTargets) {
+                // Tier 2: DM delivery relays and joined NIP-29 chat relays — prompt user
+                // (or auto-sign if they've already granted approval for this URL).
+                if (url in dmDeliveryTargets || url in groupRelayAuthTargets) {
                     if (url in userApprovedAuthRelays) {
                         try {
                             val authEvent = signer(url, challenge)
                             relay.send(ClientMessage.auth(authEvent))
                             authenticatedRelays.add(url)
-                            Log.d("RelayPool", "AUTH auto-signed for approved DM delivery relay $url")
+                            Log.d("RelayPool", "AUTH auto-signed for approved relay $url")
                             _authCompleted.tryEmit(url)
                         } catch (e: Exception) {
-                            Log.e("RelayPool", "AUTH failed for approved DM delivery relay $url: ${e.message}")
+                            Log.e("RelayPool", "AUTH failed for approved relay $url: ${e.message}")
                         }
                     } else {
-                        Log.d("RelayPool", "AUTH challenge from DM delivery relay $url — prompting user")
+                        Log.d("RelayPool", "AUTH challenge from $url — prompting user")
                         _pendingAuthRequest.value = PendingAuthRequest(url, challenge)
                     }
                     return@collect

--- a/app/src/main/kotlin/com/wisp/app/repo/GroupRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/GroupRepository.kt
@@ -81,7 +81,8 @@ class GroupRepository(private val context: Context, pubkeyHex: String? = null) {
                 val metadata = when {
                     persisted != null && (persisted.name != null || persisted.picture != null) ->
                         Nip29.GroupMetadata(groupId, persisted.name, persisted.picture,
-                            persisted.about, persisted.isPrivate, persisted.isClosed)
+                            persisted.about, persisted.isPrivate, persisted.isClosed,
+                            persisted.isRestricted, persisted.isHidden)
                     else -> {
                         // Fall back to locally-stored name in SharedPreferences
                         val localName = prefs.getString("local_name_$key", null)

--- a/app/src/main/kotlin/com/wisp/app/ui/component/AuthApprovalDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/AuthApprovalDialog.kt
@@ -18,8 +18,9 @@ fun AuthApprovalDialog(
         text = {
             Text(
                 text = "The relay $relayUrl is requesting authentication. " +
-                    "This is a DM delivery relay for a recipient. " +
-                    "Authenticating will reveal your identity to the relay operator.",
+                    "Authenticating will reveal your identity (pubkey) to the relay operator, " +
+                    "which some relays need before serving private DMs or chat rooms. " +
+                    "If you allow once, we'll remember this choice for this relay.",
                 style = MaterialTheme.typography.bodyMedium
             )
         },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -92,6 +93,12 @@ fun DmListScreen(
     var showCreateDialog by remember { mutableStateOf(false) }
     var showDiscoverSheet by remember { mutableStateOf(false) }
     var showFabMenu by remember { mutableStateOf(false) }
+    var joinError by remember { mutableStateOf<GroupListViewModel.JoinError?>(null) }
+
+    // Collect one-shot join rejections from the relay and surface them as a dialog.
+    LaunchedEffect(groupListViewModel) {
+        groupListViewModel.joinErrors.collect { joinError = it }
+    }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -187,9 +194,9 @@ fun DmListScreen(
     if (showJoinDialog) {
         JoinGroupDialog(
             onDismiss = { showJoinDialog = false },
-            onJoin = { relayUrl, groupId ->
+            onJoin = { relayUrl, groupId, inviteCode ->
                 showJoinDialog = false
-                groupListViewModel.joinGroup(relayUrl, groupId, signer)
+                groupListViewModel.joinGroup(relayUrl, groupId, signer, inviteCode)
             }
         )
     }
@@ -197,9 +204,13 @@ fun DmListScreen(
     if (showCreateDialog) {
         CreateGroupDialog(
             onDismiss = { showCreateDialog = false },
-            onCreate = { relayUrl, name ->
+            onCreate = { relayUrl, name, isPrivate, isClosed, isRestricted, isHidden ->
                 showCreateDialog = false
-                groupListViewModel.createGroup(relayUrl, name, signer)
+                groupListViewModel.createGroup(relayUrl, name, signer,
+                    isPrivate = isPrivate,
+                    isClosed = isClosed,
+                    isRestricted = isRestricted,
+                    isHidden = isHidden)
             }
         )
     }
@@ -212,6 +223,34 @@ fun DmListScreen(
             onJoin = { relayUrl, groupId ->
                 showDiscoverSheet = false
                 groupListViewModel.joinGroup(relayUrl, groupId, signer)
+            }
+        )
+    }
+
+    joinError?.let { err ->
+        AlertDialog(
+            onDismissRequest = { joinError = null },
+            title = { Text(stringResource(R.string.title_join_rejected)) },
+            text = {
+                Column {
+                    Text(
+                        stringResource(R.string.msg_join_rejected_body),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    if (err.message.isNotBlank()) {
+                        Spacer(Modifier.height(12.dp))
+                        Text(
+                            text = "Relay said: ${err.message}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { joinError = null }) {
+                    Text(stringResource(R.string.btn_ok))
+                }
             }
         )
     }
@@ -376,7 +415,7 @@ private fun GroupRoomRow(
 @Composable
 private fun JoinGroupDialog(
     onDismiss: () -> Unit,
-    onJoin: (relayUrl: String, groupId: String) -> Unit
+    onJoin: (relayUrl: String, groupId: String, inviteCode: String?) -> Unit
 ) {
     var inviteLink by remember { mutableStateOf("") }
     var showError by remember { mutableStateOf(false) }
@@ -390,7 +429,7 @@ private fun JoinGroupDialog(
                     value = inviteLink,
                     onValueChange = { inviteLink = it; showError = false },
                     label = { Text(stringResource(R.string.label_invite_link)) },
-                    placeholder = { Text("groups.0xchat.com'roomid") },
+                    placeholder = { Text("chat.wisp.talk'roomid") },
                     singleLine = true,
                     isError = showError,
                     supportingText = if (showError) {
@@ -403,9 +442,9 @@ private fun JoinGroupDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    val parsed = com.wisp.app.nostr.Nip29.parseGroupIdentifier(inviteLink.trim())
+                    val parsed = com.wisp.app.nostr.Nip29.parseInviteLink(inviteLink.trim())
                     if (parsed != null) {
-                        onJoin(parsed.first, parsed.second)
+                        onJoin(parsed.first, parsed.second, parsed.third)
                     } else {
                         showError = true
                     }
@@ -425,10 +464,21 @@ private fun JoinGroupDialog(
 @Composable
 private fun CreateGroupDialog(
     onDismiss: () -> Unit,
-    onCreate: (relayUrl: String, name: String) -> Unit
+    onCreate: (
+        relayUrl: String,
+        name: String,
+        isPrivate: Boolean,
+        isClosed: Boolean,
+        isRestricted: Boolean,
+        isHidden: Boolean
+    ) -> Unit
 ) {
     var groupName by remember { mutableStateOf("") }
     var relayUrl by remember { mutableStateOf(com.wisp.app.nostr.Nip29.DEFAULT_GROUP_RELAYS.first()) }
+    var isPrivate by remember { mutableStateOf(false) }
+    var isClosed by remember { mutableStateOf(false) }
+    var isRestricted by remember { mutableStateOf(false) }
+    var isHidden by remember { mutableStateOf(false) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -450,13 +500,41 @@ private fun CreateGroupDialog(
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth()
                 )
+                Spacer(Modifier.height(8.dp))
+                GroupFlagSwitch(
+                    label = stringResource(R.string.group_flag_private_label),
+                    description = stringResource(R.string.group_flag_private_desc),
+                    checked = isPrivate,
+                    onCheckedChange = { isPrivate = it }
+                )
+                GroupFlagSwitch(
+                    label = stringResource(R.string.group_flag_closed_label),
+                    description = stringResource(R.string.group_flag_closed_desc),
+                    checked = isClosed,
+                    onCheckedChange = { isClosed = it }
+                )
+                GroupFlagSwitch(
+                    label = stringResource(R.string.group_flag_restricted_label),
+                    description = stringResource(R.string.group_flag_restricted_desc),
+                    checked = isRestricted,
+                    onCheckedChange = { isRestricted = it }
+                )
+                GroupFlagSwitch(
+                    label = stringResource(R.string.group_flag_hidden_label),
+                    description = stringResource(R.string.group_flag_hidden_desc),
+                    checked = isHidden,
+                    onCheckedChange = { isHidden = it }
+                )
             }
         },
         confirmButton = {
             TextButton(
                 onClick = {
                     val url = relayUrl.trim()
-                    if (url.isNotEmpty()) onCreate(url, groupName.trim())
+                    if (url.isNotEmpty()) onCreate(
+                        url, groupName.trim(),
+                        isPrivate, isClosed, isRestricted, isHidden
+                    )
                 }
             ) {
                 Text(stringResource(R.string.action_create))
@@ -468,6 +546,30 @@ private fun CreateGroupDialog(
             }
         }
     )
+}
+
+@Composable
+private fun GroupFlagSwitch(
+    label: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+            .padding(vertical = 6.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label, style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface)
+            Text(description, style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/GroupDetailScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/GroupDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.wisp.app.ui.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,10 +21,19 @@ import androidx.compose.material.icons.automirrored.outlined.ExitToApp
 import androidx.compose.material.icons.outlined.DeleteForever
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.EditOff
 import androidx.compose.material.icons.outlined.FileUpload
+import androidx.compose.material.icons.outlined.Groups
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.LockOpen
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.NotificationsOff
+import androidx.compose.material.icons.outlined.PersonAdd
+import androidx.compose.material.icons.outlined.PersonOff
 import androidx.compose.material.icons.outlined.PersonRemove
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material.icons.outlined.VisibilityOff
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -89,9 +99,12 @@ fun GroupDetailScreen(
     var showLeaveDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var removeTarget by remember { mutableStateOf<String?>(null) }
+    var assignRoleTarget by remember { mutableStateOf<String?>(null) }
+    var latestInviteCode by remember { mutableStateOf<String?>(null) }
 
     val clipboardManager = LocalClipboardManager.current
     val inviteLink = Nip29.inviteLink(relayUrl, groupId)
+    val codedInviteLink = latestInviteCode?.let { Nip29.inviteLink(relayUrl, groupId, it) }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -124,6 +137,65 @@ fun GroupDetailScreen(
             // Group header
             item {
                 GroupHeader(room = room)
+            }
+
+            // Access & visibility — show all 4 dimensions with icon + label + description,
+            // so users always know the room's posture (public/private, open/closed, etc.).
+            val metadata = room?.metadata
+            if (metadata != null) {
+                item {
+                    HorizontalDivider(thickness = 0.5.dp, color = MaterialTheme.colorScheme.outline)
+                    Text(
+                        stringResource(R.string.section_room_access),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
+                    )
+                    GroupFlagDetailRow(
+                        icon = if (metadata.isPrivate) Icons.Outlined.Lock else Icons.Outlined.LockOpen,
+                        label = stringResource(
+                            if (metadata.isPrivate) R.string.group_flag_private_label
+                            else R.string.group_flag_public_label
+                        ),
+                        description = stringResource(
+                            if (metadata.isPrivate) R.string.group_flag_private_desc
+                            else R.string.group_flag_public_desc
+                        )
+                    )
+                    GroupFlagDetailRow(
+                        icon = if (metadata.isClosed) Icons.Outlined.PersonOff else Icons.Outlined.Groups,
+                        label = stringResource(
+                            if (metadata.isClosed) R.string.group_flag_closed_label
+                            else R.string.group_flag_open_label
+                        ),
+                        description = stringResource(
+                            if (metadata.isClosed) R.string.group_flag_closed_desc
+                            else R.string.group_flag_open_desc
+                        )
+                    )
+                    GroupFlagDetailRow(
+                        icon = if (metadata.isRestricted) Icons.Outlined.EditOff else Icons.Outlined.Edit,
+                        label = stringResource(
+                            if (metadata.isRestricted) R.string.group_flag_restricted_label
+                            else R.string.group_flag_unrestricted_label
+                        ),
+                        description = stringResource(
+                            if (metadata.isRestricted) R.string.group_flag_restricted_desc
+                            else R.string.group_flag_unrestricted_desc
+                        )
+                    )
+                    GroupFlagDetailRow(
+                        icon = if (metadata.isHidden) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility,
+                        label = stringResource(
+                            if (metadata.isHidden) R.string.group_flag_hidden_label
+                            else R.string.group_flag_visible_label
+                        ),
+                        description = stringResource(
+                            if (metadata.isHidden) R.string.group_flag_hidden_desc
+                            else R.string.group_flag_visible_desc
+                        )
+                    )
+                }
             }
 
             // Invite link
@@ -205,6 +277,103 @@ fun GroupDetailScreen(
                 HorizontalDivider(thickness = 0.5.dp, color = MaterialTheme.colorScheme.outline)
             }
 
+            // Admin-only invite codes section
+            if (isAdmin) {
+                item {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            stringResource(R.string.section_invite_codes),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
+                        )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    val code = groupListViewModel.createInvite(relayUrl, groupId, signer)
+                                    if (code != null) latestInviteCode = code
+                                }
+                                .padding(horizontal = 16.dp, vertical = 12.dp)
+                        ) {
+                            Icon(
+                                Icons.Outlined.PersonAdd,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Text(
+                                stringResource(R.string.action_generate_invite),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                        latestInviteCode?.let { code ->
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        clipboardManager.setText(AnnotatedString(code))
+                                    }
+                                    .padding(horizontal = 16.dp, vertical = 10.dp)
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        stringResource(R.string.label_latest_invite_code),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                    Text(
+                                        code,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        fontFamily = FontFamily.Monospace,
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                }
+                                IconButton(onClick = {
+                                    clipboardManager.setText(AnnotatedString(code))
+                                }) {
+                                    Icon(
+                                        Icons.Outlined.ContentCopy,
+                                        contentDescription = stringResource(R.string.action_copy_code),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                }
+                            }
+                            codedInviteLink?.let { link ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            clipboardManager.setText(AnnotatedString(link))
+                                        }
+                                        .padding(horizontal = 16.dp, vertical = 10.dp)
+                                ) {
+                                    Text(
+                                        stringResource(R.string.action_copy_invite_link),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    Icon(
+                                        Icons.Outlined.ContentCopy,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                }
+                            }
+                        }
+                        HorizontalDivider(thickness = 0.5.dp, color = MaterialTheme.colorScheme.outline)
+                    }
+                }
+            }
+
             // Leave / Delete actions
             item {
                 Row(
@@ -271,8 +440,10 @@ fun GroupDetailScreen(
                         pubkey = pubkey,
                         isAdmin = admins.contains(pubkey),
                         showRemove = isAdmin && pubkey != myPubkey && !admins.contains(pubkey),
+                        showAssignRole = isAdmin && pubkey != myPubkey,
                         eventRepo = eventRepo,
-                        onRemove = { removeTarget = pubkey }
+                        onRemove = { removeTarget = pubkey },
+                        onAssignRole = { assignRoleTarget = pubkey }
                     )
                     HorizontalDivider(thickness = 0.5.dp, color = MaterialTheme.colorScheme.outline)
                 }
@@ -369,6 +540,46 @@ fun GroupDetailScreen(
             }
         )
     }
+
+    assignRoleTarget?.let { target ->
+        val profile = remember(target) { eventRepo.getProfileData(target) }
+        val displayName = profile?.displayString ?: target.take(10) + "…"
+        var rolesText by remember(target) { mutableStateOf("admin") }
+        AlertDialog(
+            onDismissRequest = { assignRoleTarget = null },
+            title = { Text(stringResource(R.string.title_assign_role)) },
+            text = {
+                Column {
+                    Text(
+                        stringResource(R.string.msg_assign_role, displayName),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = rolesText,
+                        onValueChange = { rolesText = it },
+                        label = { Text(stringResource(R.string.label_roles)) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val roles = rolesText.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+                    groupListViewModel.putUser(relayUrl, groupId, target, roles, signer)
+                    assignRoleTarget = null
+                }) {
+                    Text(stringResource(R.string.action_save))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { assignRoleTarget = null }) {
+                    Text(stringResource(R.string.btn_cancel))
+                }
+            }
+        )
+    }
 }
 
 @Composable
@@ -396,20 +607,93 @@ private fun GroupHeader(room: GroupRoom?) {
                 modifier = Modifier.padding(horizontal = 24.dp)
             )
         }
-        if (metadata?.isPrivate == true || metadata?.isClosed == true) {
-            Spacer(Modifier.height(4.dp))
-            Row {
-                if (metadata.isPrivate) {
-                    Text("private", style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 4.dp))
-                }
-                if (metadata.isClosed) {
-                    Text("closed", style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 4.dp))
+        // Header posture chip(s): show restrictive flags when set, otherwise a single
+        // "Public" chip so a fully-open room still carries a clear badge.
+        if (metadata != null) {
+            val anyFlag = metadata.isPrivate || metadata.isClosed || metadata.isRestricted || metadata.isHidden
+            Spacer(Modifier.height(10.dp))
+            Row(
+                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(6.dp),
+                modifier = Modifier.padding(horizontal = 16.dp)
+            ) {
+                if (!anyFlag) {
+                    GroupFlagChip(Icons.Outlined.LockOpen,
+                        stringResource(R.string.group_flag_public_label))
+                } else {
+                    if (metadata.isPrivate) {
+                        GroupFlagChip(Icons.Outlined.Lock,
+                            stringResource(R.string.group_flag_private_label))
+                    }
+                    if (metadata.isClosed) {
+                        GroupFlagChip(Icons.Outlined.PersonOff,
+                            stringResource(R.string.group_flag_closed_label))
+                    }
+                    if (metadata.isRestricted) {
+                        GroupFlagChip(Icons.Outlined.EditOff,
+                            stringResource(R.string.group_flag_restricted_label))
+                    }
+                    if (metadata.isHidden) {
+                        GroupFlagChip(Icons.Outlined.VisibilityOff,
+                            stringResource(R.string.group_flag_hidden_label))
+                    }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun GroupFlagChip(icon: ImageVector, label: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .background(
+                color = MaterialTheme.colorScheme.primaryContainer,
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(10.dp)
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.size(14.dp)
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onPrimaryContainer
+        )
+    }
+}
+
+@Composable
+private fun GroupFlagDetailRow(icon: ImageVector, label: String, description: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }
@@ -419,8 +703,10 @@ private fun MemberRow(
     pubkey: String,
     isAdmin: Boolean,
     showRemove: Boolean,
+    showAssignRole: Boolean,
     eventRepo: EventRepository,
-    onRemove: () -> Unit
+    onRemove: () -> Unit,
+    onAssignRole: () -> Unit
 ) {
     val profile = remember(pubkey) { eventRepo.getProfileData(pubkey) }
     Row(
@@ -448,6 +734,16 @@ private fun MemberRow(
                 modifier = Modifier.size(18.dp)
             )
             Spacer(Modifier.width(4.dp))
+        }
+        if (showAssignRole) {
+            IconButton(onClick = onAssignRole) {
+                Icon(
+                    Icons.Outlined.PersonAdd,
+                    contentDescription = stringResource(R.string.cd_assign_role),
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
         }
         if (showRemove) {
             IconButton(onClick = onRemove) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/GroupListViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/GroupListViewModel.kt
@@ -11,6 +11,7 @@ import com.wisp.app.nostr.Nip30
 import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.NostrSigner
 import com.wisp.app.nostr.SimpleGroupEntry
+import com.wisp.app.relay.PublishResult
 import com.wisp.app.relay.RelayConfig
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.EventRepository
@@ -25,6 +26,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -57,6 +61,11 @@ class GroupListViewModel(app: Application) : AndroidViewModel(app) {
     val discoveryLoading: StateFlow<Boolean> = _discoveryLoading
     private var discoverGen = 0
 
+    /** One-shot join-rejection signal — the UI listens and surfaces a dialog. */
+    data class JoinError(val relayUrl: String, val groupId: String, val message: String)
+    private val _joinErrors = MutableSharedFlow<JoinError>(extraBufferCapacity = 8)
+    val joinErrors: SharedFlow<JoinError> = _joinErrors
+
     val groups: StateFlow<List<GroupRoom>>
         get() = groupRepo?.joinedGroups ?: MutableStateFlow(emptyList())
 
@@ -86,9 +95,28 @@ class GroupListViewModel(app: Application) : AndroidViewModel(app) {
         notifRepo = nRepo
         myPubkey = pubkey
         collectRelayEvents()
+        collectAuthCompleted()
         // Auto-subscribe to groups with notifications enabled so messages arrive in the background
         for ((relayUrl, groupId) in repository.getNotifiedGroupKeys()) {
             subscribeToGroup(relayUrl, groupId)
+        }
+    }
+
+    /** When NIP-42 AUTH completes for a relay we have groups on, re-fire the group
+     *  subscriptions — the relay likely closed them with "auth-required:" and they won't
+     *  deliver events until we re-send the REQs post-auth. */
+    private fun collectAuthCompleted() {
+        val pool = relayPool ?: return
+        viewModelScope.launch(Dispatchers.Default) {
+            pool.authCompleted.collect { relayUrl ->
+                val repo = groupRepo ?: return@collect
+                val groupsOnRelay = repo.getJoinedGroupKeys().filter { it.first == relayUrl }
+                if (groupsOnRelay.isEmpty()) return@collect
+                Log.d("GroupListVM", "[authCompleted] re-firing subs for ${groupsOnRelay.size} groups on $relayUrl")
+                for ((url, groupId) in groupsOnRelay) {
+                    sendGroupReqs(url, groupId)
+                }
+            }
         }
     }
 
@@ -249,17 +277,20 @@ class GroupListViewModel(app: Application) : AndroidViewModel(app) {
                         repo.addReaction(relayUrl, groupId, messageId, event.pubkey, emoji, emojiUrl)
                     }
                     Nip29.KIND_GROUP_METADATA -> {
+                        Log.d("GroupListVM", "[raw 39000 metadata] relay=$relayUrl ${event.toJson()}")
                         val metadata = Nip29.parseGroupMetadata(event) ?: return@collect
                         repo.getRoom(relayUrl, metadata.groupId) ?: return@collect
                         repo.updateMetadata(relayUrl, metadata.groupId, metadata)
                     }
                     Nip29.KIND_GROUP_ADMINS -> {
+                        Log.d("GroupListVM", "[raw 39001 admins] relay=$relayUrl ${event.toJson()}")
                         val groupId = event.tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.get(1)
                             ?: return@collect
                         repo.getRoom(relayUrl, groupId) ?: return@collect
-                        repo.updateAdmins(relayUrl, groupId, Nip29.parseGroupAdmins(event))
+                        repo.updateAdmins(relayUrl, groupId, Nip29.parseGroupAdminPubkeys(event))
                     }
                     Nip29.KIND_GROUP_MEMBERS -> {
+                        Log.d("GroupListVM", "[raw 39002 members] relay=$relayUrl ${event.toJson()}")
                         val groupId = event.tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.get(1)
                             ?: return@collect
                         repo.getRoom(relayUrl, groupId) ?: return@collect
@@ -296,33 +327,92 @@ class GroupListViewModel(app: Application) : AndroidViewModel(app) {
         publishGroupList(signer)
     }
 
-    fun joinGroup(relayUrl: String, groupId: String, signer: NostrSigner?) {
+    fun joinGroup(relayUrl: String, groupId: String, signer: NostrSigner?, inviteCode: String? = null) {
         val repo = groupRepo ?: return
         val pool = relayPool ?: return
-        val relayUrl = relayUrl.lowercase().trimEnd('/')
+        val normalizedUrl = relayUrl.lowercase().trimEnd('/')
+
+        // Without a signer we can't prove identity — nothing to do.
+        val s = signer ?: return
+
+        // Bring up the relay connection up front so the OK response lands on a live socket.
+        pool.ensureGroupRelay(normalizedUrl)
+
+        viewModelScope.launch(Dispatchers.Default) {
+            val event = try {
+                val tags = mutableListOf(listOf("h", groupId))
+                inviteCode?.takeIf { it.isNotEmpty() }?.let { tags.add(listOf("code", it)) }
+                s.signEvent(kind = Nip29.KIND_JOIN_REQUEST, content = "", tags = tags)
+            } catch (e: Exception) {
+                Log.w("GroupListVM", "[joinGroup] sign failed: ${e.message}")
+                _joinErrors.tryEmit(JoinError(normalizedUrl, groupId,
+                    "Couldn't sign join request: ${e.message ?: "unknown error"}"))
+                return@launch
+            }
+
+            // Subscribe to publishResults BEFORE sending so we don't miss a fast OK response.
+            val resultDeferred = CompletableDeferred<PublishResult>()
+            val collectJob = launch {
+                pool.publishResults
+                    .filter { it.eventId == event.id && it.relayUrl == normalizedUrl }
+                    .collect { resultDeferred.complete(it); return@collect }
+            }
+
+            Log.d("GroupListVM", "[joinGroup] sending 9021 group=$groupId relay=$normalizedUrl code=${inviteCode != null}")
+            pool.sendToRelayOrEphemeral(normalizedUrl, ClientMessage.event(event), skipBadCheck = true)
+
+            val result = withTimeoutOrNull(10_000) { resultDeferred.await() }
+            collectJob.cancel()
+
+            when {
+                // No OK came back in 10s — some relays silently accept. Be optimistic and admit,
+                // then let subsequent REQs surface reality (no messages = they never got in).
+                result == null -> {
+                    Log.d("GroupListVM", "[joinGroup] no OK in 10s — optimistically admitting")
+                    commitJoin(repo, normalizedUrl, groupId, s)
+                }
+                // Accepted outright, or relay says we're already a member (per NIP-29 spec).
+                result.accepted || result.message.startsWith("duplicate:", ignoreCase = true) -> {
+                    Log.d("GroupListVM", "[joinGroup] accepted relay=$normalizedUrl msg=${result.message}")
+                    commitJoin(repo, normalizedUrl, groupId, s)
+                }
+                else -> {
+                    // Rejection. Don't add the room locally — surface the relay's reason to the UI.
+                    Log.w("GroupListVM", "[joinGroup] rejected relay=$normalizedUrl msg=${result.message}")
+                    _joinErrors.tryEmit(JoinError(normalizedUrl, groupId, result.message))
+                    // Tear the relay connection back down if we're not using it for any other
+                    // group — no reason to hold an open socket after a rejected join.
+                    if (groupRepo?.getJoinedGroupKeys()?.none { it.first == normalizedUrl } == true) {
+                        pool.removeGroupRelay(normalizedUrl)
+                    }
+                }
+            }
+        }
+    }
+
+    /** Shared post-accept path: add the group locally, subscribe, publish kind 10009. */
+    private fun commitJoin(repo: GroupRepository, relayUrl: String, groupId: String, signer: NostrSigner?) {
         repo.addGroup(relayUrl, groupId)
         applyCachedPreview(relayUrl, groupId)
         subscribeToGroup(relayUrl, groupId)
         publishGroupList(signer)
+        // Re-request all subscriptions after a short delay — private relays close the initial
+        // REQs with "restricted: not a member" and only respond after the join is processed.
         viewModelScope.launch(Dispatchers.Default) {
-            signer?.let { s ->
-                try {
-                    val event = s.signEvent(
-                        kind = Nip29.KIND_JOIN_REQUEST,
-                        content = "",
-                        tags = listOf(listOf("h", groupId))
-                    )
-                    pool.sendToRelayOrEphemeral(relayUrl, ClientMessage.event(event), skipBadCheck = true)
-                } catch (_: Exception) { }
-            }
-            // Re-request all subscriptions after a short delay — private relays close the initial
-            // REQs with "restricted: not a member" and only respond after the join is processed.
             kotlinx.coroutines.delay(2_000)
             sendGroupReqs(relayUrl, groupId)
         }
     }
 
-    fun createGroup(relayUrl: String, name: String, signer: NostrSigner?) {
+    fun createGroup(
+        relayUrl: String,
+        name: String,
+        signer: NostrSigner?,
+        isPrivate: Boolean = false,
+        isClosed: Boolean = false,
+        isRestricted: Boolean = false,
+        isHidden: Boolean = false
+    ) {
         val repo = groupRepo ?: return
         val pool = relayPool ?: return
         val relayUrl = relayUrl.lowercase().trimEnd('/')
@@ -330,8 +420,21 @@ class GroupListViewModel(app: Application) : AndroidViewModel(app) {
         // Store name locally — avoids a second signing operation at create time which
         // causes an infinite loop in the remote signer bridge after "Always allow" is granted.
         repo.addGroup(relayUrl, groupId, localName = name.trim().ifEmpty { null })
+        // Optimistically record the chosen flags so the UI reflects the intended posture
+        // before the 39000 metadata event round-trips back from the relay.
+        repo.updateMetadata(relayUrl, groupId, Nip29.GroupMetadata(
+            groupId = groupId,
+            name = name.trim().ifEmpty { null },
+            picture = null,
+            about = null,
+            isPrivate = isPrivate,
+            isClosed = isClosed,
+            isRestricted = isRestricted,
+            isHidden = isHidden
+        ))
         subscribeToGroup(relayUrl, groupId)
         publishGroupList(signer)
+        val anyFlagSet = isPrivate || isClosed || isRestricted || isHidden
         signer?.let { s ->
             viewModelScope.launch(Dispatchers.Default) {
                 try {
@@ -340,8 +443,41 @@ class GroupListViewModel(app: Application) : AndroidViewModel(app) {
                         content = "",
                         tags = listOf(listOf("h", groupId))
                     )
+                    Log.d("GroupListVM", "[createGroup] publishing 9007 group=$groupId relay=$relayUrl")
                     pool.sendToRelayOrEphemeral(relayUrl, ClientMessage.event(createEvent), skipBadCheck = true)
-                } catch (_: Exception) { }
+                } catch (e: Exception) {
+                    Log.w("GroupListVM", "[createGroup] 9007 sign/publish failed: ${e.message}")
+                    return@launch
+                }
+
+                // Only fire the follow-up 9002 if the user actually customized the group's
+                // posture. This keeps default "open" creations to a single signing op (the
+                // original behavior that avoided the remote-signer bridge infinite loop).
+                if (!anyFlagSet) return@launch
+
+                // Give the relay time to process 9007 and mark us as admin before 9002 —
+                // relay29 rejects edit-metadata from non-admins, and back-to-back events
+                // can race against the admin grant.
+                kotlinx.coroutines.delay(1_500)
+
+                try {
+                    val editTags = mutableListOf(listOf("h", groupId))
+                    if (name.isNotBlank()) editTags.add(listOf("name", name.trim()))
+                    editTags.add(listOf(if (isPrivate) "private" else "public"))
+                    editTags.add(listOf(if (isClosed) "closed" else "open"))
+                    editTags.add(listOf(if (isRestricted) "restricted" else "unrestricted"))
+                    editTags.add(listOf(if (isHidden) "hidden" else "visible"))
+                    val editEvent = s.signEvent(
+                        kind = Nip29.KIND_EDIT_METADATA,
+                        content = "",
+                        tags = editTags
+                    )
+                    Log.d("GroupListVM", "[createGroup] publishing 9002 group=$groupId " +
+                        "private=$isPrivate closed=$isClosed restricted=$isRestricted hidden=$isHidden")
+                    pool.sendToRelayOrEphemeral(relayUrl, ClientMessage.event(editEvent), skipBadCheck = true)
+                } catch (e: Exception) {
+                    Log.w("GroupListVM", "[createGroup] 9002 sign/publish failed: ${e.message}")
+                }
             }
         }
     }
@@ -378,12 +514,69 @@ class GroupListViewModel(app: Application) : AndroidViewModel(app) {
                     picture = picture.trim().ifEmpty { existing?.picture },
                     about = about.trim().ifEmpty { existing?.about },
                     isPrivate = existing?.isPrivate ?: false,
-                    isClosed = existing?.isClosed ?: false
+                    isClosed = existing?.isClosed ?: false,
+                    isRestricted = existing?.isRestricted ?: false,
+                    isHidden = existing?.isHidden ?: false
                 ))
                 // Persist updated name locally
                 if (name.isNotBlank()) {
                     repo.addGroup(relayUrl, groupId, localName = name.trim())
                 }
+            } catch (_: Exception) { }
+        }
+    }
+
+    /**
+     * Admin action: generate a new invite code and publish it via kind 9009. Returns the code
+     * immediately so the caller can display / copy it; the relay publish happens asynchronously.
+     */
+    fun createInvite(relayUrl: String, groupId: String, signer: NostrSigner?): String? {
+        val pool = relayPool ?: return null
+        signer ?: return null
+        val code = Nip29.generateInviteCode()
+        viewModelScope.launch(Dispatchers.Default) {
+            try {
+                val event = signer.signEvent(
+                    kind = Nip29.KIND_CREATE_INVITE,
+                    content = "",
+                    tags = listOf(listOf("h", groupId), listOf("code", code))
+                )
+                pool.sendToRelayOrEphemeral(relayUrl, ClientMessage.event(event), skipBadCheck = true)
+            } catch (_: Exception) { }
+        }
+        return code
+    }
+
+    /** Admin action: assign one or more roles to a user (kind 9000). */
+    fun putUser(
+        relayUrl: String,
+        groupId: String,
+        targetPubkey: String,
+        roles: List<String>,
+        signer: NostrSigner?
+    ) {
+        val pool = relayPool ?: return
+        val repo = groupRepo ?: return
+        signer ?: return
+        val cleanedRoles = roles.map { it.trim() }.filter { it.isNotEmpty() }
+        // Optimistic local promotion — if any role was assigned, reflect the user in the
+        // admins list immediately so the UI updates without waiting for a 39001 replay.
+        if (cleanedRoles.isNotEmpty()) {
+            repo.getRoom(relayUrl, groupId)?.let { room ->
+                if (targetPubkey !in room.admins) {
+                    repo.updateAdmins(relayUrl, groupId, room.admins + targetPubkey)
+                }
+            }
+        }
+        viewModelScope.launch(Dispatchers.Default) {
+            try {
+                val pTag = mutableListOf("p", targetPubkey).apply { addAll(cleanedRoles) }
+                val event = signer.signEvent(
+                    kind = Nip29.KIND_PUT_USER,
+                    content = "",
+                    tags = listOf(listOf("h", groupId), pTag)
+                )
+                pool.sendToRelayOrEphemeral(relayUrl, ClientMessage.event(event), skipBadCheck = true)
             } catch (_: Exception) { }
         }
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/GroupRoomViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/GroupRoomViewModel.kt
@@ -86,6 +86,15 @@ class GroupRoomViewModel(app: Application) : AndroidViewModel(app) {
                 }
             }
         }
+
+        // Clear a stale "auth-required" (or any) error as soon as NIP-42 AUTH completes
+        // for our relay. GroupListViewModel re-fires the subs in parallel, so messages
+        // should start flowing again; this just keeps the banner from lingering.
+        viewModelScope.launch {
+            pool.authCompleted.collect { url ->
+                if (url == relayUrl) _relayError.value = null
+            }
+        }
     }
 
     fun updateText(text: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -749,6 +749,8 @@
     <string name="title_join_chat_room">Join Chat Room</string>
     <string name="title_create_group">Create Chat Room</string>
     <string name="error_invalid_invite_link">Invalid invite link</string>
+    <string name="title_join_rejected">Couldn\'t join chat room</string>
+    <string name="msg_join_rejected_body">The relay rejected your join request. This room may be invite-only — ask an admin for an invite link with a code.</string>
     <string name="label_relay_url">Relay URL</string>
     <string name="label_group_id">Room ID</string>
     <string name="label_group_name">Room Name</string>
@@ -788,6 +790,36 @@
     <string name="label_notifications">Notifications</string>
     <string name="label_notifications_on">On — new messages will be tracked</string>
     <string name="label_notifications_off">Off — tap to enable</string>
+
+    <!-- NIP-29 group configuration flags -->
+    <string name="group_flag_private_label">Private</string>
+    <string name="group_flag_private_desc">Only members can read messages</string>
+    <string name="group_flag_closed_label">Closed</string>
+    <string name="group_flag_closed_desc">Only invited users can join</string>
+    <string name="group_flag_restricted_label">Restricted</string>
+    <string name="group_flag_restricted_desc">Only members can post</string>
+    <string name="group_flag_hidden_label">Hidden</string>
+    <string name="group_flag_hidden_desc">Group info is hidden from non-members</string>
+    <string name="group_flag_public_label">Public</string>
+    <string name="group_flag_public_desc">Anyone can read messages</string>
+    <string name="group_flag_open_label">Open</string>
+    <string name="group_flag_open_desc">Anyone can join</string>
+    <string name="group_flag_unrestricted_label">Unrestricted</string>
+    <string name="group_flag_unrestricted_desc">Anyone can post</string>
+    <string name="group_flag_visible_label">Visible</string>
+    <string name="group_flag_visible_desc">Group info can be found by anyone</string>
+
+    <!-- NIP-29 invites + roles -->
+    <string name="section_room_access">Access &amp; visibility</string>
+    <string name="section_invite_codes">Invite codes</string>
+    <string name="action_generate_invite">Generate invite code</string>
+    <string name="label_latest_invite_code">Latest invite code</string>
+    <string name="action_copy_code">Copy code</string>
+    <string name="action_copy_invite_link">Copy invite link</string>
+    <string name="title_assign_role">Assign role</string>
+    <string name="label_roles">Roles (comma-separated)</string>
+    <string name="msg_assign_role">Set roles for %s. Leave empty to revoke admin status.</string>
+    <string name="cd_assign_role">Assign role</string>
 
     <!-- Fiat mode -->
     <string name="drawer_fiat_mode">Fiat Mode</string>


### PR DESCRIPTION
## Summary

Expands NIP-29 group support beyond the previous open/unrestricted-only creation path:

- **Create dialog** exposes the four NIP-29 config flags (private, closed, restricted, hidden) as plain-English toggles. A follow-up `kind:9002` is only fired when the user actually customizes posture, with a 1.5s delay after `9007` so the relay has time to mark us admin before accepting edit-metadata.
- **Group Detail** gains an "Access & visibility" section with icon + label + description rows for all four dimensions, plus a header badge chip — every room now carries a clear posture indicator (defaults to "Public" when fully open).
- **Admin-only invite codes**: generate `kind:9009` events, display + copy the code and full invite link. Join dialog parses `relay'groupId?code=…` and plumbs the code through `kind:9021`.
- **Per-member "Assign role"** action sends `kind:9000` with free-form role tags; admin parsing preserves role strings without breaking existing call sites.
- **Join flow waits for OK**: instead of optimistically adding a room the relay will silently reject, we wait up to 10s for the relay's OK response. Rejections surface in a clear dialog ("Couldn't join chat room — relay said: …") instead of a broken chat screen. Accepts / `duplicate:` responses commit locally as before.
- **Group relay AUTH prompts**: joined chat relays are added to the tier-2 AUTH pool, so challenges prompt the user (and remember the approval) instead of being silently discarded. On `authCompleted` we re-fire the group REQs and clear stale "auth-required" banners.
- **Default group relay** switched from `groups.0xchat.com` to `chat.wisp.talk`.
- **Diagnostic logging**: raw `39000`/`39001`/`39002` JSON is logged on arrival so relay-side state can be inspected from logcat without additional tooling.

## Known issue (server-side, not blocking)

`chat.wisp.talk` is omitting non-admin pubkeys from `kind:39002` on closed groups — confirmed by inspecting raw events (both closed groups in my test account's `39002` contained only the admin, even though several users had joined via invite code). This is relay-side behavior, not a client bug; to be fixed on the relay separately.

## Test plan

- [ ] Create an open group — single `9007` fires, no flag tags published, relay defaults apply
- [ ] Create a group with one or more flags on — `9007` + delayed `9002` fires with both the positive tag and the three inverse tags; verify from `GroupListVM` logs
- [ ] Open a closed group you're not yet a member of, paste an invite link — 9021 sent with `code` tag, access granted
- [ ] Open a closed group with no code — rejection dialog appears, room is not added locally
- [ ] Open any private / hidden group for the first time — AUTH prompt appears; after Allow, the banner clears and messages/members load
- [ ] Generate an invite code from Group Detail — `kind:9009` published, both "Copy code" and "Copy invite link" populate the clipboard correctly
- [ ] Assign admin role to a member — `kind:9000` with the p-tag + role string, local admins list updates immediately
- [ ] Posture chips + Access section correctly reflect all four flag states (including fully-open "Public" default)