### PR TITLE
fix: trending feed not reconnecting after app resume

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
@@ -21,7 +21,6 @@ class RelayLifecycleManager(
     private val context: Context,
     private val relayPool: RelayPool,
     private val scope: CoroutineScope,
-    private val onPreReconnect: (() -> Unit)? = null,
     private val onReconnected: (force: Boolean) -> Unit
 ) {
     private var connectivityJob: Job? = null
@@ -158,10 +157,6 @@ class RelayLifecycleManager(
                     Log.d("RLC", "[Lifecycle] → reconnectAll()")
                     relayPool.reconnectAll()
                 }
-                // Let callers start priority ephemeral connections (e.g. trending
-                // relay) so they connect in parallel with persistent relays instead
-                // of waiting until after awaitAnyConnected.
-                onPreReconnect?.invoke()
                 val minCount = if (force) 3 else 1
                 Log.d("RLC", "[Lifecycle] awaiting $minCount relays...")
                 relayPool.awaitAnyConnected(minCount = minCount, timeoutMs = 5_000)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -203,18 +203,6 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         context = app,
         relayPool = relayPool,
         scope = viewModelScope,
-        onPreReconnect = {
-            // Start the trending relay connection early so it connects in parallel
-            // with persistent relays, not sequentially after them.
-            if (feedSub.feedType.value == FeedType.TRENDING) {
-                val url = if (feedSub.trendingMode.value == TrendingMode.USERS) {
-                    TRENDING_USERS_RELAY_URL
-                } else {
-                    buildTrendingRelayUrl(feedSub.trendingMetric.value, feedSub.trendingTimeframe.value)
-                }
-                relayPool.preConnectEphemeral(url)
-            }
-        },
         onReconnected = { force ->
             Log.d("RLC", "[FeedVM] onReconnected(force=$force) feedType=${feedSub.feedType.value} selectedRelay=${feedSub.selectedRelay.value} feedSize=${eventRepo.feed.value.size}")
             feedSub.subscribeFeed()


### PR DESCRIPTION
## Summary
- Remove the `preConnectEphemeral` optimization from the relay reconnect path.
- It created a race: the ephemeral was still mid-connect when `subscribeTrendingFeed` fired its REQ, leaving the subscription stuck on `Connecting`.
- The direct metric-switch path never used preConnect and worked fine — this change makes the reconnect path take the same code path.

## Test plan
- [ ] Open Trending feed, minimize app, reopen — feed reconnects and loads notes.
- [ ] Repeat with Trending → Users mode.
- [ ] Switching between trending metrics still works.
- [ ] Other feeds (Follows, For You, Relay, List) still reconnect on resume.