### PR TITLE
fix: dispatch Relay.connect() off the calling thread to avoid ANR

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/Relay.kt
@@ -50,6 +50,14 @@ class Relay(
             Thread(r, "relay-reconnect").apply { isDaemon = true }
         }
 
+        /** OkHttpClient.newWebSocket() can block on the shared TaskRunner lock for several
+         *  seconds under contention — running it on the main thread causes ANRs. Dispatch
+         *  connect() through this pool so callers (UI handlers, RelayPool.sendToRelayOrEphemeral)
+         *  never wait on it. Sized to allow a few parallel connects without unbounded thread growth. */
+        private val connectExecutor = Executors.newFixedThreadPool(4) { r ->
+            Thread(r, "relay-connect").apply { isDaemon = true }
+        }
+
         fun createClient(): OkHttpClient = HttpClientFactory.createRelayClient()
     }
 
@@ -79,6 +87,10 @@ class Relay(
     var onBytesSent: ((url: String, size: Int) -> Unit)? = null
 
     fun connect() {
+        connectExecutor.execute { connectBlocking() }
+    }
+
+    private fun connectBlocking() {
         synchronized(connectLock) {
             if (isConnected || webSocket != null) return
 


### PR DESCRIPTION
## Summary
- Move `Relay.connect()` onto a dedicated background thread pool so callers (UI handlers, `RelayPool.sendToRelayOrEphemeral`) never block on `OkHttpClient.newWebSocket()`.
- Fixes ANRs observed in debug builds where the main thread was stuck >5s inside `OkHttpClient.newWebSocket()` waiting on OkHttp's shared `TaskRunner` lock.

## Root cause
ANR stack from GrapheneOS:

```
"main" prio=5 tid=1 Blocked
  at okhttp3.internal.concurrent.TaskRunner.newQueue(TaskRunner.kt:231)
  - waiting to lock <0x0217d74b> (a okhttp3.internal.concurrent.TaskRunner) held by thread 126
  at okhttp3.internal.ws.RealWebSocket.<init>(RealWebSocket.kt:85)
  at okhttp3.OkHttpClient.newWebSocket(OkHttpClient.kt:272)
  at com.wisp.app.relay.Relay.connect(Relay.kt:126)
  at com.wisp.app.relay.RelayPool.sendToRelayOrEphemeral$lambda$39(RelayPool.kt:946)
```

UI callbacks like `Navigation.kt:1700` (`onZap`) call `relayPool.sendToRelayOrEphemeral(...)` directly on the main thread; when no ephemeral exists yet, it synchronously calls `relay.connect()` → `client.newWebSocket()`, which blocks waiting for OkHttp's `TaskRunner` lock.

## Fix
- Add a 4-thread `connectExecutor` to `Relay`'s companion object.
- `connect()` now posts to that executor; the body moved to a private `connectBlocking()`.
- Safe because all callers either fire-and-forget or already poll `isConnected` afterward (`RelayProber:113`). `send()` already queues to `pendingMessages` while the WebSocket is pending and drains in `onOpen`.

## Test plan
- [ ] Build debug APK and install
- [ ] Open a group room and tap zap — confirm no main-thread freeze
- [ ] Trigger reconnect-all (background → resume) and verify all relays reconnect
- [ ] Check `RelayProber` bootstrap still completes (it polls `isConnected` with a 5s timeout)