### PR TITLE
feat: add download button to inline video controls

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -2219,6 +2219,7 @@ internal fun InlineVideoPlayerWithFullscreen(meta: MediaMeta, onFullScreen: (pos
 
     val context = LocalContext.current
     val view = LocalView.current
+    val scope = rememberCoroutineScope()
     var videoAspectRatio by remember { mutableFloatStateOf(parseAspectRatio(meta.dimension) ?: (16f / 9f)) }
     val isMuted by globalMuted.collectAsState()
     var showControls by remember { mutableStateOf(false) }
@@ -2348,6 +2349,19 @@ internal fun InlineVideoPlayerWithFullscreen(meta: MediaMeta, onFullScreen: (pos
                         imageVector = if (isMuted) Icons.AutoMirrored.Filled.VolumeOff
                             else Icons.AutoMirrored.Filled.VolumeUp,
                         contentDescription = if (isMuted) "Unmute" else "Mute"
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+                IconButton(
+                    onClick = {
+                        scope.launch { MediaDownloader.downloadMedia(context, url) }
+                    },
+                    colors = buttonColors,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_download),
+                        contentDescription = "Download"
                     )
                 }
                 Spacer(Modifier.width(4.dp))


### PR DESCRIPTION
## Summary
- Adds a download button to the inline video player controls alongside mute/fullscreen/PiP, so users don't have to enter fullscreen to save a video.
- Reuses the existing `MediaDownloader.downloadMedia` helper.

## Test plan
- [ ] Open a note containing a video, tap the video to reveal controls, tap the download icon
- [ ] Verify the video downloads to the Downloads folder with a success toast
- [ ] Confirm fullscreen download still works