### PR TITLE
feat: confirm before deleting a note

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Repeat
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -359,6 +360,7 @@ fun PostCard(
             }
             Box {
                 var menuExpanded by remember { mutableStateOf(false) }
+                var showDeleteConfirm by remember { mutableStateOf(false) }
                 val context = LocalContext.current
                 val clipboardManager = LocalClipboardManager.current
                 IconButton(
@@ -420,7 +422,7 @@ fun PostCard(
                             text = { Text(stringResource(R.string.btn_delete)) },
                             onClick = {
                                 menuExpanded = false
-                                onDelete()
+                                showDeleteConfirm = true
                             }
                         )
                     }
@@ -482,6 +484,29 @@ fun PostCard(
                                 showTranslation = !showTranslation
                             } else {
                                 onTranslate()
+                            }
+                        }
+                    )
+                }
+                if (showDeleteConfirm) {
+                    AlertDialog(
+                        onDismissRequest = { showDeleteConfirm = false },
+                        title = { Text(stringResource(R.string.title_delete_note)) },
+                        text = { Text(stringResource(R.string.msg_delete_note_confirm)) },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                showDeleteConfirm = false
+                                onDelete()
+                            }) {
+                                Text(
+                                    stringResource(R.string.btn_delete),
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showDeleteConfirm = false }) {
+                                Text(stringResource(R.string.btn_cancel))
                             }
                         }
                     )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">Chatroom löschen</string>
     <string name="title_delete_group">Chatroom löschen</string>
     <string name="msg_delete_group_confirm">Diesen Chatroom dauerhaft löschen? Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="title_delete_note">Notiz löschen?</string>
+    <string name="msg_delete_note_confirm">Eine Löschanfrage für diese Notiz an die Relays senden? Dies kann nicht garantiert werden.</string>
 
     <!-- Local Relay -->
     <string name="local_relay_my_relay">Mein lokales Relay</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">Eliminar sala de chat</string>
     <string name="title_delete_group">Eliminar sala de chat</string>
     <string name="msg_delete_group_confirm">¿Eliminar permanentemente esta sala de chat? Esta acción no se puede deshacer.</string>
+    <string name="title_delete_note">¿Eliminar nota?</string>
+    <string name="msg_delete_note_confirm">¿Enviar una solicitud de eliminación de esta nota a los relays? No se puede garantizar.</string>
 
     <string name="local_relay_my_relay">Mi Relay Local</string>
     <string name="local_relay_url_hint">ws://localhost:7777</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">Supprimer la salle de chat</string>
     <string name="title_delete_group">Supprimer la salle de chat</string>
     <string name="msg_delete_group_confirm">Supprimer définitivement cette salle de chat ? Cette action est irréversible.</string>
+    <string name="title_delete_note">Supprimer la note ?</string>
+    <string name="msg_delete_note_confirm">Envoyer une demande de suppression de cette note aux relays ? Cela ne peut pas être garanti.</string>
 
     <!-- Local Relay -->
     <string name="local_relay_my_relay">Mon relais local</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">Elimina stanza di chat</string>
     <string name="title_delete_group">Elimina stanza di chat</string>
     <string name="msg_delete_group_confirm">Eliminare definitivamente questa stanza di chat? Questa azione non può essere annullata.</string>
+    <string name="title_delete_note">Eliminare la nota?</string>
+    <string name="msg_delete_note_confirm">Inviare una richiesta di eliminazione di questa nota ai relay? Non può essere garantita.</string>
 
     <string name="local_relay_my_relay">Il mio relay locale</string>
     <string name="local_relay_url_hint">ws://localhost:7777</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">チャットルームを削除</string>
     <string name="title_delete_group">チャットルームを削除</string>
     <string name="msg_delete_group_confirm">このチャットルームを完全に削除しますか？この操作は元に戻せません。</string>
+    <string name="title_delete_note">ノートを削除しますか？</string>
+    <string name="msg_delete_note_confirm">このノートの削除リクエストをリレーに送信しますか？保証はされません。</string>
 
     <string name="local_relay_my_relay">マイローカルリレー</string>
     <string name="local_relay_url_hint">ws://localhost:7777</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">채팅방 삭제</string>
     <string name="title_delete_group">채팅방 삭제</string>
     <string name="msg_delete_group_confirm">이 채팅방을 영구적으로 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.</string>
