### PR TITLE
fix: use user's emoji picker for quoted/referenced notes

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1416,7 +1416,10 @@ fun WispNavHost(
                         isEmojiSetAdded = { pk, dTag ->
                             val ref = com.wisp.app.nostr.Nip30.buildSetReference(pk, dTag)
                             feedViewModel.customEmojiRepo.userEmojiList.value?.setReferences?.contains(ref) ?: false
-                        }
+                        },
+                        resolvedEmojisProvider = { feedViewModel.customEmojiRepo.resolvedEmojis.value },
+                        unicodeEmojisProvider = { feedViewModel.customEmojiRepo.sortedUnicodeEmojis.value },
+                        onOpenEmojiLibrary = { showDmEmojiLibrary = true }
                     )
                 },
                 resolvedEmojis = dmResolvedEmojis,
@@ -1500,7 +1503,10 @@ fun WispNavHost(
                         isEmojiSetAdded = { pk, dTag ->
                             val ref = com.wisp.app.nostr.Nip30.buildSetReference(pk, dTag)
                             feedViewModel.customEmojiRepo.userEmojiList.value?.setReferences?.contains(ref) ?: false
-                        }
+                        },
+                        resolvedEmojisProvider = { feedViewModel.customEmojiRepo.resolvedEmojis.value },
+                        unicodeEmojisProvider = { feedViewModel.customEmojiRepo.sortedUnicodeEmojis.value },
+                        onOpenEmojiLibrary = { showDmGroupEmojiLibrary = true }
                     )
                 },
                 resolvedEmojis = dmGroupResolvedEmojis,
@@ -1733,7 +1739,10 @@ fun WispNavHost(
                         isEmojiSetAdded = { pk, dTag ->
                             val ref = com.wisp.app.nostr.Nip30.buildSetReference(pk, dTag)
                             feedViewModel.customEmojiRepo.userEmojiList.value?.setReferences?.contains(ref) ?: false
-                        }
+                        },
+                        resolvedEmojisProvider = { feedViewModel.customEmojiRepo.resolvedEmojis.value },
+                        unicodeEmojisProvider = { feedViewModel.customEmojiRepo.sortedUnicodeEmojis.value },
+                        onOpenEmojiLibrary = { showGroupRoomEmojiLibrary = true }
                     )
                 },
                 onEmojiUsed = { feedViewModel.customEmojiRepo.recordEmojiUsage(it) }
@@ -2105,7 +2114,9 @@ fun WispNavHost(
                     isEmojiSetAdded = { pubkey, dTag ->
                         val ref = com.wisp.app.nostr.Nip30.buildSetReference(pubkey, dTag)
                         feedViewModel.customEmojiRepo.userEmojiList.value?.setReferences?.contains(ref) ?: false
-                    }
+                    },
+                    resolvedEmojisProvider = { feedViewModel.customEmojiRepo.resolvedEmojis.value },
+                    unicodeEmojisProvider = { feedViewModel.customEmojiRepo.sortedUnicodeEmojis.value }
                 )
             }
             val interestSets by feedViewModel.interestRepo.sets.collectAsState()
@@ -2254,7 +2265,9 @@ fun WispNavHost(
                     isEmojiSetAdded = { pubkey, dTag ->
                         val ref = com.wisp.app.nostr.Nip30.buildSetReference(pubkey, dTag)
                         feedViewModel.customEmojiRepo.userEmojiList.value?.setReferences?.contains(ref) ?: false
-                    }
+                    },
+                    resolvedEmojisProvider = { feedViewModel.customEmojiRepo.resolvedEmojis.value },
+                    unicodeEmojisProvider = { feedViewModel.customEmojiRepo.sortedUnicodeEmojis.value }
                 )
             }
             val interestSets by feedViewModel.interestRepo.sets.collectAsState()
