### PR TITLE
feat: add QR scan tab to drawer QR sheet

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.wisp.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 74
-        versionName = "1.0.0"
+        versionCode = 76
+        versionName = "1.0.2"
 
         ndk {
             abiFilters += "arm64-v8a"

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -174,6 +174,17 @@ object Routes {
     const val LIVE_STREAM = "live_stream/{hostPubkey}/{dTag}?relayHint={relayHint}"
 }
 
+/**
+ * Map a decoded NIP-19 entity to a navigation route, or null if there is no
+ * route for it (e.g. an addressable event whose kind we don't render).
+ */
+fun NostrUriData.toRoute(): String? = when (this) {
+    is NostrUriData.ProfileRef -> "profile/$pubkey"
+    is NostrUriData.NoteRef -> "thread/$eventId"
+    is NostrUriData.AddressRef ->
+        if (kind == 30023 && author != null) "article/$kind/$author/$dTag" else null
+}
+
 @Composable
 fun WispNavHost(
     deepLinkUri: String? = null,
@@ -414,16 +425,7 @@ fun WispNavHost(
     // Resolve deep link URI to a navigation route
     val deepLinkRoute = remember(deepLinkUri) {
         val uri = deepLinkUri ?: return@remember null
-        val parsed = Nip19.decodeNostrUri(uri) ?: return@remember null
-        when (parsed) {
-            is NostrUriData.ProfileRef -> "profile/${parsed.pubkey}"
-            is NostrUriData.NoteRef -> "thread/${parsed.eventId}"
-            is NostrUriData.AddressRef -> {
-                if (parsed.kind == 30023 && parsed.author != null) {
-                    "article/${parsed.kind}/${parsed.author}/${parsed.dTag}"
-                } else null
-            }
-        }
+        Nip19.decodeNostrUri(uri)?.toRoute()
     }
 
     // Handle deep links when app is already past loading (onNewIntent)
@@ -830,6 +832,9 @@ fun WispNavHost(
                 },
                 onQuotedNoteClick = { eventId ->
                     navController.navigate("thread/$eventId")
+                },
+                onScanResult = { route ->
+                    navController.navigate(route)
                 },
                 accounts = accounts,
                 onSwitchAccount = onSwitchAccount,

--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip19.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip19.kt
@@ -155,6 +155,21 @@ object Nip19 {
         return NostrUriData.ProfileRef(pubkey, relays)
     }
 
+    /**
+     * Decode a value scanned from a QR code that may or may not include the
+     * `nostr:` URI scheme. Returns null if the payload isn't a recognised
+     * NIP-19 entity.
+     */
+    fun decodeNostrQr(raw: String): NostrUriData? {
+        val trimmed = raw.trim()
+        val withoutScheme = if (trimmed.startsWith("nostr:", ignoreCase = true)) {
+            trimmed.substring("nostr:".length)
+        } else {
+            trimmed
+        }
+        return decodeNostrUri("nostr:$withoutScheme")
+    }
+
     fun decodeNostrUri(uri: String): NostrUriData? {
         val bech32 = uri.removePrefix("nostr:")
         return try {

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ProfileQrSheet.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ProfileQrSheet.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.QrCodeScanner
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -29,8 +30,11 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -47,12 +51,13 @@ import coil3.compose.AsyncImage
 import com.wisp.app.R
 import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.hexToByteArray
+import com.wisp.app.toRoute
 import com.wisp.app.ui.theme.WispThemeColors
 import kotlinx.coroutines.launch
 
 /**
- * Consolidated QR sheet showing Nostr identity and Lightning address
- * in a tabbed bottom sheet with swipeable pages.
+ * Consolidated QR sheet showing Nostr identity, Lightning address, and a scan
+ * tab in a tabbed bottom sheet with swipeable pages.
  */
 @OptIn(ExperimentalMaterial3Api::class, androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
@@ -60,6 +65,7 @@ fun ProfileQrSheet(
     pubkeyHex: String,
     avatarUrl: String? = null,
     lud16: String? = null,
+    onNavigate: (String) -> Unit = {},
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -73,8 +79,12 @@ fun ProfileQrSheet(
     val lightningQr = remember(lud16) { lud16?.let { generateQrBitmap(it) } }
 
     val hasLightning = lud16 != null
-    val pageCount = if (hasLightning) 2 else 1
+    // Page indices: 0 = Nostr, 1 = Lightning (if present), last = Scan.
+    val lightningPage = if (hasLightning) 1 else -1
+    val scanPage = if (hasLightning) 2 else 1
+    val pageCount = if (hasLightning) 3 else 2
     val pagerState = rememberPagerState(pageCount = { pageCount })
+    var scanError by remember { mutableStateOf<String?>(null) }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -86,23 +96,22 @@ fun ProfileQrSheet(
                 .fillMaxWidth()
                 .padding(bottom = 32.dp)
         ) {
-            // Tabs
-            if (hasLightning) {
-                TabRow(
-                    selectedTabIndex = pagerState.currentPage,
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    contentColor = MaterialTheme.colorScheme.primary,
-                    divider = {}
-                ) {
+            TabRow(
+                selectedTabIndex = pagerState.currentPage,
+                containerColor = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.primary,
+                divider = {}
+            ) {
+                Tab(
+                    selected = pagerState.currentPage == 0,
+                    onClick = { scope.launch { pagerState.animateScrollToPage(0) } },
+                    text = { Text("Nostr") },
+                    icon = { Icon(Icons.Outlined.Person, null, modifier = Modifier.size(18.dp)) }
+                )
+                if (hasLightning) {
                     Tab(
-                        selected = pagerState.currentPage == 0,
-                        onClick = { scope.launch { pagerState.animateScrollToPage(0) } },
-                        text = { Text("Nostr") },
-                        icon = { Icon(Icons.Outlined.Person, null, modifier = Modifier.size(18.dp)) }
-                    )
-                    Tab(
-                        selected = pagerState.currentPage == 1,
-                        onClick = { scope.launch { pagerState.animateScrollToPage(1) } },
+                        selected = pagerState.currentPage == lightningPage,
+                        onClick = { scope.launch { pagerState.animateScrollToPage(lightningPage) } },
                         text = { Text("Lightning") },
                         icon = {
                             if (useZapBolt) {
@@ -113,11 +122,16 @@ fun ProfileQrSheet(
                         }
                     )
                 }
+                Tab(
+                    selected = pagerState.currentPage == scanPage,
+                    onClick = { scope.launch { pagerState.animateScrollToPage(scanPage) } },
+                    text = { Text("Scan") },
+                    icon = { Icon(Icons.Outlined.QrCodeScanner, null, modifier = Modifier.size(18.dp)) }
+                )
             }
 
             Spacer(Modifier.height(16.dp))
 
-            // Pages
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.fillMaxWidth()
@@ -181,8 +195,7 @@ fun ProfileQrSheet(
                                 clipboardManager.setText(AnnotatedString(npub))
                             })
                         }
-                        1 -> {
-                            // Lightning QR
+                        lightningPage -> {
                             if (lightningQr != null && lud16 != null) {
                                 Box(
                                     contentAlignment = Alignment.Center,
@@ -234,6 +247,29 @@ fun ProfileQrSheet(
                                 CopyableRow(text = lud16, onCopy = {
                                     clipboardManager.setText(AnnotatedString(lud16))
                                 })
+                            }
+                        }
+                        scanPage -> {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(360.dp)
+                            ) {
+                                QrScanner(
+                                    onResult = { raw ->
+                                        val route = Nip19.decodeNostrQr(raw)?.toRoute()
+                                        if (route != null) {
+                                            scanError = null
+                                            onNavigate(route)
+                                            onDismiss()
+                                        } else {
+                                            scanError = "Not a Nostr QR code"
+                                        }
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    promptText = scanError
+                                        ?: "Point at an npub, note, profile, event, or address QR"
+                                )
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/QrScanner.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/QrScanner.kt
@@ -1,0 +1,211 @@
+package com.wisp.app.ui.component
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+
+/**
+ * Reusable QR code scanner. Requests camera permission, shows a CameraX preview
+ * with a viewfinder overlay, and invokes [onResult] exactly once with the raw
+ * decoded barcode value.
+ */
+@Composable
+fun QrScanner(
+    onResult: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    promptText: String? = null,
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var hasCameraPermission by remember { mutableStateOf(false) }
+    var scanned by remember { mutableStateOf(false) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        hasCameraPermission = granted
+    }
+
+    LaunchedEffect(Unit) {
+        hasCameraPermission = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!hasCameraPermission) {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (!hasCameraPermission) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        Icons.Default.CameraAlt,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        "Camera permission required",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = {
+                        permissionLauncher.launch(Manifest.permission.CAMERA)
+                    }) {
+                        Text("Grant permission")
+                    }
+                }
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .padding(horizontal = 16.dp)
+                    .clip(RoundedCornerShape(16.dp))
+            ) {
+                androidx.compose.ui.viewinterop.AndroidView(
+                    factory = { ctx ->
+                        val previewView = PreviewView(ctx)
+                        val cameraProviderFuture = ProcessCameraProvider.getInstance(ctx)
+                        cameraProviderFuture.addListener({
+                            val cameraProvider = cameraProviderFuture.get()
+                            val preview = Preview.Builder().build().also {
+                                it.surfaceProvider = previewView.surfaceProvider
+                            }
+
+                            val options = BarcodeScannerOptions.Builder()
+                                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                                .build()
+                            val scanner = BarcodeScanning.getClient(options)
+
+                            val analysis = ImageAnalysis.Builder()
+                                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                                .build()
+                            analysis.setAnalyzer(ContextCompat.getMainExecutor(ctx)) { imageProxy ->
+                                @androidx.camera.core.ExperimentalGetImage
+                                val mediaImage = imageProxy.image
+                                if (mediaImage != null && !scanned) {
+                                    val inputImage = InputImage.fromMediaImage(
+                                        mediaImage, imageProxy.imageInfo.rotationDegrees
+                                    )
+                                    scanner.process(inputImage)
+                                        .addOnSuccessListener { barcodes ->
+                                            val value = barcodes.firstOrNull()?.rawValue
+                                            if (value != null && !scanned) {
+                                                scanned = true
+                                                onResult(value)
+                                            }
+                                        }
+                                        .addOnCompleteListener { imageProxy.close() }
+                                } else {
+                                    imageProxy.close()
+                                }
+                            }
+
+                            try {
+                                cameraProvider.unbindAll()
+                                cameraProvider.bindToLifecycle(
+                                    lifecycleOwner,
+                                    CameraSelector.DEFAULT_BACK_CAMERA,
+                                    preview,
+                                    analysis
+                                )
+                            } catch (e: Exception) {
+                                Log.e("QrScanner", "Camera bind failed", e)
+                            }
+                        }, ContextCompat.getMainExecutor(ctx))
+                        previewView
+                    },
+                    modifier = Modifier.fillMaxSize()
+                )
+
+                Box(
+                    modifier = Modifier
+                        .size(250.dp)
+                        .align(Alignment.Center)
+                        .background(Color.Transparent)
+                ) {
+                    Canvas(modifier = Modifier.fillMaxSize()) {
+                        val strokeW = 3.dp.toPx()
+                        val cornerLen = 30.dp.toPx()
+                        val color = Color.White
+                        drawLine(color, Offset(0f, 0f), Offset(cornerLen, 0f), strokeWidth = strokeW)
+                        drawLine(color, Offset(0f, 0f), Offset(0f, cornerLen), strokeWidth = strokeW)
+                        drawLine(color, Offset(size.width, 0f), Offset(size.width - cornerLen, 0f), strokeWidth = strokeW)
+                        drawLine(color, Offset(size.width, 0f), Offset(size.width, cornerLen), strokeWidth = strokeW)
+                        drawLine(color, Offset(0f, size.height), Offset(cornerLen, size.height), strokeWidth = strokeW)
+                        drawLine(color, Offset(0f, size.height), Offset(0f, size.height - cornerLen), strokeWidth = strokeW)
+                        drawLine(color, Offset(size.width, size.height), Offset(size.width - cornerLen, size.height), strokeWidth = strokeW)
+                        drawLine(color, Offset(size.width, size.height), Offset(size.width, size.height - cornerLen), strokeWidth = strokeW)
+                    }
+                }
+            }
+        }
+
+        if (promptText != null) {
+            Spacer(Modifier.height(16.dp))
+            Text(
+                promptText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 32.dp)
+            )
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -110,7 +110,8 @@ fun WispDrawerContent(
     onLogout: () -> Unit,
     hasEmbeddedWallet: Boolean = false,
     userStatus: String? = null,
-    onUpdateStatus: ((String) -> Unit)? = null
+    onUpdateStatus: ((String) -> Unit)? = null,
+    onScanResult: (String) -> Unit = {},
 ) {
     ModalDrawerSheet(
         drawerContainerColor = MaterialTheme.colorScheme.surface,
@@ -384,6 +385,10 @@ fun WispDrawerContent(
                 pubkeyHex = pubkey,
                 avatarUrl = profile?.picture,
                 lud16 = profile?.lud16,
+                onNavigate = { route ->
+                    showProfileQr = false
+                    onScanResult(route)
+                },
                 onDismiss = { showProfileQr = false }
             )
         }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -189,7 +189,8 @@ fun FeedScreen(
     onGroupRoom: ((String, String) -> Unit)? = null,
     onLiveStreamClick: ((String, String, String?) -> Unit)? = null,
     fetchGroupPreview: (suspend (String, String) -> com.wisp.app.repo.GroupPreview?)? = null,
-    scrollToTopTrigger: Int = 0
+    scrollToTopTrigger: Int = 0,
+    onScanResult: (String) -> Unit = {},
 ) {
     val feed by viewModel.feed.collectAsState()
     val feedType by viewModel.feedType.collectAsState()
@@ -742,6 +743,10 @@ fun FeedScreen(
                 userStatus = statusVersion.let { userPubkey?.let { viewModel.eventRepo.getUserStatus(it) } },
                 onUpdateStatus = { status ->
                     viewModel.publishUserStatus(status)
+                },
+                onScanResult = { route ->
+                    scope.launch { drawerState.close() }
+                    onScanResult(route)
                 }
             )
         }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -1202,26 +1202,6 @@ private fun ScanQRContent(
     onResult: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
-    var hasCameraPermission by remember { mutableStateOf(false) }
-    var scanned by remember { mutableStateOf(false) }
-
-    val permissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { granted ->
-        hasCameraPermission = granted
-    }
-
-    LaunchedEffect(Unit) {
-        hasCameraPermission = ContextCompat.checkSelfPermission(
-            context, Manifest.permission.CAMERA
-        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
-        if (!hasCameraPermission) {
-            permissionLauncher.launch(Manifest.permission.CAMERA)
-        }
-    }
-
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -1236,142 +1216,18 @@ private fun ScanQRContent(
 
         Spacer(Modifier.height(16.dp))
 
-        if (!hasCameraPermission) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        Icons.Default.CameraAlt,
-                        contentDescription = null,
-                        modifier = Modifier.size(48.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    Text(
-                        stringResource(R.string.wallet_camera_permission),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    Button(onClick = {
-                        permissionLauncher.launch(Manifest.permission.CAMERA)
-                    }) {
-                        Text(stringResource(R.string.wallet_grant_permission))
-                    }
-                }
-            }
-        } else {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .padding(horizontal = 16.dp)
-                    .clip(RoundedCornerShape(16.dp))
-            ) {
-                AndroidView(
-                    factory = { ctx ->
-                        val previewView = PreviewView(ctx)
-                        val cameraProviderFuture = ProcessCameraProvider.getInstance(ctx)
-                        cameraProviderFuture.addListener({
-                            val cameraProvider = cameraProviderFuture.get()
-                            val preview = Preview.Builder().build().also {
-                                it.surfaceProvider = previewView.surfaceProvider
-                            }
-
-                            val options = BarcodeScannerOptions.Builder()
-                                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-                                .build()
-                            val scanner = BarcodeScanning.getClient(options)
-
-                            val analysis = ImageAnalysis.Builder()
-                                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                                .build()
-                            analysis.setAnalyzer(ContextCompat.getMainExecutor(ctx)) { imageProxy ->
-                                @androidx.camera.core.ExperimentalGetImage
-                                val mediaImage = imageProxy.image
-                                if (mediaImage != null && !scanned) {
-                                    val inputImage = InputImage.fromMediaImage(
-                                        mediaImage, imageProxy.imageInfo.rotationDegrees
-                                    )
-                                    scanner.process(inputImage)
-                                        .addOnSuccessListener { barcodes ->
-                                            val value = barcodes.firstOrNull()?.rawValue
-                                            if (value != null && !scanned) {
-                                                scanned = true
-                                                val cleaned = value
-                                                    .removePrefix("lightning:")
-                                                    .removePrefix("LIGHTNING:")
-                                                    .removePrefix("bitcoin:")
-                                                    .removePrefix("BITCOIN:")
-                                                onResult(cleaned)
-                                            }
-                                        }
-                                        .addOnCompleteListener { imageProxy.close() }
-                                } else {
-                                    imageProxy.close()
-                                }
-                            }
-
-                            try {
-                                cameraProvider.unbindAll()
-                                cameraProvider.bindToLifecycle(
-                                    lifecycleOwner,
-                                    CameraSelector.DEFAULT_BACK_CAMERA,
-                                    preview,
-                                    analysis
-                                )
-                            } catch (e: Exception) {
-                                Log.e("ScanQR", "Camera bind failed", e)
-                            }
-                        }, ContextCompat.getMainExecutor(ctx))
-                        previewView
-                    },
-                    modifier = Modifier.fillMaxSize()
-                )
-
-                // Viewfinder overlay
-                Box(
-                    modifier = Modifier
-                        .size(250.dp)
-                        .align(Alignment.Center)
-                        .background(Color.Transparent)
-                ) {
-                    Canvas(modifier = Modifier.fillMaxSize()) {
-                        val strokeW = 3.dp.toPx()
-                        val cornerLen = 30.dp.toPx()
-                        val color = Color.White
-                        // Top-left corner
-                        drawLine(color, start = androidx.compose.ui.geometry.Offset(0f, 0f), end = androidx.compose.ui.geometry.Offset(cornerLen, 0f), strokeWidth = strokeW)
-                        drawLine(color, start = androidx.compose.ui.geometry.Offset(0f, 0f), end = androidx.compose.ui.geometry.Offset(0f, cornerLen), strokeWidth = strokeW)
-                        // Top-right corner
-                        drawLine(color, start = androidx.compose.ui.geometry.Offset(size.width, 0f), end = androidx.compose.ui.geometry.Offset(size.width - cornerLen, 0f), strokeWidth = strokeW)
-                        drawLine(color, start = androidx.compose.ui.geometry.Offset(size.width, 0f), end = androidx.compose.ui.geometry.Offset(size.width, cornerLen), strokeWidth = strokeW)
-                        // Bottom-left corner
-                        drawLine(color, start = androidx.compose.ui.geometry.Offset(0f, size.height), end = androidx.compose.ui.geometry.Offset(cornerLen, size.height), strokeWidth = strokeW)
-                        drawLine(color, start = androidx.compose.ui.geometry.Offset(0f, size.height), end = androidx.compose.ui.geometry.Offset(0f, size.height - cornerLen), strokeWidth = strokeW)
-                        // Bottom-right corner
-                        drawLine(color, start = androidx.compose.ui.geometry.Offset(size.width, size.height), end = androidx.compose.ui.geometry.Offset(size.width - cornerLen, size.height), strokeWidth = strokeW)
-                        drawLine(color, start = androidx.compose.ui.geometry.Offset(size.width, size.height), end = androidx.compose.ui.geometry.Offset(size.width, size.height - cornerLen), strokeWidth = strokeW)
-                    }
-                }
-            }
-        }
-
-        Spacer(Modifier.height(16.dp))
-
-        Text(
-            stringResource(R.string.wallet_point_camera),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(horizontal = 32.dp)
+        com.wisp.app.ui.component.QrScanner(
+            onResult = { value ->
+                val cleaned = value
+                    .removePrefix("lightning:")
+                    .removePrefix("LIGHTNING:")
+                    .removePrefix("bitcoin:")
+                    .removePrefix("BITCOIN:")
+                onResult(cleaned)
+            },
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            promptText = stringResource(R.string.wallet_point_camera),
         )
-
-        Spacer(Modifier.height(16.dp))
     }
 }
 


### PR DESCRIPTION
## Summary
- New **Scan** tab in the drawer QR sheet — opens the camera and decodes Nostr QR codes (`npub`, `note`, `nprofile`, `nevent`, `naddr`), with or without the `nostr:` prefix, and navigates directly to the matching profile / thread / article.
- Extracts the existing wallet camera scanner into a reusable `QrScanner` component shared by the wallet and the drawer.
- Centralizes `NostrUriData` → route mapping in `Navigation.kt` so the deep-link handler and the scanner share a single implementation.
- Bumps version to **1.0.2 (76)**.

## Test plan
- [ ] Build & install: `JAVA_HOME=~/Downloads/android-studio/jbr ./gradlew installDebug`
- [ ] Drawer → QR icon → confirm three tabs (Nostr, Lightning if lud16 set, Scan)
- [ ] Tap Scan → grant camera permission → scan an `npub1…` QR → lands on profile
- [ ] Repeat with `note1`, `nprofile1`, `nevent1`, and `naddr1` (kind 30023)
- [ ] Repeat each with the `nostr:` prefix stripped → same behavior
- [ ] Scan an unrelated QR (e.g. a URL) → sheet stays open with "Not a Nostr QR" message
- [ ] Wallet → Send → Scan QR — confirm Lightning invoice scanning still works (regression check)
- [ ] Deny camera permission → permission-denied UI with Grant button