+    <string name="title_delete_note">노트를 삭제하시겠습니까?</string>
+    <string name="msg_delete_note_confirm">이 노트에 대한 삭제 요청을 릴레이로 보내시겠습니까? 보장되지는 않습니다.</string>
 
     <!-- Local Relay -->
     <string name="local_relay_my_relay">내 로컬 릴레이</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">Chatruimte verwijderen</string>
     <string name="title_delete_group">Chatruimte verwijderen</string>
     <string name="msg_delete_group_confirm">Deze chatruimte definitief verwijderen? Dit kan niet ongedaan worden gemaakt.</string>
+    <string name="title_delete_note">Notitie verwijderen?</string>
+    <string name="msg_delete_note_confirm">Een verwijderverzoek voor deze notitie naar de relays sturen? Dit kan niet worden gegarandeerd.</string>
 
     <string name="local_relay_my_relay">Mijn lokale relay</string>
     <string name="local_relay_url_hint">ws://localhost:7777</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">Excluir sala de chat</string>
     <string name="title_delete_group">Excluir sala de chat</string>
     <string name="msg_delete_group_confirm">Excluir permanentemente esta sala de chat? Esta ação não pode ser desfeita.</string>
+    <string name="title_delete_note">Excluir nota?</string>
+    <string name="msg_delete_note_confirm">Enviar uma solicitação de exclusão desta nota para os relays? Não pode ser garantido.</string>
 
     <string name="local_relay_my_relay">Meu relay local</string>
     <string name="local_relay_url_hint">ws://localhost:7777</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -648,6 +648,8 @@
     <string name="action_delete_group">Удалить чат-комнату</string>
     <string name="title_delete_group">Удалить чат-комнату</string>
     <string name="msg_delete_group_confirm">Навсегда удалить эту чат-комнату? Это действие нельзя отменить.</string>
+    <string name="title_delete_note">Удалить заметку?</string>
+    <string name="msg_delete_note_confirm">Отправить запрос на удаление этой заметки на реле? Это не может быть гарантировано.</string>
 
     <string name="local_relay_my_relay">Моё локальное реле</string>
     <string name="local_relay_url_hint">ws://localhost:7777</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -687,6 +687,8 @@
     <string name="action_delete_group">删除聊天室</string>
     <string name="title_delete_group">删除聊天室</string>
     <string name="msg_delete_group_confirm">永久删除此聊天室？此操作无法撤销。</string>
+    <string name="title_delete_note">删除笔记？</string>
+    <string name="msg_delete_note_confirm">向中继发送删除此笔记的请求？无法保证一定成功。</string>
 
     <!-- Local Relay -->
     <string name="local_relay_my_relay">我的本地中继</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,6 +787,8 @@
     <string name="action_delete_group">Delete Chat Room</string>
     <string name="title_delete_group">Delete Chat Room</string>
     <string name="msg_delete_group_confirm">Permanently delete this chat room? This cannot be undone.</string>
+    <string name="title_delete_note">Delete note?</string>
+    <string name="msg_delete_note_confirm">Send a deletion request to relays for this note? This cannot be guaranteed.</string>
     <string name="label_notifications">Notifications</string>
     <string name="label_notifications_on">On — new messages will be tracked</string>
     <string name="label_notifications_off">Off — tap to enable</string>


### PR DESCRIPTION
## Summary
- Tapping Delete in a note card's 3-dot menu now opens a confirmation `AlertDialog` instead of immediately broadcasting the deletion request, so accidental taps don't fire off a kind-5 event.
- Added `title_delete_note` / `msg_delete_note_confirm` strings in the default locale plus all 10 translated locales (de, es, fr, it, ja, ko, nl, pt, ru, zh).

## Test plan
- [ ] Open own note → 3-dot menu → Delete → dialog appears; Cancel dismisses, Delete fires the deletion request.
- [ ] Verify strings render in each supported locale.