@@ -2411,7 +2424,10 @@ fun WispNavHost(
                     isEmojiSetAdded = { pubkey, dTag ->
                         val ref = com.wisp.app.nostr.Nip30.buildSetReference(pubkey, dTag)
                         feedViewModel.customEmojiRepo.userEmojiList.value?.setReferences?.contains(ref) ?: false
-                    }
+                    },
+                    resolvedEmojisProvider = { feedViewModel.customEmojiRepo.resolvedEmojis.value },
+                    unicodeEmojisProvider = { feedViewModel.customEmojiRepo.sortedUnicodeEmojis.value },
+                    onOpenEmojiLibrary = { showArticleEmojiLibrary = true }
                 )
             }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -174,6 +174,9 @@ data class NoteActions(
     val onRemoveEmojiSet: ((pubkey: String, dTag: String) -> Unit)? = null,
     val isEmojiSetAdded: ((pubkey: String, dTag: String) -> Boolean)? = null,
     val onPollVote: (String, List<String>) -> Unit = { _, _ -> },
+    val resolvedEmojisProvider: () -> Map<String, String> = { emptyMap() },
+    val unicodeEmojisProvider: () -> List<String> = { emptyList() },
+    val onOpenEmojiLibrary: (() -> Unit)? = null,
 )
 
 data class MediaMeta(
@@ -996,6 +999,7 @@ fun QuotedNote(
         val hasUserZapped = remember(zapVersion, eventId) { eventRepo.hasUserZapped(eventId) }
         val reactionDetails = remember(reactionVersion, eventId) { eventRepo.getReactionDetails(eventId) }
         val zapDetails = remember(zapVersion, eventId) { eventRepo.getZapDetails(eventId) }
+        val reactionEmojiUrls = remember(reactionVersion, eventId) { eventRepo.getReactionEmojiUrls(eventId) }
 
         // Poll data for quoted polls
         val pollVoteCounts = remember(pollVoteVersion, eventId) {
@@ -1060,6 +1064,10 @@ fun QuotedNote(
                     onPin = { noteActions.onPin(eventId) },
                     onQuotedNoteClick = effectiveNoteClick,
                     noteActions = noteActions,
+                    reactionEmojiUrls = reactionEmojiUrls,
+                    resolvedEmojis = noteActions.resolvedEmojisProvider(),
+                    unicodeEmojis = noteActions.unicodeEmojisProvider(),
+                    onOpenEmojiLibrary = noteActions.onOpenEmojiLibrary,
                     showDivider = false
                 )
             } else {
@@ -1102,6 +1110,10 @@ fun QuotedNote(
                     zapPollSatsCounts = zapPollSatsCounts,
                     zapPollTotalSats = zapPollTotalSats,
                     userZapPollVote = userZapPollVote,
+                    reactionEmojiUrls = reactionEmojiUrls,
+                    resolvedEmojis = noteActions.resolvedEmojisProvider(),
+                    unicodeEmojis = noteActions.unicodeEmojisProvider(),
+                    onOpenEmojiLibrary = noteActions.onOpenEmojiLibrary,
                     showDivider = false
                 )
             }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -353,7 +353,10 @@ fun FeedScreen(
                 val ref = com.wisp.app.nostr.Nip30.buildSetReference(pubkey, dTag)
                 viewModel.customEmojiRepo.userEmojiList.value?.setReferences?.contains(ref) ?: false
             },
-            onPollVote = { pollId, optionIds -> viewModel.publishPollVote(pollId, optionIds) }
+            onPollVote = { pollId, optionIds -> viewModel.publishPollVote(pollId, optionIds) },
+            resolvedEmojisProvider = { viewModel.customEmojiRepo.resolvedEmojis.value },
+            unicodeEmojisProvider = { viewModel.customEmojiRepo.sortedUnicodeEmojis.value },
+            onOpenEmojiLibrary = { showEmojiLibrary = true }
         )
     }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -1371,7 +1371,7 @@ private fun ReferencedNotePostCard(
             onQuotedNoteClick = params.onNoteClick,
             noteActions = run {
                 val p = params
-                if (p.onPayInvoice != null || p.onGroupRoom != null || p.fetchGroupPreview != null || p.onAddEmojiSet != null) {
+                if (p.onPayInvoice != null || p.onGroupRoom != null || p.fetchGroupPreview != null || p.onAddEmojiSet != null || p.onOpenEmojiLibrary != null) {
                     com.wisp.app.ui.component.NoteActions(
                         onPayInvoice = p.onPayInvoice,
                         onGroupRoom = p.onGroupRoom,
@@ -1380,7 +1380,10 @@ private fun ReferencedNotePostCard(
                         onRemoveEmojiSet = p.onRemoveEmojiSet,
                         isEmojiSetAdded = p.isEmojiSetAdded,
                         onPollVote = p.onPollVote,
-                        nip05Repo = p.nip05Repo
+                        nip05Repo = p.nip05Repo,
+                        resolvedEmojisProvider = { p.resolvedEmojis },
+                        unicodeEmojisProvider = { p.unicodeEmojis },
+                        onOpenEmojiLibrary = p.onOpenEmojiLibrary
                     )
                 } else null
             },
@@ -1457,7 +1460,7 @@ private fun ReferencedNotePostCard(
             onZapPollVote = { idx -> params.onZapPollVote(event.id, idx) },
             noteActions = run {
                 val p = params
-                if (p.onPayInvoice != null || p.onGroupRoom != null || p.fetchGroupPreview != null || p.onAddEmojiSet != null) {
+                if (p.onPayInvoice != null || p.onGroupRoom != null || p.fetchGroupPreview != null || p.onAddEmojiSet != null || p.onOpenEmojiLibrary != null) {
                     com.wisp.app.ui.component.NoteActions(
                         onPayInvoice = p.onPayInvoice,
                         onGroupRoom = p.onGroupRoom,
@@ -1466,7 +1469,10 @@ private fun ReferencedNotePostCard(
                         onRemoveEmojiSet = p.onRemoveEmojiSet,
                         isEmojiSetAdded = p.isEmojiSetAdded,
                         onPollVote = p.onPollVote,
-                        nip05Repo = p.nip05Repo
+                        nip05Repo = p.nip05Repo,
+                        resolvedEmojisProvider = { p.resolvedEmojis },
+                        unicodeEmojisProvider = { p.unicodeEmojis },
+                        onOpenEmojiLibrary = p.onOpenEmojiLibrary
                     )
                 } else null
             },

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -161,6 +162,8 @@ fun ThreadScreen(
     val pollVoteVersion by eventRepo.pollVoteVersion.collectAsState()
     val followList by contactRepo.followList.collectAsState()
 
+    val resolvedEmojisState = rememberUpdatedState(resolvedEmojis)
+    val unicodeEmojisState = rememberUpdatedState(unicodeEmojis)
     val noteActions = remember(userPubkey) {
         NoteActions(
             onReply = onReply,
@@ -188,7 +191,10 @@ fun ThreadScreen(
             onAddEmojiSet = onAddEmojiSet,
             onRemoveEmojiSet = onRemoveEmojiSet,
             isEmojiSetAdded = isEmojiSetAdded,
-            onPollVote = onPollVote
+            onPollVote = onPollVote,
+            resolvedEmojisProvider = { resolvedEmojisState.value },
+            unicodeEmojisProvider = { unicodeEmojisState.value },
+            onOpenEmojiLibrary = onOpenEmojiLibrary
         )
     }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/UserProfileScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -187,19 +188,24 @@ fun UserProfileScreen(
     onRemoveEmojiSet: ((String, String) -> Unit)? = null,
     isEmojiSetAdded: ((String, String) -> Boolean)? = null
 ) {
-    val invoiceNoteActions = remember(onPayInvoice, onGroupRoom, onLiveStreamClick, fetchGroupPreview, onAddEmojiSet) {
-        if (onPayInvoice != null || onGroupRoom != null || fetchGroupPreview != null || onAddEmojiSet != null || onLiveStreamClick != null) {
+    val resolvedEmojisState = rememberUpdatedState(resolvedEmojis)
+    val unicodeEmojisState = rememberUpdatedState(unicodeEmojis)
+    val invoiceNoteActions = remember(onPayInvoice, onGroupRoom, onLiveStreamClick, fetchGroupPreview, onAddEmojiSet, onOpenEmojiLibrary) {
+        if (onPayInvoice != null || onGroupRoom != null || fetchGroupPreview != null || onAddEmojiSet != null || onLiveStreamClick != null || onOpenEmojiLibrary != null) {
             com.wisp.app.ui.component.NoteActions(
-                onPayInvoice = onPayInvoice,
-                onGroupRoom = onGroupRoom,
-                onLiveStreamClick = onLiveStreamClick,
-                fetchGroupPreview = fetchGroupPreview,
-                onAddEmojiSet = onAddEmojiSet,
-                onRemoveEmojiSet = onRemoveEmojiSet,
-                isEmojiSetAdded = isEmojiSetAdded,
-                onPollVote = onPollVote,
-                nip05Repo = nip05Repo
-            )
+            onPayInvoice = onPayInvoice,
+            onGroupRoom = onGroupRoom,
+            onLiveStreamClick = onLiveStreamClick,
+            fetchGroupPreview = fetchGroupPreview,
+            onAddEmojiSet = onAddEmojiSet,
+            onRemoveEmojiSet = onRemoveEmojiSet,
+            isEmojiSetAdded = isEmojiSetAdded,
+            onPollVote = onPollVote,
+            nip05Repo = nip05Repo,
+            resolvedEmojisProvider = { resolvedEmojisState.value },
+            unicodeEmojisProvider = { unicodeEmojisState.value },
+            onOpenEmojiLibrary = onOpenEmojiLibrary
+        )
         } else null
     }
     val profile by viewModel.profile.collectAsState()


### PR DESCRIPTION
## Summary
- Quoted/referenced notes rendered inline via `RichContent.QuotedNote` were showing the default 17-emoji fallback picker with no custom emoji support, instead of the user's sorted-by-frequency picker used everywhere else.
- Added `resolvedEmojisProvider`, `unicodeEmojisProvider`, and `onOpenEmojiLibrary` to `NoteActions` and forwarded them (plus a per-event `reactionEmojiUrls`) into the nested `PostCard`/`GalleryCard` rendered by `QuotedNote`.
- Wired the new fields in every `NoteActions` construction: FeedScreen, ThreadScreen, NotificationsScreen, UserProfileScreen, and Navigation.kt (DM, group DM, group room, hashtag, set feed, article). Providers let the already-`remember`ed `NoteActions` read fresh StateFlow state on each invocation.

## Test plan
- [ ] Open a note that quotes another note in the main feed — long-press the reaction button on the quoted note and confirm the full emoji library opens (custom emojis + frequency-sorted unicode).
- [ ] Repeat in a thread view.
- [ ] Repeat in notifications.
- [ ] Repeat on a user profile feed.
- [ ] Repeat in a DM / group DM / group room / hashtag / set feed / article.
- [ ] React with a custom emoji from the quoted note and confirm it publishes and renders correctly.