### PR TITLE
chore: bump version to 1.0.5 (79)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = baseApplicationId
         minSdk = 26
         targetSdk = 35
-        versionCode = 78
-        versionName = "1.0.4"
+        versionCode = 79
+        versionName = "1.0.5"
         resValue("string", "app_name", "Wisp")
 
         ndk {


### PR DESCRIPTION
## Summary
- Bump `versionName` to 1.0.5 and `versionCode` to 79.

## Test plan
- [ ] Release build assembles cleanly