### PR TITLE
fix: pull own NIP-09 deletions on startup so deleted sets stay gone

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -6,6 +6,7 @@ import com.wisp.app.nostr.DmMessage
 import com.wisp.app.nostr.DmReaction
 import com.wisp.app.nostr.EncryptedMedia
 import com.wisp.app.nostr.DmZap
+import com.wisp.app.nostr.Nip09
 import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.Nip17
 import com.wisp.app.nostr.Nip53
@@ -439,6 +440,23 @@ class EventRouter(
                     interestRepo.updateFromEvent(event)
                 }
             }
+            if (event.kind == 5) {
+                val myPubkey = getUserPubkey()
+                if (myPubkey != null && event.pubkey == myPubkey) {
+                    // Run through EventRepository so deletion coords/ids are persisted
+                    // in DeletedEventsRepository. Safe to call repeatedly.
+                    eventRepo.addEvent(event)
+                    // Relays often keep re-serving deleted addressable events; sweep
+                    // matching entries out of the repos that hold them in memory.
+                    for (coord in Nip09.getDeletedAddresses(event)) {
+                        val parts = coord.split(":", limit = 3)
+                        if (parts.size != 3 || parts[1] != myPubkey) continue
+                        val kind = parts[0].toIntOrNull() ?: continue
+                        val dTag = parts[2]
+                        if (kind == Nip51.KIND_INTEREST_SET) interestRepo.removeSet(dTag)
+                    }
+                }
+            }
             if (event.kind == Nip51.KIND_BOOKMARK_SET) {
                 val myPubkey = getUserPubkey()
                 val s = getSigner()
@@ -565,7 +583,7 @@ class EventRouter(
 
     companion object {
         private val SELF_DATA_KINDS = intArrayOf(
-            0, 3, 10002, 10050, 10007, 10006,
+            0, 3, 5, 10002, 10050, 10007, 10006,
             Nip51.KIND_MUTE_LIST, Nip51.KIND_SIMPLE_GROUPS, Nip51.KIND_BOOKMARK_LIST,
             Nip51.KIND_PIN_LIST, Blossom.KIND_SERVER_LIST, Nip51.KIND_FOLLOW_SET,
             Nip51.KIND_INTEREST_SET, Nip51.KIND_BOOKMARK_SET, Nip51.KIND_RELAY_SET,

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -572,7 +572,11 @@ class StartupCoordinator(
         )
         val selfDataFilters = listOf(
             Filter(kinds = replaceableKinds, authors = listOf(myPubkey), limit = replaceableKinds.size),
-            Filter(kinds = addressableKinds, authors = listOf(myPubkey), limit = 250)
+            Filter(kinds = addressableKinds, authors = listOf(myPubkey), limit = 250),
+            // NIP-09 deletion events the user has published. Pulled so that deletions
+            // survive across devices and fresh installs even when relays keep re-serving
+            // the deleted replaceable/addressable events.
+            Filter(kinds = listOf(5), authors = listOf(myPubkey), limit = 500)
         )
         // Send to indexer relays (ephemeral if not already connected) AND the user's own
         // write relays — write relays are the authoritative source since the user published


### PR DESCRIPTION
## Summary
- Some relays keep re-serving hashtag sets (and other addressable events) after we publish a kind 5 deletion, so deleted sets reappeared on every app reload — especially on fresh installs and second devices where the local \`DeletedEventsRepository\` had no record of the deletion.
- \`subscribeSelfData\` now also requests our own kind 5 events, giving us back the deletions we previously published.
- \`EventRouter\` routes incoming self-authored kind 5s through \`EventRepository.addEvent\` (so the coords/ids are marked in \`DeletedEventsRepository\`) and sweeps any matching interest set out of \`InterestRepository\`, so a deletion that arrives after the 30015 still wins the race.

## Test plan
- [ ] Create a few hashtag sets, delete them, force-stop and relaunch — sets stay deleted.
- [ ] Clear app data (or install on a fresh device) with the same account — previously deleted sets do not reappear after the self-data fetch completes.
- [ ] Creating and editing interest sets still works (no regression in \`updateFromEvent\` path).