### PR TITLE
feat: post undo timer settings

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
@@ -3,6 +3,10 @@ package com.wisp.app.repo
 import android.content.Context
 
 class InterfacePreferences(context: Context) {
+    companion object {
+        val postUndoTimerOptions = listOf(5, 10, 15, 20, 30)
+    }
+
     private val prefs = context.getSharedPreferences("wisp_settings", Context.MODE_PRIVATE)
 
     fun getAccentColor(): Int = prefs.getInt("accent_color", 0xFFFF9800.toInt())
@@ -35,6 +39,18 @@ class InterfacePreferences(context: Context) {
     fun isLiveStreamsHidden(): Boolean = prefs.getBoolean("live_streams_hidden", false)
     fun setLiveStreamsHidden(hidden: Boolean) = prefs.edit().putBoolean("live_streams_hidden", hidden).apply()
 
+    fun isPostUndoTimerEnabled(): Boolean = prefs.getBoolean("post_undo_timer_enabled", true)
+    fun setPostUndoTimerEnabled(enabled: Boolean) = prefs.edit().putBoolean("post_undo_timer_enabled", enabled).apply()
+
+    fun getPostUndoTimerSeconds(): Int {
+        val stored = prefs.getInt("post_undo_timer_seconds", 10)
+        return if (stored in postUndoTimerOptions) stored else 10
+    }
+    fun setPostUndoTimerSeconds(seconds: Int) = prefs.edit().putInt("post_undo_timer_seconds", seconds).apply()
+
+    fun isPostUndoTimerForReplies(): Boolean = prefs.getBoolean("post_undo_timer_for_replies", false)
+    fun setPostUndoTimerForReplies(enabled: Boolean) = prefs.edit().putBoolean("post_undo_timer_for_replies", enabled).apply()
+
     /** Reset all interface preferences to defaults (called on full logout). */
     fun reset() {
         prefs.edit()
@@ -46,6 +62,9 @@ class InterfacePreferences(context: Context) {
             .remove("dark_theme")
             .remove("balance_hidden")
             .remove("live_streams_hidden")
+            .remove("post_undo_timer_enabled")
+            .remove("post_undo_timer_seconds")
+            .remove("post_undo_timer_for_replies")
             .apply()
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,6 +41,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -58,6 +60,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import android.content.Intent
 import androidx.compose.ui.platform.LocalContext
@@ -74,6 +77,9 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.collectAsState
 import java.text.DateFormat
@@ -500,6 +506,85 @@ fun InterfaceScreen(
                         interfacePrefs.setClientTagEnabled(it)
                     }
                 )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Posting section
+            Text(
+                text = stringResource(R.string.settings_posting),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            var undoTimerEnabled by remember { mutableStateOf(interfacePrefs.isPostUndoTimerEnabled()) }
+            var undoTimerSeconds by remember { mutableIntStateOf(interfacePrefs.getPostUndoTimerSeconds()) }
+            var undoTimerForReplies by remember { mutableStateOf(interfacePrefs.isPostUndoTimerForReplies()) }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.settings_undo_countdown), style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        stringResource(R.string.settings_undo_countdown_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = undoTimerEnabled,
+                    onCheckedChange = {
+                        undoTimerEnabled = it
+                        interfacePrefs.setPostUndoTimerEnabled(it)
+                    }
+                )
+            }
+
+            if (undoTimerEnabled) {
+                Spacer(Modifier.height(8.dp))
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    InterfacePreferences.postUndoTimerOptions.forEachIndexed { index, secs ->
+                        SegmentedButton(
+                            selected = undoTimerSeconds == secs,
+                            onClick = {
+                                undoTimerSeconds = secs
+                                interfacePrefs.setPostUndoTimerSeconds(secs)
+                            },
+                            shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = InterfacePreferences.postUndoTimerOptions.size
+                            )
+                        ) {
+                            Text("${secs}s")
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.settings_undo_include_replies), style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            stringResource(R.string.settings_undo_include_replies_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
+                        Switch(
+                            checked = undoTimerForReplies,
+                            onCheckedChange = {
+                                undoTimerForReplies = it
+                                interfacePrefs.setPostUndoTimerForReplies(it)
+                            }
+                        )
+                    }
+                }
             }
 
             Spacer(Modifier.height(24.dp))

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -507,8 +507,27 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             }
         }
 
