### PR TITLE
feat: broadcast notes to inbox relays of mentioned pubkeys

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -320,13 +320,26 @@ class OutboxRouter(
      * Publish an event to own write relays AND the target user's read (inbox) relays.
      * Used for replies, reactions, and reposts so they reach the intended recipient.
      */
-    fun publishToInbox(eventMsg: String, targetPubkey: String): Int {
+    fun publishToInbox(eventMsg: String, targetPubkey: String): Int =
+        publishToInbox(eventMsg, listOf(targetPubkey))
+
+    /**
+     * Publish an event to own write relays AND the union of all target users' read (inbox)
+     * relays. Inbox URLs are deduplicated across targets and against our own write relays,
+     * so when multiple mentioned pubkeys share an inbox the note is only sent there once.
+     */
+    fun publishToInbox(eventMsg: String, targetPubkeys: Collection<String>): Int {
         var sentCount = relayPool.sendToWriteRelays(eventMsg)
-        val readRelays = relayListRepo.getReadRelays(targetPubkey)
-        if (readRelays != null) {
-            for (url in readRelays) {
-                if (relayPool.sendToRelayOrEphemeral(url, eventMsg)) sentCount++
-            }
+        if (targetPubkeys.isEmpty()) return sentCount
+        val ourWrite = relayPool.getWriteRelayUrls().toSet()
+        val inboxUrls = mutableSetOf<String>()
+        for (pk in targetPubkeys.toSet()) {
+            val readRelays = relayListRepo.getReadRelays(pk) ?: continue
+            inboxUrls.addAll(readRelays)
+        }
+        for (url in inboxUrls) {
+            if (url in ourWrite) continue
+            if (relayPool.sendToRelayOrEphemeral(url, eventMsg)) sentCount++
         }
         return sentCount
     }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -653,15 +653,21 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             return sentCount
         }
 
+        // Pubkeys whose inbox relays should also receive this note: the reply target plus
+        // anyone mentioned in the content. Dedup happens inside OutboxRouter.publishToInbox.
+        val inboxPubkeys = buildSet {
+            replyTo?.pubkey?.let { add(it) }
+            addAll(mentionedPubkeys)
+        }
+
         // Hand off to PowManager for background mining if PoW enabled
         if (_powEnabled.value && powManager != null) {
-            val replyPubkey = replyTo?.pubkey
             powManager.submitNote(
                 signer = signer,
                 content = finalContent,
                 tags = tags,
                 kind = eventKind,
-                replyToPubkey = replyPubkey,
+                inboxPubkeys = inboxPubkeys,
                 onPublished = {
                     if (replyTo != null) {
                         eventRepo?.addReplyCount(replyTo.id, "pow-pending")
@@ -684,8 +690,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         val event = signer.signEvent(kind = eventKind, content = finalContent, tags = tags)
         android.util.Log.d("GALLERY", "[ComposeVM] publishNote kind=$eventKind id=${event.id.take(12)} content='${finalContent.take(50)}' tags=${tags.size} galleryMode=${_galleryMode.value} uploadedUrls=${_uploadedUrls.value.size}")
         val msg = ClientMessage.event(event)
-        var sentCount = if (replyTo != null && outboxRouter != null) {
-            outboxRouter.publishToInbox(msg, replyTo.pubkey)
+        var sentCount = if (outboxRouter != null && inboxPubkeys.isNotEmpty()) {
+            outboxRouter.publishToInbox(msg, inboxPubkeys)
         } else {
             relayPool.sendToWriteRelays(msg)
         }
@@ -693,8 +699,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         if (sentCount == 0) {
             val reconnected = relayPool.ensureWriteRelaysConnected()
             if (reconnected > 0) {
-                sentCount = if (replyTo != null && outboxRouter != null) {
-                    outboxRouter.publishToInbox(msg, replyTo.pubkey)
+                sentCount = if (outboxRouter != null && inboxPubkeys.isNotEmpty()) {
+                    outboxRouter.publishToInbox(msg, inboxPubkeys)
                 } else {
                     relayPool.sendToWriteRelays(msg)
                 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/PowManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/PowManager.kt
@@ -44,6 +44,7 @@ class PowManager(
         tags: List<List<String>>,
         kind: Int = 1,
         replyToPubkey: String? = null,
+        inboxPubkeys: Collection<String> = replyToPubkey?.let { listOf(it) } ?: emptyList(),
         onPublished: (() -> Unit)? = null
     ) {
         miningJob?.cancel()
@@ -76,8 +77,8 @@ class PowManager(
                 )
 
                 val msg = ClientMessage.event(event)
-                var sentCount = if (replyToPubkey != null) {
-                    outboxRouter.publishToInbox(msg, replyToPubkey)
+                var sentCount = if (inboxPubkeys.isNotEmpty()) {
+                    outboxRouter.publishToInbox(msg, inboxPubkeys)
                 } else {
                     relayPool.sendToWriteRelays(msg)
                 }
@@ -85,8 +86,8 @@ class PowManager(
                 if (sentCount == 0) {
                     val reconnected = relayPool.ensureWriteRelaysConnected()
                     if (reconnected > 0) {
-                        sentCount = if (replyToPubkey != null) {
-                            outboxRouter.publishToInbox(msg, replyToPubkey)
+                        sentCount = if (inboxPubkeys.isNotEmpty()) {
+                            outboxRouter.publishToInbox(msg, inboxPubkeys)
                         } else {
                             relayPool.sendToWriteRelays(msg)
                         }


### PR DESCRIPTION
## Summary
- When publishing a kind-1 note (root or reply) that mentions pubkeys via `nostr:` references, also deliver the event to each mentioned pubkey's read (inbox) relays per NIP-65.
- Inbox URLs are deduplicated across all mentioned pubkeys (and against our own write relays) so shared inboxes only receive the event once.
- Works for both the standard publish path (`ComposeViewModel`) and the background PoW mining path (`PowManager`).

## Changes
- `OutboxRouter.publishToInbox` gains a `Collection<String>` overload that unions the read relays of every target pubkey and dedupes URLs before sending.
- `ComposeViewModel.publishNote` builds `inboxPubkeys = replyTo.pubkey + extractedMentions` and uses it for both direct publish and PoW handoff.
- `PowManager.submitNote` accepts an `inboxPubkeys` collection (defaulting to `replyToPubkey` for backwards compatibility).

## Test plan
- [ ] Publish a root note mentioning two users whose inbox relays overlap — verify the note reaches each distinct inbox relay exactly once.
- [ ] Publish a reply that also mentions a third party — verify reply target and mentioned user both receive via their inbox relays.
- [ ] Publish a note with PoW enabled — same checks apply after mining completes.
- [ ] Publish a note with no mentions or reply target — behaviour unchanged (write-relays only).