### PR TITLE
feat: loop inline mp4 videos in note cards

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -2214,12 +2214,14 @@ internal fun InlineVideoPlayerWithFullscreen(meta: MediaMeta, onFullScreen: (pos
     var isBuffering by remember { mutableStateOf(false) }
 
     val exoPlayer = remember(url) {
-        PipController.reclaimPlayer(url)
+        (PipController.reclaimPlayer(url)
             ?: HttpClientFactory.createExoPlayer(context).apply {
                 setMediaItem(MediaItem.fromUri(Uri.parse(url)))
                 prepare()
                 volume = if (globalMuted.value) 0f else 1f
                 playWhenReady = false
+            }).apply {
+                repeatMode = Player.REPEAT_MODE_ONE
             }
     }
 
@@ -2491,12 +2493,14 @@ private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
     var isPlaying by remember { mutableStateOf(false) }
     var isBuffering by remember { mutableStateOf(false) }
     val exoPlayer = remember(url) {
-        PipController.reclaimPlayer(url)
+        (PipController.reclaimPlayer(url)
             ?: HttpClientFactory.createExoPlayer(context).apply {
                 setMediaItem(MediaItem.fromUri(Uri.parse(url)))
                 prepare()
                 volume = if (globalMuted.value) 0f else 1f
                 playWhenReady = false
+            }).apply {
+                repeatMode = Player.REPEAT_MODE_ONE
             }
     }
 


### PR DESCRIPTION
## Summary
- Inline MP4 videos rendered inside RichContent note cards now auto-repeat (`Player.REPEAT_MODE_ONE`).
- Applied to both `InlineVideoPlayerWithFullscreen` and `InlineVideoPlayer`, including the PiP-reclaimed player path so reclaim from picture-in-picture also loops.
- Fullscreen and audio playback paths are untouched.

## Test plan
- [ ] Open a note containing an MP4 — confirm it loops on completion when autoplay is on.
- [ ] Tap to play an MP4 with autoplay disabled — confirm it loops once started.
- [ ] Enter PiP from fullscreen, return to inline — confirm reclaimed player still loops.
- [ ] Verify fullscreen video still ends/pauses normally (not affected by this change).
- [ ] Verify audio playback is unchanged.