### PR TITLE
fix: reduce drawer menu item spacing

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -400,28 +400,28 @@ fun WispDrawerContent(
             label = { Text(stringResource(R.string.drawer_my_profile)) },
             selected = false,
             onClick = onProfile,
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         NavigationDrawerItem(
             icon = { Icon(Icons.Outlined.Home, contentDescription = null) },
             label = { Text(stringResource(R.string.drawer_feeds)) },
             selected = false,
             onClick = onFeed,
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         NavigationDrawerItem(
             icon = { Icon(Icons.Outlined.Search, contentDescription = null) },
             label = { Text(stringResource(R.string.title_search)) },
             selected = false,
             onClick = onSearch,
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         NavigationDrawerItem(
             icon = { Icon(Icons.Outlined.Email, contentDescription = null) },
             label = { Text(stringResource(R.string.nav_messages)) },
             selected = false,
             onClick = onMessages,
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         val useZapBolt = com.wisp.app.ui.util.useBoltIcon()
         NavigationDrawerItem(
@@ -439,21 +439,21 @@ fun WispDrawerContent(
             label = { Text(stringResource(R.string.nav_wallet)) },
             selected = false,
             onClick = onWallet,
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         NavigationDrawerItem(
             icon = { Icon(Icons.Outlined.FormatListBulleted, contentDescription = null) },
             label = { Text(stringResource(R.string.drawer_lists)) },
             selected = false,
             onClick = onLists,
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         NavigationDrawerItem(
             icon = { Icon(Icons.Outlined.Edit, contentDescription = null) },
             label = { Text(stringResource(R.string.drawer_drafts)) },
             selected = false,
             onClick = onDrafts,
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         var settingsExpanded by remember { mutableStateOf(false) }
         LaunchedEffect(settingsExpanded) {
@@ -474,7 +474,7 @@ fun WispDrawerContent(
             },
             selected = false,
             onClick = { settingsExpanded = !settingsExpanded },
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
         AnimatedVisibility(visible = settingsExpanded) {
             Column {
@@ -483,70 +483,70 @@ fun WispDrawerContent(
                     label = { Text(stringResource(R.string.drawer_interface)) },
                     selected = false,
                     onClick = onInterfaceSettings,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.Settings, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_relays)) },
                     selected = false,
                     onClick = onRelaySettings,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.Cloud, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_media_servers)) },
                     selected = false,
                     onClick = onMediaServers,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.Key, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_keys)) },
                     selected = false,
                     onClick = onKeys,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.Block, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_safety)) },
                     selected = false,
                     onClick = onSafety,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.Shield, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_proof_of_work)) },
                     selected = false,
                     onClick = onPowSettings,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.Hub, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_social_graph)) },
                     selected = false,
                     onClick = onSocialGraph,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.EmojiEmotions, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_custom_emojis)) },
                     selected = false,
                     onClick = onCustomEmojis,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.FavoriteBorder, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_relay_health)) },
                     selected = false,
                     onClick = onRelayHealth,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
                 NavigationDrawerItem(
                     icon = { Icon(Icons.Outlined.BugReport, contentDescription = null) },
                     label = { Text(stringResource(R.string.drawer_console)) },
                     selected = false,
                     onClick = onConsole,
-                    modifier = Modifier.padding(start = 36.dp, end = 12.dp)
+                    modifier = Modifier.height(48.dp).padding(start = 36.dp, end = 12.dp)
                 )
             }
         }
@@ -568,7 +568,7 @@ fun WispDrawerContent(
             },
             selected = false,
             onClick = { showLogoutDialog = true },
-            modifier = Modifier.padding(horizontal = 12.dp)
+            modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
 
         if (showLogoutDialog) {


### PR DESCRIPTION
## Summary
- Reduces NavigationDrawerItem height from default 56dp to 48dp
- Sidebar no longer requires excessive scrolling to reach bottom items

## Test plan
- [ ] Open drawer — all menu items visible with less scrolling
- [ ] Expand Settings sub-menu — items still readable and tappable