### PR TITLE
fix: improve Switch visibility in unchecked state

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt
@@ -423,7 +423,10 @@ fun ZapDialog(
                             },
                             colors = SwitchDefaults.colors(
                                 checkedThumbColor = LightningOrange,
-                                checkedTrackColor = LightningOrange.copy(alpha = 0.5f)
+                                checkedTrackColor = LightningOrange.copy(alpha = 0.5f),
+                                uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+                                uncheckedBorderColor = MaterialTheme.colorScheme.outline
                             )
                         )
                     }
@@ -458,7 +461,10 @@ fun ZapDialog(
                             enabled = canPrivateZap,
                             colors = SwitchDefaults.colors(
                                 checkedThumbColor = LightningOrange,
-                                checkedTrackColor = LightningOrange.copy(alpha = 0.5f)
+                                checkedTrackColor = LightningOrange.copy(alpha = 0.5f),
+                                uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+                                uncheckedBorderColor = MaterialTheme.colorScheme.outline
                             )
                         )
                     }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmListScreen.kt
@@ -67,6 +67,7 @@ import com.wisp.app.repo.GroupRoom
 import com.wisp.app.ui.component.GroupCard
 import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.viewmodel.DmListViewModel
+import com.wisp.app.ui.theme.wispSwitchColors
 import com.wisp.app.viewmodel.GroupListViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -608,7 +609,7 @@ private fun GroupFlagSwitch(
             Text(description, style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
-        Switch(checked = checked, onCheckedChange = onCheckedChange)
+        Switch(checked = checked, onCheckedChange = onCheckedChange, colors = wispSwitchColors())
     }
 }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/GroupDetailScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/GroupDetailScreen.kt
@@ -69,6 +69,7 @@ import com.wisp.app.relay.RelayPool
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.GroupRoom
 import com.wisp.app.ui.component.ProfilePicture
+import com.wisp.app.ui.theme.wispSwitchColors
 import com.wisp.app.viewmodel.GroupListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -271,7 +272,8 @@ fun GroupDetailScreen(
                         onCheckedChange = {
                             notified = it
                             groupListViewModel.setGroupNotified(relayUrl, groupId, it)
-                        }
+                        },
+                        colors = wispSwitchColors()
                     )
                 }
                 HorizontalDivider(thickness = 0.5.dp, color = MaterialTheme.colorScheme.outline)

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -70,6 +70,7 @@ import com.wisp.app.repo.InterfacePreferences
 import com.wisp.app.repo.LocaleRepository
 import com.wisp.app.ui.theme.ThemePreset
 import com.wisp.app.ui.theme.Themes
