### PR TITLE
fix: preserve local relay and emoji frequency across account switches

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/BlossomRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/BlossomRepository.kt
@@ -53,9 +53,12 @@ class BlossomRepository(private val context: Context, pubkeyHex: String? = null)
         _servers.value = list
     }
 
+    // In-memory reset only. `prefs` is shared with KeyRepository
+    // (`wisp_prefs_{pubkey}`), so `prefs.edit().clear()` would also wipe
+    // `local_relay`, `relays`, `dm_relays`, etc. `reload(newPubkey)` below
+    // repoints to the new account's file.
     fun clear() {
         _servers.value = listOf(Blossom.DEFAULT_SERVER)
-        prefs.edit().clear().apply()
     }
 
     fun reload(pubkeyHex: String?) {

--- a/app/src/main/kotlin/com/wisp/app/repo/CustomEmojiRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/CustomEmojiRepository.kt
@@ -153,6 +153,9 @@ class CustomEmojiRepository(private val context: Context, pubkeyHex: String? = n
         _sortedUnicodeEmojis.value = all.sortedByDescending { freq[it] ?: 0 }
     }
 
+    // Resets in-memory state only; does NOT touch disk. On account switch the
+    // repo is called before the pubkey swap, so wiping `prefs` here would
+    // destroy the outgoing account's per-pubkey file.
     fun clear() {
         _userEmojiList.value = null
         _ownSets.value = emptyList()
@@ -162,7 +165,6 @@ class CustomEmojiRepository(private val context: Context, pubkeyHex: String? = n
         _unicodeEmojis.value = emptyList()
         _emojiFrequency.value = emptyMap()
         _sortedUnicodeEmojis.value = emptyList()
-        prefs.edit().clear().apply()
     }
 
     fun reload(pubkeyHex: String?) {


### PR DESCRIPTION
## Summary
- `BlossomRepository.clear()` was wiping `wisp_prefs_{pubkey}` — the same file `KeyRepository` uses for `local_relay`, `relays`, `dm_relays`, etc. On every account switch, `resetForAccountSwitch()` called this against the outgoing account's file, erasing the local relay config (the only key with no relay-side mirror to restore it).
- `CustomEmojiRepository.clear()` did the same to its own per-pubkey file, erasing the "most used" emoji frequency map.
- Both now leave disk untouched; the subsequent `reload(newPubkey)` repoints `prefs` to the incoming account's file.

## Test plan
- [x] Configure local relay on account A, switch to B, switch back to A — local relay config persists.
- [x] React with emojis on account A, switch to B, switch back — "most used" ordering preserved for both accounts independently.
- [x] `./gradlew assembleDebug` passes.