### PR TITLE
feat: open edit profile when tapping drawer avatar

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -144,6 +144,7 @@ fun WispDrawerContent(
                     if (crashTapCount >= 7) {
                         throw RuntimeException("Test crash")
                     }
+                    onProfile()
                 }) {
                     ProfilePicture(url = profile?.picture, size = 64)
                 }


### PR DESCRIPTION
## Summary
- Tapping the profile picture in the sidebar drawer header now navigates to the edit profile screen (reuses the existing `onProfile` callback, already wired to `Routes.PROFILE_EDIT`).

## Test plan
- [ ] Open the drawer and tap the avatar → lands on Edit Profile.
- [ ] Existing "My Profile" drawer row still works.