+import com.wisp.app.ui.theme.wispSwitchColors
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -230,7 +231,8 @@ fun InterfaceScreen(
                         isLargeText = it
                         interfacePrefs.setLargeText(it)
                         onChanged()
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
 
@@ -393,7 +395,8 @@ fun InterfaceScreen(
                         newNotesHidden = it
                         interfacePrefs.setNewNotesButtonHidden(it)
                         onChanged()
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
 
@@ -424,7 +427,8 @@ fun InterfaceScreen(
                         autoLoadMedia = it
                         interfacePrefs.setAutoLoadMedia(it)
                         onChanged()
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
             Spacer(Modifier.height(12.dp))
@@ -446,7 +450,8 @@ fun InterfaceScreen(
                         videoAutoPlay = it
                         interfacePrefs.setVideoAutoPlay(it)
                         onChanged()
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
             Spacer(Modifier.height(12.dp))
@@ -468,7 +473,8 @@ fun InterfaceScreen(
                         liveStreamsHidden = it
                         interfacePrefs.setLiveStreamsHidden(it)
                         onChanged()
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
 
@@ -498,7 +504,8 @@ fun InterfaceScreen(
                     onCheckedChange = {
                         clientTagEnabled = it
                         interfacePrefs.setClientTagEnabled(it)
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
 
@@ -531,7 +538,8 @@ fun InterfaceScreen(
                 }
                 Switch(
                     checked = fiatModeEnabled,
-                    onCheckedChange = { fiatPrefs.setFiatMode(it) }
+                    onCheckedChange = { fiatPrefs.setFiatMode(it) },
+                    colors = wispSwitchColors()
                 )
             }
 
@@ -684,7 +692,8 @@ fun InterfaceScreen(
                         onCheckedChange = {
                             diagnosticEnabled = it
                             DiagnosticLogger.setEnabled(context, it)
-                        }
+                        },
+                        colors = wispSwitchColors()
                     )
                 }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ListsHubScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ListsHubScreen.kt
@@ -55,6 +55,7 @@ import com.wisp.app.repo.BookmarkSetRepository
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.ListRepository
 import com.wisp.app.ui.component.ProfilePicture
+import com.wisp.app.ui.theme.wispSwitchColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -549,7 +550,8 @@ private fun CreateListDialog(
                     )
                     Switch(
                         checked = isPrivate,
-                        onCheckedChange = { isPrivate = it }
+                        onCheckedChange = { isPrivate = it },
+                        colors = wispSwitchColors()
                     )
                 }
                 if (isPrivate) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/NotificationsScreen.kt
@@ -128,7 +128,7 @@ import com.wisp.app.ui.component.ProfilePicture
 import com.wisp.app.ui.theme.WispThemeColors
 import com.wisp.app.viewmodel.NotificationFilter
 import com.wisp.app.viewmodel.NotificationsViewModel
-import androidx.compose.material3.SwitchDefaults
+import com.wisp.app.ui.theme.wispSwitchColors
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import com.wisp.app.R
@@ -540,11 +540,7 @@ private fun NotificationFilterSheet(
                     androidx.compose.material3.Switch(
                         checked = enabled,
                         onCheckedChange = { onToggleType(filter) },
-                        colors = SwitchDefaults.colors(
-                            uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
-                            uncheckedBorderColor = MaterialTheme.colorScheme.outline
-                        )
+                        colors = wispSwitchColors()
                     )
                 }
             }
@@ -580,11 +576,7 @@ private fun NotificationFilterSheet(
                 androidx.compose.material3.Switch(
                     checked = chatRoomsEnabled,
                     onCheckedChange = { onToggleChatRooms() },
-                    colors = SwitchDefaults.colors(
-                        uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
-                        uncheckedBorderColor = MaterialTheme.colorScheme.outline
-                    )
+                    colors = wispSwitchColors()
                 )
             }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/PowSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/PowSettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import com.wisp.app.repo.PowPreferences
+import com.wisp.app.ui.theme.wispSwitchColors
 import com.wisp.app.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -103,7 +104,8 @@ fun PowSettingsScreen(
                     onCheckedChange = {
                         noteEnabled = it
                         powPrefs.setNotePowEnabled(it)
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
             if (noteEnabled) {
@@ -144,7 +146,8 @@ fun PowSettingsScreen(
                     onCheckedChange = {
                         reactionEnabled = it
                         powPrefs.setReactionPowEnabled(it)
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
             if (reactionEnabled) {
@@ -185,7 +188,8 @@ fun PowSettingsScreen(
                     onCheckedChange = {
                         dmEnabled = it
                         powPrefs.setDmPowEnabled(it)
-                    }
+                    },
+                    colors = wispSwitchColors()
                 )
             }
             if (dmEnabled) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/RelayScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/RelayScreen.kt
@@ -51,6 +51,7 @@ import com.wisp.app.relay.RelayConfig
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.relay.RelaySetType
 import com.wisp.app.R
+import com.wisp.app.ui.theme.wispSwitchColors
 import com.wisp.app.viewmodel.RelayViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -253,7 +254,8 @@ private fun LocalRelayTab(config: LocalRelayConfig?, viewModel: RelayViewModel) 
             }
             Switch(
                 checked = config.enabled,
-                onCheckedChange = { viewModel.toggleLocalRelayEnabled() }
+                onCheckedChange = { viewModel.toggleLocalRelayEnabled() },
+                colors = wispSwitchColors()
             )
         }
 

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyFiltersTab.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyFiltersTab.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.wisp.app.R
 import com.wisp.app.repo.ExtendedNetworkCache
 import com.wisp.app.repo.SafetyPreferences
+import com.wisp.app.ui.theme.wispSwitchColors
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
@@ -60,7 +61,8 @@ fun SafetyFiltersTab(
             }
             Switch(
                 checked = spamEnabled,
-                onCheckedChange = { safetyPrefs.setSpamFilterEnabled(it) }
+                onCheckedChange = { safetyPrefs.setSpamFilterEnabled(it) },
+                colors = wispSwitchColors()
             )
         }
         Text(
@@ -90,7 +92,8 @@ fun SafetyFiltersTab(
                 onCheckedChange = {
                     safetyPrefs.setWotFilterEnabled(it)
                     onWotToggled()
-                }
+                },
+                colors = wispSwitchColors()
             )
         }
         Text(

--- a/app/src/main/kotlin/com/wisp/app/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/theme/Theme.kt
@@ -1,6 +1,8 @@
 package com.wisp.app.ui.theme
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwitchColors
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.Typography
@@ -39,6 +41,13 @@ object WispThemeColors {
     val bookmarkColor: Color @Composable get() = LocalWispColors.current.bookmarkColor
     val paidColor: Color @Composable get() = LocalWispColors.current.paidColor
 }
+
+@Composable
+fun wispSwitchColors(): SwitchColors = SwitchDefaults.colors(
+    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+    uncheckedBorderColor = MaterialTheme.colorScheme.outline
+)
 
 private val WispTypography = Typography(
     titleLarge = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold),


### PR DESCRIPTION
## Summary
- Adds `wispSwitchColors()` helper in Theme.kt with visible unchecked thumb/track/border colors
- Applied to all Switch instances across 10 files so off-state toggles are distinguishable from the background
- Consolidates duplicate inline colors from NotificationsScreen into the shared helper

## Test plan
- [ ] Open Settings → Interface — all off toggles show visible thumb and track outline
- [ ] Check Safety, PoW, Relay, Notifications, Groups, Lists screens — same fix
- [ ] Zap dialog anonymous/private toggles — unchecked state visible, checked state still orange