### PR TITLE
docs: rewrite README for v1.0.0 feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wisp
 
-A minimal, performant Android client for the [Nostr](https://nostr.com) protocol. Built with Kotlin and Jetpack Compose, Wisp prioritizes decentralization, intelligent relay routing, and a clean native experience.
+A minimal, performant Android client for the [Nostr](https://nostr.com) protocol. Built with Kotlin and Jetpack Compose (Material 3), Wisp prioritizes decentralization, intelligent relay routing, strong privacy, and a clean native experience.
 
-> **Status:** Early alpha (v0.1.0) — actively developed, expect breaking changes.
+> **Status:** v1.0.0 — stable, actively developed.
 
 ---
 
@@ -10,22 +10,21 @@ A minimal, performant Android client for the [Nostr](https://nostr.com) protocol
 
 - [Why Wisp](#why-wisp)
 - [Key Features](#key-features)
-- [Screenshots](#screenshots)
 - [Architecture](#architecture)
 - [Supported NIPs](#supported-nips)
 - [Getting Started](#getting-started)
 - [Building from Source](#building-from-source)
 - [Contributing](#contributing)
-- [Roadmap](#roadmap)
+- [Tech Stack](#tech-stack)
 - [License](#license)
 
 ---
 
 ## Why Wisp
 
-Most Nostr clients treat relays as interchangeable dumb pipes. Wisp takes a different approach — it implements the outbox/inbox relay model from day one, routing messages intelligently based on where users actually publish and read. The result is faster event delivery, less wasted bandwidth, and a client that actively promotes the decentralized architecture Nostr was designed for.
+Most Nostr clients treat relays as interchangeable dumb pipes and lean on a small handful of "mega-relays." Wisp takes a different approach — it implements the full outbox/inbox relay model with reliability scoring, routes messages based on where users actually publish and read, and is built so that decentralization is the default path, not an opt-in.
 
-Wisp is built to be fast, lightweight, and respectful of both your device and the relay network.
+The result is faster event delivery, less wasted bandwidth, and a client that actively reinforces the architecture Nostr was designed for. Wisp is built to be fast, lightweight, and respectful of both your device and the relay network.
 
 ---
 
@@ -33,92 +32,106 @@ Wisp is built to be fast, lightweight, and respectful of both your device and th
 
 ### Intelligent Outbox/Inbox Relay Routing
 
-Wisp implements a full outbox/inbox model with relay scoring:
+Wisp implements a full NIP-65 outbox/inbox model with relay scoring:
 
-- **Outbox reads**: Fetches a user's posts from their *write relays* (where they actually publish), not from a hardcoded list
-- **Inbox writes**: Delivers replies and reactions to a user's *read relays* (where they actually look), ensuring they see your interactions
-- **Relay scoring**: Tracks relay reliability and author coverage to optimize which relays to query, minimizing redundant connections
-- **Smart relay hints**: When tagging events, selects relay hints that overlap between your outbox and the target's inbox for optimal discoverability
-- **Ephemeral connections**: Dynamically opens short-lived relay connections as needed (up to 30) with automatic cleanup after 5 minutes of inactivity
-- **Fallback strategies**: Gracefully degrades to broadcast mode for users without published relay lists
+- **Outbox reads** — fetches a user's posts from their *write relays* (where they actually publish), not from a hardcoded list
+- **Inbox writes** — delivers replies, reactions, and mentions to the recipient's *read relays* so they actually see them
+- **Relay scoring** — `RelayScoreBoard` tracks reliability and author coverage per relay to pick the smallest useful set for each query
+- **Smart relay hints** — when tagging events, chooses hints that overlap the author's outbox with the target's inbox for best discoverability
+- **Persistent + ephemeral pool** — `RelayPool` maintains up to 30 persistent connections plus up to 50 short-lived ephemeral ones, with idle cleanup and per-relay cooldowns after failures
+- **NIP-42 authentication** — signs AUTH challenges only for relays the user has explicitly approved, with persisted approvals, and waits for AUTH before sending sensitive publishes (DMs, group events)
+- **NIP-11 relay info** — fetches and respects relay metadata, capabilities, and limitations
+- **Tor support** — route relay traffic through an embedded Tor client for enhanced privacy
 
-### Performance First
+### Privacy & Private Messaging
 
-- **LRU caching** across events (5,000), profiles, reactions, reposts, and zaps — data is fetched once and reused
-- **Off-main-thread processing**: All event parsing and relay communication runs on background dispatchers
-- **Debounced UI updates**: Feed emissions are coalesced to one per 16ms frame, preventing excessive recompositions from rapid relay events
-- **Deduplication**: Atomic check-then-put prevents the same event from being processed twice across multiple relays
-- **Lazy profile loading**: Metadata is fetched asynchronously in batches with periodic sweep cycles
-- **Relay cooldowns**: Failed relays get a 5-minute cooldown before retry, preventing connection storms
+- **NIP-17 gift-wrap DMs** — three-layer privacy model (rumor → seal → gift wrap) with timestamp randomization
+- **NIP-44 modern encryption** — ECDH + HKDF + XChaCha20 + HMAC-SHA256, with aggressive conversation-key caching (ECDH is expensive; cache it per peer)
+- **NIP-04 fallback** — legacy encrypted DMs still read for backward compatibility
+- **Dedicated DM relays** — publish DMs to a separate relay set (NIP-51 kind 10050) from your public posts
+- **Encrypted media** — optional encrypted image attachments in DMs
+- **Optional Amber / NIP-55 remote signer** — keep your `nsec` in a dedicated signer app and never hand it to Wisp at all
 
-### Promotes Decentralization from the Start
+### Lightning & Zaps
 
-- No hardcoded "mega-relay" dependency — default relays are starting points, not requirements
-- First-class NIP-65 relay list support encourages users to publish their own relay preferences
-- Outbox model means the client respects *where users choose to publish*, not where the client developer decided to look
-- Blocked relay support (NIP-51 kind 10006) lets users opt out of specific relays entirely
-- DM relay sets (NIP-51 kind 10050) allow separate relay infrastructure for private messaging
-- Blossom media uploads distribute content across decentralized media servers instead of centralized CDNs
+A built-in non-custodial Lightning wallet powered by [Breez SDK (Spark)](https://github.com/breez/breez-sdk-spark), plus NWC as an alternative:
 
-### Lightning Wallet
+- **Embedded Spark wallet** — self-custodial Lightning node that runs on-device
+- **12-word seed backup** — standard BIP-39 mnemonic recovery
+- **Encrypted relay backup** — wallet credentials encrypted to your own pubkey (NIP-44) and published as a NIP-78 app-data event (kind 30078) so you can restore from any session; format-compatible with other Spark wallets
+- **NWC (NIP-47)** — connect any `nostr+walletconnect://` compatible wallet as an alternative
+- **Lightning address** — configure a reusable LN address for receiving
+- **Transaction history** — paginated, with counterparty resolution from zap receipts
+- **Zaps** — send (NIP-57), display zap receipts on the feed, and vote in **zap polls** (NIP-69)
+- **QR scanning** — scan or import to pay invoices
 
-Wisp includes a built-in non-custodial Lightning wallet powered by [Breez SDK (Spark)](https://github.com/niclas9/breez-sdk-spark), with NWC as an alternative:
+### Safety & Content Filtering
 
-- **Embedded Spark wallet**: Self-custodial Lightning node that runs on-device — no external wallet app needed
-- **Seed phrase backup**: 12-word mnemonic for wallet recovery on any device
-- **Encrypted relay backup**: Back up wallet credentials to your Nostr relays, encrypted with your private key, and restore from any session
-- **NWC support**: Alternatively connect any [NIP-47](https://github.com/nostr-protocol/nips/blob/master/47.md) compatible wallet via `nostr+walletconnect://` URI
-- **Lightning address**: Set up and share a reusable Lightning address for receiving payments
-- **Transaction history**: Paginated transaction list with counterparty resolution from zap receipts
-- **QR code scanning**: Scan or import QR codes to pay Lightning invoices
-- **Zaps**: Send Lightning zaps to posts with optional messages, with zap receipt tracking on the feed
-
-### Blossom Media Support
-
-- Upload images and media to decentralized [Blossom](https://github.com/hzrd149/blossom) servers
-- Manage your server list (kind 10063) with per-account isolation
-- Nostr event-based authentication for uploads (kind 24242)
-- Multi-server fallback — tries each configured server until one succeeds
-- Automatic EXIF stripping where supported by the server
-
-### Private Messaging
-
-- **NIP-17 gift wrap encryption**: Three-layer privacy model (rumor → seal → gift wrap) with timestamp randomization
-- **NIP-44 modern encryption**: ECDH + HKDF + XChaCha20 + HMAC-SHA256, replacing legacy NIP-04
-- **Conversation key caching**: Expensive ECDH computations are cached per peer
-- **Separate DM relays**: Publish DMs to dedicated relay sets for better privacy
-
-### Safety Controls
-
-- Mute lists (NIP-51 kind 10000) for blocking pubkeys
-- Keyword muting for content filtering
-- Relay blocking to opt out of specific relays
+- **nspam ML classifier** — on-device LightGBM spam model with MurmurHash3 feature hashing; filters out low-quality content without sending anything off-device
+- **Social graph filtering** — optional "follows + follows-of-follows" scope built from an on-device social graph database
+- **Mute lists** (NIP-51 kind 10000) for blocking pubkeys, synced via Nostr
+- **Keyword muting** for content filtering
+- **Blocked relays** (NIP-51 kind 10006) to opt out of specific relays entirely
 - All safety lists sync across clients via published Nostr events
+
+### Rich Content Types
+
+- **Notes & long-form articles** — NIP-01 short notes and NIP-23 articles (kind 30023), with full reader view
+- **Picture posts** (NIP-68, kind 20) and **video posts** (NIP-71, kinds 21/22) with imeta parsing, blurhash, thumbnails, and fallback mirrors
+- **Live streams** (NIP-53, kind 30311) — watch and chat on live activities
+- **Polls** (NIP-88, kinds 1068/1018) — create and vote on single- or multiple-choice polls
+- **Reposts** (NIP-18) with tracking
+- **Emoji reactions** (NIP-25) with **custom emoji packs** (NIP-30)
+- **Reply threading** (NIP-10) with root resolution and marked e-tags
+- **Drafts** (NIP-37, kind 31234) — save unfinished posts to your relays so they follow you across devices
+- **Proof-of-work** (NIP-13) — optional PoW mining with configurable difficulty, coroutine-cancellable
+
+### Groups & Communities
+
+- **NIP-29 relay-based groups** — join, browse, chat (kind 9), manage membership, with metadata and admin/member addressable events
+- **Group persistence** — joined groups and recent messages are cached locally (ObjectBox) so rooms open instantly
+- Group event AUTH gating — group joins, creates, and invites (9021/9007/9009) wait for NIP-42 AUTH before sending, and surface admin failures
+
+### Media & Storage
+
+- **Blossom** — upload images and media to decentralized [Blossom](https://github.com/hzrd149/blossom) servers
+- Per-account Blossom server list (kind 10063)
+- Nostr-event-based upload auth (kind 24242)
+- Multi-server fallback — tries each configured server until one succeeds
+
+### Performance
+
+- **LRU caches** across events (5,000), profiles, reactions, reposts, and zaps — data is fetched once and reused
+- **Selective on-device persistence** — ObjectBox stores only the kinds worth keeping warm (notes, articles, media posts, zap receipts, polls, reactions, reposts, profiles) for fast cold-start; everything else stays in RAM
+- **Off-main-thread processing** — event parsing, crypto, and relay I/O all run on background dispatchers
+- **Frame-debounced UI updates** — feed emissions are coalesced to one per ~16 ms frame, preventing recomposition storms from bursty relay traffic
+- **Atomic dedup** — check-then-put guards so the same event never gets processed twice across relays
+- **Lazy metadata fetching** — profiles are batched and swept periodically rather than fetched per-event
+- **Relay cooldowns** — failed relays get a 5-minute cooldown before retry, preventing connection storms
+- **Cancellable PoW mining** — honors coroutine cancellation so cancelled mines release the CPU immediately
+
+### Identity, Keys & Accounts
+
+- **Multiple accounts** with per-account encrypted storage
+- **EncryptedSharedPreferences** (AES256-GCM) for private keys — `nsec` never touches plain SharedPreferences
+- **Biometric authentication** for key access
+- **NIP-55 remote signing** — delegate all signing/encryption to Amber (or another signer app) via Android intents, so Wisp never holds the key
+- **NIP-19 bech32** — npub, nsec, note, nevent, nprofile encode/decode, with `nostr:` URI rendering in post content
+- **NIP-05 DNS verification** with result caching
+- **QR code display** for sharing keys and profiles
 
 ### Additional Features
 
-- **Thread view** with NIP-10 reply threading and root resolution
-- **Notifications** aggregating mentions, reactions, and zaps
-- **Search** for profiles and content
-- **Bookmarks and pins** (NIP-51)
-- **Custom follow sets** (NIP-51 kind 30000) as alternative feed sources
-- **Reposts** with tracking and display
-- **Emoji reactions** (NIP-25) with custom emoji picker
-- **NIP-05 DNS verification** with caching
-- **NIP-19 bech32 encoding** — npub, nsec, note, nevent, nprofile support
-- **Nostr URI rendering** in post content (nostr:npub..., nostr:note...)
-- **QR code display** for sharing keys and profiles
-- **Multiple account support** with per-account encrypted storage
-- **Biometric authentication** for key access
-- **Relay console** for debugging relay communication
+- **Thread view** with full NIP-10 root/reply resolution
+- **Notifications** aggregating mentions, reactions, zaps, and reposts
+- **Hashtag feeds** and hashtag following
+- **Search** for profiles, content, and hashtags
+- **Bookmarks** and **pins** (NIP-51), plus custom **follow sets** (kind 30000) as alternative feed sources
+- **Relay console and health view** for debugging relay communication
 - **Profile editing** with metadata publishing
-- **Onboarding flow** with follow suggestions for new users
-
----
-
-## Screenshots
-
-*Coming soon*
+- **Onboarding flow** — key creation, topic/interest selection, and follow suggestions for new users
+- **Translation** of foreign-language posts
+- **Fiat conversion** of sats for zaps and balances
 
 ---
 
@@ -127,66 +140,57 @@ Wisp includes a built-in non-custodial Lightning wallet powered by [Breez SDK (S
 Wisp follows an MVVM architecture with clear layer separation:
 
 ```
-┌─────────────────────────────────────────────┐
-│                   UI Layer                   │
-│         Jetpack Compose Screens              │
-│    (FeedScreen, ThreadScreen, DmScreen...)   │
-├─────────────────────────────────────────────┤
-│               ViewModel Layer                │
-│   FeedViewModel, ThreadViewModel,            │
-│   DmConversationViewModel, WalletViewModel   │
-├─────────────────────────────────────────────┤
-│              Repository Layer                │
-│  EventRepo, ContactRepo, DmRepo, NwcRepo,   │
-│  RelayListRepo, BlossomRepo, MuteRepo...     │
-├─────────────────────────────────────────────┤
-│              Protocol Layer                  │
-│   Nip01, Nip02, Nip10, Nip17, Nip19,        │
-│   Nip25, Nip44, Nip47, Nip51, Nip57, Nip65  │
-├─────────────────────────────────────────────┤
-│               Relay Layer                    │
-│   RelayPool, OutboxRouter, RelayScoreBoard,  │
-│   SubscriptionManager, Relay (WebSocket)     │
-└─────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│                      UI Layer                         │
+│              Jetpack Compose Screens                  │
+│   FeedScreen, ThreadScreen, DmScreen, GroupRoom,      │
+│   LiveStream, Article, Wallet, Notifications, ...     │
+├──────────────────────────────────────────────────────┤
+│                   ViewModel Layer                     │
+│  FeedVM, ThreadVM, DmConversationVM, WalletVM,        │
+│  GroupRoomVM, LiveStreamVM, SocialGraphVM, ...        │
+├──────────────────────────────────────────────────────┤
+│                   Repository Layer                    │
+│   EventRepo, ContactRepo, DmRepo, NwcRepo, Spark,     │
+│   RelayListRepo, BlossomRepo, MuteRepo, GroupRepo,    │
+│   MetadataFetcher, SocialGraphDb, SpamAuthorCache...  │
+├──────────────────────────────────────────────────────┤
+│                    Protocol Layer                     │
+│   Nip01 Nip02 Nip04 Nip05 Nip09 Nip10 Nip11 Nip13     │
+│   Nip17 Nip18 Nip19 Nip25 Nip29 Nip30 Nip37 Nip42     │
+│   Nip44 Nip47 Nip51 Nip53 Nip57 Nip65 Nip68 Nip69     │
+│   Nip71 Nip78 Nip88 + Blossom, Bolt11, NostrSigner    │
+├──────────────────────────────────────────────────────┤
+│                     Relay Layer                       │
+│   RelayPool, OutboxRouter, RelayScoreBoard,           │
+│   SubscriptionManager, RelayHealthTracker,            │
+│   TorManager, Relay (OkHttp WebSocket)                │
+└──────────────────────────────────────────────────────┘
 ```
 
 ### Key Design Decisions
 
-- **No database**: All state is held in-memory (LRU caches) or in SharedPreferences/EncryptedSharedPreferences. This keeps the app simple and fast — events are fetched from relays on each session, as Nostr intended.
-- **NIP objects**: Each NIP is implemented as a Kotlin `object` with static helper functions (e.g., `Nip17.createGiftWrap()`), making the protocol layer modular and testable.
-- **Flow-based reactivity**: SharedFlow for relay events, StateFlow for UI state. No RxJava, no LiveData — pure coroutines.
-- **Encrypted key storage**: Private keys never touch plain SharedPreferences. AES256-GCM via Android's EncryptedSharedPreferences.
+- **Mostly in-memory, selectively persistent** — the bulk of state lives in LRU caches; ObjectBox persists a narrow set of kinds (notes, articles, media posts, reactions, reposts, zap receipts, polls, profiles) plus joined groups, so cold starts are fast without the complexity of a full event store. Preferences live in SharedPreferences; private keys live in EncryptedSharedPreferences.
+- **NIP objects** — each NIP is implemented as a Kotlin `object` with pure helper functions (e.g., `Nip17.createGiftWrap()`, `Nip44.encrypt()`), making the protocol layer modular and easy to test.
+- **Flow-based reactivity** — SharedFlow for relay events, StateFlow for UI state. No RxJava, no LiveData — pure coroutines.
+- **Signer abstraction** — `NostrSigner` is an interface. `LocalSigner` holds the key; `RemoteSigner` delegates every sign/encrypt/decrypt to an external NIP-55 app. UI code never sees the difference.
+- **Off-main-thread crypto** — all signing, NIP-44 encryption, and PoW mining run on `Dispatchers.Default` with proper cancellation support.
+- **Encrypted key storage** — private keys use AES256-GCM via Android's Security Crypto library, never plain SharedPreferences.
 
 ### Project Structure
 
 ```
 app/src/main/kotlin/com/wisp/app/
 ├── nostr/          # Protocol implementations (NipXX.kt objects)
-│   ├── Event.kt        # Core event structure, signing, serialization
-│   ├── Filter.kt       # Subscription filters
-│   ├── Keys.kt         # Key generation and conversion
-│   ├── Nip02.kt        # Follow list management
-│   ├── Nip10.kt        # Reply threading
-│   ├── Nip17.kt        # Gift wrap DMs
-│   ├── Nip19.kt        # Bech32 encoding
-│   ├── Nip25.kt        # Reactions
-│   ├── Nip44.kt        # Modern encryption
-│   ├── Nip47.kt        # Wallet Connect
-│   ├── Nip51.kt        # Lists (mute, bookmark, pin, follow sets)
-│   ├── Nip57.kt        # Zaps
-│   └── Nip65.kt        # Relay list metadata
-├── relay/          # Relay connection and routing
-│   ├── Relay.kt            # WebSocket connection per relay
-│   ├── RelayPool.kt        # Connection pool (persistent + ephemeral)
-│   ├── OutboxRouter.kt     # Outbox/inbox routing logic
-│   ├── RelayScoreBoard.kt  # Relay quality scoring
-│   └── SubscriptionManager.kt  # Subscription lifecycle
-├── repo/           # Data repositories and persistence
-├── viewmodel/      # Screen ViewModels
-├── ui/             # Jetpack Compose screens and components
-│   ├── screen/         # Full screens (Feed, Thread, DM, etc.)
+├── relay/          # WebSocket relay, pool, outbox router, scoring, Tor
+├── repo/           # Data repositories, caches, and persistence wrappers
+├── db/             # ObjectBox entities (EventEntity, GroupMessageEntity...)
+├── ml/             # On-device nspam LightGBM classifier
+├── viewmodel/      # Screen ViewModels and coordinators
+├── ui/
+│   ├── screen/         # Full screens (Feed, Thread, DM, Group, Wallet...)
 │   └── component/      # Reusable UI components
-└── db/             # Database layer
+└── util/           # Shared utilities
 ```
 
 ---
@@ -195,22 +199,37 @@ app/src/main/kotlin/com/wisp/app/
 
 | NIP | Description | Status |
 |-----|-------------|--------|
-| [01](https://github.com/nostr-protocol/nips/blob/master/01.md) | Basic protocol flow | Implemented |
-| [02](https://github.com/nostr-protocol/nips/blob/master/02.md) | Follow lists | Implemented |
-| [04](https://github.com/nostr-protocol/nips/blob/master/04.md) | Encrypted DMs (legacy) | Implemented (fallback) |
-| [05](https://github.com/nostr-protocol/nips/blob/master/05.md) | DNS-based verification | Implemented |
-| [09](https://github.com/nostr-protocol/nips/blob/master/09.md) | Event deletion | Implemented |
-| [10](https://github.com/nostr-protocol/nips/blob/master/10.md) | Reply threading | Implemented |
-| [11](https://github.com/nostr-protocol/nips/blob/master/11.md) | Relay information | Implemented |
-| [17](https://github.com/nostr-protocol/nips/blob/master/17.md) | Private DMs (gift wrap) | Implemented |
-| [18](https://github.com/nostr-protocol/nips/blob/master/18.md) | Reposts | Implemented |
-| [19](https://github.com/nostr-protocol/nips/blob/master/19.md) | Bech32 encoding | Implemented |
-| [25](https://github.com/nostr-protocol/nips/blob/master/25.md) | Reactions | Implemented |
-| [44](https://github.com/nostr-protocol/nips/blob/master/44.md) | Versioned encryption | Implemented |
-| [47](https://github.com/nostr-protocol/nips/blob/master/47.md) | Wallet Connect (NWC) | Implemented |
-| [51](https://github.com/nostr-protocol/nips/blob/master/51.md) | Lists | Implemented |
-| [57](https://github.com/nostr-protocol/nips/blob/master/57.md) | Lightning zaps | Implemented |
-| [65](https://github.com/nostr-protocol/nips/blob/master/65.md) | Relay list metadata | Implemented |
+| [01](https://github.com/nostr-protocol/nips/blob/master/01.md) | Basic protocol flow | ✅ |
+| [02](https://github.com/nostr-protocol/nips/blob/master/02.md) | Follow lists | ✅ |
+| [04](https://github.com/nostr-protocol/nips/blob/master/04.md) | Encrypted DMs (legacy) | ✅ (fallback) |
+| [05](https://github.com/nostr-protocol/nips/blob/master/05.md) | DNS-based verification | ✅ |
+| [09](https://github.com/nostr-protocol/nips/blob/master/09.md) | Event deletion | ✅ |
+| [10](https://github.com/nostr-protocol/nips/blob/master/10.md) | Reply threading | ✅ |
+| [11](https://github.com/nostr-protocol/nips/blob/master/11.md) | Relay information | ✅ |
+| [13](https://github.com/nostr-protocol/nips/blob/master/13.md) | Proof of Work | ✅ |
+| [17](https://github.com/nostr-protocol/nips/blob/master/17.md) | Private DMs (gift wrap) | ✅ |
+| [18](https://github.com/nostr-protocol/nips/blob/master/18.md) | Reposts | ✅ |
+| [19](https://github.com/nostr-protocol/nips/blob/master/19.md) | Bech32 encoding | ✅ |
+| [23](https://github.com/nostr-protocol/nips/blob/master/23.md) | Long-form articles | ✅ |
+| [25](https://github.com/nostr-protocol/nips/blob/master/25.md) | Reactions | ✅ |
+| [29](https://github.com/nostr-protocol/nips/blob/master/29.md) | Relay-based groups | ✅ |
+| [30](https://github.com/nostr-protocol/nips/blob/master/30.md) | Custom emoji | ✅ |
+| [37](https://github.com/nostr-protocol/nips/blob/master/37.md) | Draft events | ✅ |
+| [42](https://github.com/nostr-protocol/nips/blob/master/42.md) | Relay AUTH | ✅ |
+| [44](https://github.com/nostr-protocol/nips/blob/master/44.md) | Versioned encryption | ✅ |
+| [47](https://github.com/nostr-protocol/nips/blob/master/47.md) | Wallet Connect (NWC) | ✅ |
+| [51](https://github.com/nostr-protocol/nips/blob/master/51.md) | Lists (mute, bookmark, pin, follow sets, relay sets) | ✅ |
+| [53](https://github.com/nostr-protocol/nips/blob/master/53.md) | Live activities | ✅ |
+| [55](https://github.com/nostr-protocol/nips/blob/master/55.md) | Android signer (Amber) | ✅ |
+| [57](https://github.com/nostr-protocol/nips/blob/master/57.md) | Lightning zaps | ✅ |
+| [65](https://github.com/nostr-protocol/nips/blob/master/65.md) | Relay list metadata | ✅ |
+| [68](https://github.com/nostr-protocol/nips/blob/master/68.md) | Picture-first posts | ✅ |
+| 69 | Zap polls (kind 6969) | ✅ |
+| [71](https://github.com/nostr-protocol/nips/blob/master/71.md) | Video posts | ✅ |
+| [78](https://github.com/nostr-protocol/nips/blob/master/78.md) | App-specific data (wallet backup) | ✅ |
+| [88](https://github.com/nostr-protocol/nips/blob/master/88.md) | Polls | ✅ |
+
+Also: **Blossom** media servers (BUDs 01–03), **NWC** transport, and **bolt11** invoice parsing.
 
 ---
 
@@ -219,18 +238,19 @@ app/src/main/kotlin/com/wisp/app/
 ### Requirements
 
 - Android 8.0 (API 26) or higher
-- A Nostr keypair (you can generate one in-app or import an existing nsec)
+- A Nostr keypair (generate one in-app, import an existing `nsec`, or pair Amber for NIP-55 remote signing)
 
 ### Installation
 
-APK downloads will be available on the [Releases](../../releases) page once published.
+APK downloads are available on the [Releases](../../releases) page.
 
 ### First Launch
 
-1. **Create or import a key** — Generate a fresh keypair or paste your existing `nsec`
-2. **Set up your profile** — The onboarding flow walks you through name, picture, and bio
-3. **Follow some people** — Wisp suggests popular accounts to get your feed started
-4. **Configure relays** — Your relay list is published as a NIP-65 event so other outbox-aware clients can find you
+1. **Create, import, or pair a signer** — generate a fresh keypair, paste your `nsec`, or connect Amber for remote signing
+2. **Set up your profile** — the onboarding flow walks you through name, picture, and bio
+3. **Pick some interests** — topic/interest selection seeds your first follow suggestions
+4. **Follow some people** — Wisp suggests popular accounts to get your feed started
+5. **Configure relays** — your relay list is published as a NIP-65 event so other outbox-aware clients can find you
 
 ---
 
@@ -252,41 +272,37 @@ cd wisp
 # Build debug APK
 ./gradlew assembleDebug
 
-# Install on connected device
+# Install on a connected device
 ./gradlew installDebug
+
+# Build release APK (R8-minified)
+./gradlew assembleRelease
 ```
 
-### Run Tests
-
-```bash
-./gradlew test
-```
+Release builds use R8 minification; keep rules live in `app/proguard-rules.pro` and cover kotlinx.serialization, secp256k1 JNI, Bouncy Castle, OkHttp, Coil, Security Crypto, Media3, and ZXing.
 
 ---
 
 ## Contributing
 
-Contributions are welcome! Wisp is an open-source project and we appreciate help from the community.
+Contributions are welcome. Wisp is open source and community help makes it better.
 
 ### How to Contribute
 
 1. **Fork** the repository
-2. **Create a branch** for your feature or fix:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+2. **Create a branch** for your feature or fix (`feat/…`, `fix/…`, `refactor/…`, `docs/…`, `chore/…`, `perf/…`)
 3. **Make your changes** — follow the existing code patterns and conventions
-4. **Test** your changes on a real device or emulator
-5. **Commit** with a clear, descriptive message
-6. **Open a pull request** against `main`
+4. **Test** on a real device or emulator
+5. **Commit** with a clear, descriptive message (`<type>: <summary>`)
+6. **Open a pull request** against `main` — one concern per PR, small and focused
 
 ### Code Conventions
 
 - **Kotlin** with Jetpack Compose — no XML layouts
 - **NIP implementations** go in `NipXX.kt` as Kotlin `object` with static helper functions
-- **Events** are created via `NostrEvent.create(privkey, pubkey, kind, content, tags)`
+- **Events** are created via `NostrEvent.create(privkey, pubkey, kind, content, tags)` — or, for remote-signer accounts, through the `NostrSigner` abstraction
 - **Hex encoding** uses `ByteArray.toHex()` / `String.hexToByteArray()` extensions
-- **Coroutines** for all async work — `Dispatchers.Default` for CPU-bound, `Dispatchers.IO` for network
+- **Coroutines** for all async work — `Dispatchers.Default` for CPU-bound (crypto, PoW), `Dispatchers.IO` for network
 - **StateFlow** for UI state, **SharedFlow** for relay events
 - Keep functions small and focused. Prefer clarity over cleverness.
 
@@ -294,56 +310,19 @@ Contributions are welcome! Wisp is an open-source project and we appreciate help
 
 - UI/UX polish and accessibility improvements
 - Additional NIP implementations
-- Testing — unit tests and integration tests
+- Unit and integration tests
 - Performance profiling and optimization
 - Translations and localization
 - Documentation improvements
 
 ### Reporting Issues
 
-Found a bug or have a feature request? [Open an issue](../../issues) with:
+[Open an issue](../../issues) with:
 
 - Steps to reproduce (for bugs)
 - Expected vs actual behavior
 - Device and Android version
 - Relevant logs from the in-app relay console (if applicable)
-
----
-
-## Roadmap
-
-### Near Term
-- [ ] Local database for offline access and faster startup (Room or SQLDelight)
-- [ ] Image and video previews in the feed
-- [ ] Hashtag following and trending topics
-- [ ] Push notifications via UnifiedPush
-- [ ] Profile banner images
-- [ ] Event deletion (NIP-09) UI
-- [ ] Improved thread view with collapsible replies
-
-### Medium Term
-- [ ] NIP-42 relay authentication
-- [ ] NIP-96 file storage integration
-- [ ] Long-form content (NIP-23) reading and publishing
-- [ ] Community/group support (NIP-72)
-- [ ] Relay discovery and recommendations
-- [ ] Advanced search with relay-side filtering
-- [ ] Custom emoji packs (NIP-30)
-- [ ] Media gallery per profile
-
-### Long Term
-- [ ] Marketplace integration (NIP-15)
-- [ ] Tor/proxy support for enhanced privacy
-- [ ] Offline-first architecture with background sync
-- [ ] Widgets for Android home screen
-- [ ] Wear OS companion app
-- [ ] Full accessibility audit and WCAG compliance
-
-### Ongoing
-- [ ] Performance optimization and memory profiling
-- [ ] Expanded NIP coverage as the protocol evolves
-- [ ] UI refinements based on community feedback
-- [ ] Security audits and hardening
 
 ---
 
@@ -356,12 +335,15 @@ Found a bug or have a feature request? [Open an issue](../../issues) with:
 | Networking | OkHttp 4 (WebSocket) |
 | Image Loading | Coil 3 |
 | Serialization | kotlinx.serialization |
-| Cryptography | secp256k1-kmp (Schnorr), Bouncy Castle (XChaCha20), Android Security Crypto (AES-GCM) |
+| Persistence | ObjectBox (selective event store), EncryptedSharedPreferences, SharedPreferences |
+| Cryptography | secp256k1-kmp (Schnorr / ECDH), Bouncy Castle (XChaCha20), Android Security Crypto (AES-GCM), javax.crypto (HKDF/HMAC) |
+| ML | LightGBM (on-device nspam classifier) with MurmurHash3 feature hashing |
 | Navigation | Jetpack Navigation Compose |
-| Lightning | Breez SDK Spark |
+| Lightning | Breez SDK Spark + NWC (NIP-47) |
 | Media | Media3 / ExoPlayer |
 | QR Codes | ZXing |
-| Build | Gradle 8.7 / AGP 8.7 |
+| Privacy Network | Embedded Tor (optional) |
+| Build | Gradle 8.x / AGP 8.x |
 | Min SDK | Android 8.0 (API 26) |
 | Target SDK | Android 15 (API 35) |
 


### PR DESCRIPTION
## Summary
- Rewrite the README to reflect Wisp's current state at v1.0.0 — the previous version described the very first iteration.
- Expand the NIPs table from 16 to 27 entries (adds 09, 13, 23, 29, 30, 37, 42, 55, 53, 68, 69, 71, 78, 88).
- Document new feature areas: NIP-29 groups, rich content types (articles, picture/video posts, polls, live streams, drafts, PoW), on-device nspam ML classifier, social-graph filtering, Tor support, NIP-55 Amber remote signer, NIP-42 AUTH with user approval.
- Update architecture notes — ObjectBox now selectively persists events/groups, added `db/` and `ml/` layers, documented the `NostrSigner` abstraction.
- Refresh tech stack (ObjectBox, LightGBM, Tor) and drop the now-stale roadmap/screenshots sections.

## Test plan
- [ ] Render README on GitHub and confirm formatting (tables, code blocks, diagrams)
- [ ] Verify all NIP links resolve