+        val interfacePrefs = InterfacePreferences(getApplication())
+        val isReply = replyTo != null
+        val useTimer = interfacePrefs.isPostUndoTimerEnabled() && (!isReply || interfacePrefs.isPostUndoTimerForReplies())
+        val timerSeconds = interfacePrefs.getPostUndoTimerSeconds()
+
         _publishing.value = true
-        startCountdown(text, s, relayPool, replyTo, quoteTo, outboxRouter, onSuccess, onNotePublished, powManager, resolvedEmojis)
+        if (!useTimer || timerSeconds <= 0) {
+            viewModelScope.launch {
+                try {
+                    val sentCount = publishNote(text, s, relayPool, replyTo, quoteTo, outboxRouter, powManager, resolvedEmojis)
+                    if (sentCount == 0) return@launch
+                    onNotePublished?.invoke()
+                    onSuccess()
+                } catch (e: Exception) {
+                    _error.value = getApplication<Application>().getString(R.string.error_publish_failed, e.message ?: "Unknown error")
+                    _publishing.value = false
+                }
+            }
+            return
+        }
+        startCountdown(text, s, relayPool, replyTo, quoteTo, outboxRouter, onSuccess, onNotePublished, powManager, resolvedEmojis, timerSeconds)
     }
 
     private fun startCountdown(
@@ -521,7 +540,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         onSuccess: () -> Unit,
         onNotePublished: (() -> Unit)? = null,
         powManager: PowManager? = null,
-        resolvedEmojis: Map<String, String> = emptyMap()
+        resolvedEmojis: Map<String, String> = emptyMap(),
+        seconds: Int = 10
     ) {
         countdownJob?.cancel()
         pendingPublish = {
@@ -537,12 +557,13 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
                 }
             }
         }
-        _countdownSeconds.value = 10
+        _countdownSeconds.value = seconds
         countdownJob = viewModelScope.launch {
-            for (i in 10 downTo 1) {
-                _countdownSeconds.value = i
+            for (i in (seconds - 1) downTo 1) {
                 delay(1000)
+                _countdownSeconds.value = i
             }
+            delay(1000)
             _countdownSeconds.value = null
             pendingPublish?.invoke()
             pendingPublish = null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -507,6 +507,12 @@
     <string name="settings_client_tag">Client Tag</string>
     <string name="settings_tag_notes">Tag notes with Wisp</string>
     <string name="settings_tag_notes_description">Include a tag identifying Wisp as the client. This is visible to others.</string>
+    <string name="settings_posting">Posting</string>
+    <string name="settings_undo_countdown">Undo countdown</string>
+    <string name="settings_undo_countdown_description">Holds new posts for a few seconds before publishing so you can cancel.</string>
+    <string name="settings_undo_duration">Duration</string>
+    <string name="settings_undo_include_replies">Include replies</string>
+    <string name="settings_undo_include_replies_description">Off by default — replies send immediately. Turn on to apply the same countdown to replies.</string>
     <string name="settings_public_key">Public Key</string>
     <string name="settings_private_key">Private Key</string>
     <string name="settings_public_key_copied">Public key copied</string>


### PR DESCRIPTION
## Summary
- Adds configurable undo countdown in Settings → Interface → Posting
- "Undo countdown" toggle (default on), duration picker (5/10/15/20/30s, default 10), "Include replies" toggle (default off — replies send immediately)
- ComposeViewModel skips countdown when disabled or for replies unless opted in

Dedicated to Séimí Mac Síomón and Corndalorian.

Ports barrydeen/wisp-ios#34 to Android.

## Screenshot
<img width="1080" height="1920" alt="image" src="https://github.com/user-attachments/assets/935e3f85-1eb6-4dcc-a58e-3bffd7a2cbba" />

## Test plan
- [ ] Settings → Interface → Posting: toggle undo off, send a note — publishes without countdown
- [ ] Toggle undo on, send — countdown shows immediately on tap
- [ ] Change duration to 30s — countdown reflects new value
- [ ] Reply to a note — sends immediately by default
- [ ] Toggle Include replies on — replies now show the countdown