### PR TITLE
perf: avoid O(N^2) indexOf in notifications list

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -381,9 +382,9 @@ fun NotificationsScreen(
                         }
                     )
                 }
-                items(items = notifications, key = { it.id }, contentType = { "notification" }) { item ->
+                itemsIndexed(items = notifications, key = { _, it -> it.id }, contentType = { _, _ -> "notification" }) { index, item ->
                     val isExpanded = expandedId == item.id
-                    val itemIndex = notifications.indexOf(item) + 1 // +1 for summary header
+                    val itemIndex = index + 1 // +1 for summary header
                     val coroutineScope = rememberCoroutineScope()
                     ZenNotificationRow(
                         item = item,


### PR DESCRIPTION
## Summary
- Users (notably on GrapheneOS) reported the app freezing when tapping the Notifications bottom-nav tab.
- Root cause: inside the `LazyColumn` `items { … }` lambda we called `notifications.indexOf(item)` on every item composition. That's a linear scan per item → O(N²) total work per recomposition pass, with each scan invoking `FlatNotificationItem.equals` (data class). With a few hundred notifications and frequent `profileVersion` bumps invalidating the list, this is enough to stall the main thread long enough to look like a freeze on slower hardware.
- Fix: switch to `itemsIndexed(...)` and use the supplied `index` directly. One-line behavioral equivalent, no more quadratic scan.

## Test plan
- [ ] Open the Notifications tab on a populated account; verify list renders and scrolls smoothly
- [ ] Tap a notification to expand/collapse (uses `itemIndex` for `animateScrollToItem`) and confirm scroll-to-item still lands correctly when replying
- [ ] Pull to refresh; confirm ordering and summary header are unchanged
- [ ] Ideally: have a GrapheneOS user confirm the freeze on tab switch is gone