### PR TITLE
fix: stop restoring stale tab back stacks on bottom-nav switch

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -27,7 +27,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -619,11 +618,8 @@ fun WispNavHost(
                             } else {
                                 if (tab == BottomTab.WALLET) walletViewModel.navigateHome()
                                 navController.navigate(tab.route) {
-                                    popUpTo(navController.graph.findStartDestination().id) {
-                                        saveState = true
-                                    }
+                                    popUpTo(Routes.FEED) { inclusive = false }
                                     launchSingleTop = true
-                                    restoreState = true
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

PR #514 (\`fix/tab-switch-jank\`) introduced two UX regressions in the bottom-nav tab handler:

- Tapping a bottom-nav tab restored the tab's saved back stack, returning the user to a previously-open thread instead of the tab's main feed/notifications screen.
- The graph's start destination (\`Routes.LOADING\`) is popped inclusive once the loading screen finishes, so \`popUpTo(graph.findStartDestination().id) { saveState = true }\` never matched. The resulting back stack could surface the splash/auth screen on system back from Notifications, which the user perceived as a logout.

Reverts that block to the pre-#514 \`popUpTo(Routes.FEED) { inclusive = false }\` + \`launchSingleTop = true\` pattern. The user always lands on the tab's main screen, and the back stack stays shallow so the BackHandler behaves predictably.

The \`refreshDmsAndNotifications()\` throttle introduced alongside the broken nav block is **preserved** — that part addresses real REQ churn jank and is independent of how the back stack is structured.

## Test plan

- [ ] Open thread from FEED, tap NOTIFICATIONS → lands on Notifications list (not the thread)
- [ ] Open thread from FEED, tap NOTIFICATIONS, tap HOME → lands on FEED (not the thread)
- [ ] Open thread from NOTIFICATIONS, tap any other tab → does not return to thread
- [ ] From FEED, tap NOTIFICATIONS, press system back → lands on FEED (no splash/auth)
- [ ] Open thread from FEED, press back → returns to FEED
- [ ] Open thread from NOTIFICATIONS, press back → returns to NOTIFICATIONS
- [ ] Rapidly bounce HOME / MESSAGES / NOTIFICATIONS five+ times → \`refreshDmsAndNotifications()\` still throttled to once per 30s