### PR TITLE
feat: register-style fiat input on the zap dialog

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/ExchangeRateRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/ExchangeRateRepository.kt
@@ -116,6 +116,17 @@ object ExchangeRateRepository {
         return sats.toDouble() / 100_000_000.0 * btcPrice
     }
 
+    /**
+     * Inverse of [satsToFiat] — convert a fiat amount expressed in the
+     * currency's major unit (dollars, euros, etc.) into sats. Returns null
+     * when no rate is cached. Used by the zap sheet's custom-amount input
+     * in fiat mode where the user types `1.50` for a $1.50 zap.
+     */
+    fun fiatToSats(majorAmount: Double, currency: String): Long? {
+        val btcPrice = _rates.value[currency.uppercase()] ?: return null
+        return (majorAmount / btcPrice * 100_000_000.0).toLong()
+    }
+
     fun currencyFor(code: String): FiatCurrency =
         SUPPORTED.firstOrNull { it.code.equals(code, ignoreCase = true) } ?: SUPPORTED[0]
 

--- a/app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt
@@ -75,12 +75,18 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.wisp.app.R
+import com.wisp.app.repo.ExchangeRateRepository
+import com.wisp.app.repo.FiatCurrency
 import com.wisp.app.repo.FiatPreferences
 import com.wisp.app.repo.ZapPreferences
 import com.wisp.app.repo.ZapPreset
@@ -133,7 +139,7 @@ fun ZapDialog(
     val context = LocalContext.current
     val fiatPrefs = remember { FiatPreferences.get(context) }
     val fiatMode by fiatPrefs.fiatMode.collectAsState()
-    @Suppress("unused_variable") val fiatCurrency by fiatPrefs.currency.collectAsState()
+    val fiatCurrency by fiatPrefs.currency.collectAsState()
     var presets by remember { mutableStateOf(ZapPreferences(context).getPresets().sortedBy { it.amountSats }) }
     var selectedPreset by remember { mutableStateOf<ZapPreset?>(presets.firstOrNull()) }
     var isCustom by remember { mutableStateOf(false) }
@@ -160,7 +166,17 @@ fun ZapDialog(
     }
 
     val effectiveAmount = if (isCustom) {
-        customAmount.toLongOrNull() ?: 0L
+        if (fiatMode) {
+            // Register-style: customAmount is a digit-only string that's
+            // interpreted as cents (last two digits). "21" → $0.21,
+            // "2100" → $21.00.
+            val cents = customAmount.toLongOrNull() ?: 0L
+            if (cents > 0) {
+                ExchangeRateRepository.fiatToSats(cents.toDouble() / 100.0, fiatCurrency) ?: 0L
+            } else 0L
+        } else {
+            customAmount.toLongOrNull() ?: 0L
+        }
     } else {
         selectedPreset?.amountSats ?: 0L
     }
@@ -191,8 +207,10 @@ fun ZapDialog(
                     modifier = Modifier.padding(24.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    // Header with animated bolt
-                    AnimatedBoltHeader()
+                    // Header with animated bolt — switches to a coin-stack
+                    // glyph in fiat mode so the icon reads as money rather
+                    // than zap. Mirrors the iOS dynamic `zapImage`.
+                    AnimatedBoltHeader(fiatMode = fiatMode)
 
                     Spacer(Modifier.height(8.dp))
 
@@ -207,11 +225,33 @@ fun ZapDialog(
 
                     Spacer(Modifier.height(4.dp))
 
-                    // Amount display — tap to edit directly
+                    // Amount display — tap to edit directly. In fiat mode the
+                    // input is interpreted register-style: digits fill from the
+                    // cents place ("21" → $0.21, "2100" → $21.00). The field
+                    // is bound to the raw digit string and a
+                    // `VisualTransformation` renders it as the formatted
+                    // dollar string with the cursor pinned to the end — that
+                    // way backspace removes the rightmost digit and Compose
+                    // can map cursor positions cleanly (binding the field
+                    // directly to the formatted string and rewriting it on
+                    // every keystroke broke backspace because Compose
+                    // couldn't map the cursor between the old and new
+                    // formatted strings).
+                    val currency = if (fiatMode) {
+                        ExchangeRateRepository.currencyFor(fiatCurrency)
+                    } else null
+                    val centsTransformation = remember(currency) {
+                        currency?.let { CentsVisualTransformation(it) }
+                    }
                     if (isCustom) {
                         BasicTextField(
                             value = customAmount,
-                            onValueChange = { customAmount = it.filter { c -> c.isDigit() } },
+                            onValueChange = { new ->
+                                customAmount = if (fiatMode) sanitizeFiatInput(new) else new.filter { c -> c.isDigit() }
+                            },
+                            visualTransformation = if (fiatMode && centsTransformation != null) {
+                                centsTransformation
+                            } else VisualTransformation.None,
                             textStyle = MaterialTheme.typography.displaySmall.copy(
                                 fontWeight = FontWeight.Bold,
                                 color = LightningOrange,
@@ -227,7 +267,7 @@ fun ZapDialog(
                                 Box(contentAlignment = Alignment.Center) {
                                     if (customAmount.isEmpty()) {
                                         Text(
-                                            text = "0",
+                                            text = if (fiatMode) "${currency?.symbol ?: ""}0.00" else "0",
                                             style = MaterialTheme.typography.displaySmall,
                                             fontWeight = FontWeight.Bold,
                                             color = LightningOrange.copy(alpha = 0.3f)
@@ -252,7 +292,15 @@ fun ZapDialog(
                             color = LightningOrange,
                             modifier = Modifier
                                 .clickable {
-                                    customAmount = effectiveAmount.toString()
+                                    // Seed the field with the equivalent cents
+                                    // digit string so the user can refine the
+                                    // selected preset rather than starting from
+                                    // empty in fiat mode.
+                                    customAmount = if (fiatMode) {
+                                        seedRegisterCents(effectiveAmount, fiatCurrency)
+                                    } else {
+                                        effectiveAmount.toString()
+                                    }
                                     isCustom = true
                                 }
                                 .padding(vertical = 4.dp)
@@ -347,8 +395,21 @@ fun ZapDialog(
                         Column {
                             OutlinedTextField(
                                 value = customAmount,
-                                onValueChange = { customAmount = it.filter { c -> c.isDigit() } },
-                                label = { Text(stringResource(R.string.placeholder_amount_sats)) },
+                                onValueChange = { new ->
+                                    customAmount = if (fiatMode) sanitizeFiatInput(new) else new.filter { c -> c.isDigit() }
+                                },
+                                visualTransformation = if (fiatMode && centsTransformation != null) {
+                                    centsTransformation
+                                } else VisualTransformation.None,
+                                label = {
+                                    Text(
+                                        if (fiatMode) {
+                                            stringResource(R.string.placeholder_amount_currency, currency?.symbol ?: "")
+                                        } else {
+                                            stringResource(R.string.placeholder_amount_sats)
+                                        }
+                                    )
+                                },
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                                 modifier = Modifier.fillMaxWidth(),
                                 singleLine = true,
@@ -359,7 +420,10 @@ fun ZapDialog(
                                     cursorColor = LightningOrange
                                 )
                             )
-                            val saveAmount = customAmount.toLongOrNull() ?: 0L
+                            // Save-as-preset only makes sense for whole-sat
+                            // amounts; in fiat mode we always derive sats
+                            // through the exchange rate, which can drift.
+                            val saveAmount = if (fiatMode) 0L else (customAmount.toLongOrNull() ?: 0L)
                             if (saveAmount > 0) {
                                 Spacer(Modifier.height(6.dp))
                                 TextButton(
@@ -496,7 +560,9 @@ fun ZapDialog(
                             shape = RoundedCornerShape(16.dp)
                         ) {
                             Icon(
-                                painter = painterResource(R.drawable.ic_bolt),
+                                painter = painterResource(
+                                    if (fiatMode) R.drawable.ic_coin_stack else R.drawable.ic_bolt
+                                ),
                                 contentDescription = null,
                                 modifier = Modifier.size(15.dp)
                             )
@@ -521,8 +587,71 @@ fun ZapDialog(
 
 }
 
+/**
+ * Register-style sanitiser: digits only. The fiat-mode amount field is
+ * interpreted as integer cents (last two digits = cents place), so
+ * decimal points and other punctuation in user input are stripped — the
+ * decimal in the displayed string ("$0.21") is presentation-only.
+ */
+private fun sanitizeFiatInput(text: String): String =
+    text.filter { it.isDigit() }
+
+/**
+ * Format a digit-only string as `$X.XX` register-style — last two digits
+ * are cents, everything before them is whole dollars. "21" → "$0.21",
+ * "2100" → "$21.00". Used for the empty-field placeholder; the live
+ * field display goes through [CentsVisualTransformation] so Compose's
+ * cursor mapping works correctly.
+ */
+private fun formatRegisterCents(digits: String, currency: FiatCurrency): String {
+    val cents = digits.toLongOrNull() ?: 0L
+    val dollars = cents.toDouble() / 100.0
+    val formatter = java.text.DecimalFormat("#,##0.00")
+    return "${currency.symbol}${formatter.format(dollars)}"
+}
+
+/**
+ * Renders a digit-only field value as the formatted register-style
+ * dollar string and pegs the cursor to the end. The previous approach
+ * — binding the TextField directly to the formatted string and
+ * re-formatting in `onValueChange` — broke backspace on Android: when
+ * Compose's internal text changed from "$0.2" (after the user removed
+ * the last char) to our re-formatted "$0.02", Compose couldn't map the
+ * old cursor position into the new string and effectively snapped it
+ * to the start, so subsequent backspaces just moved the cursor instead
+ * of deleting. With a [VisualTransformation] the field is bound to the
+ * raw digits, the cursor lives in raw-string coordinates, and the
+ * `OffsetMapping` always points to the end of the formatted view.
+ */
+private class CentsVisualTransformation(
+    private val currency: FiatCurrency
+) : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val formatted = formatRegisterCents(text.text, currency)
+        val rawLength = text.text.length
+        val transformedLength = formatted.length
+        val mapping = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int = transformedLength
+            override fun transformedToOriginal(offset: Int): Int = rawLength
+        }
+        return TransformedText(AnnotatedString(formatted), mapping)
+    }
+}
+
+/**
+ * Cents-as-digits seed for the custom-amount field. Converts the current
+ * sats amount through the cached rate, rounds to the nearest cent, and
+ * returns the digit string (e.g. 1234 cents → "1234"). Empty for zero
+ * or when no rate is cached.
+ */
+private fun seedRegisterCents(amountSats: Long, currencyCode: String): String {
+    val dollars = ExchangeRateRepository.satsToFiat(amountSats, currencyCode) ?: return ""
+    val cents = (dollars * 100.0).toLong()
+    return if (cents > 0) cents.toString() else ""
+}
+
 @Composable
-private fun AnimatedBoltHeader() {
+private fun AnimatedBoltHeader(fiatMode: Boolean = false) {
     val infiniteTransition = rememberInfiniteTransition(label = "bolt")
 
     val glowAlpha by infiniteTransition.animateFloat(
@@ -567,9 +696,11 @@ private fun AnimatedBoltHeader() {
                 )
         )
 
-        // Bolt icon
+        // Bolt / coin-stack icon depending on mode
         Icon(
-            painter = painterResource(R.drawable.ic_bolt),
+            painter = painterResource(
+                if (fiatMode) R.drawable.ic_coin_stack else R.drawable.ic_bolt
+            ),
             contentDescription = null,
             tint = zapColor,
             modifier = Modifier

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt
@@ -455,11 +455,18 @@ private fun StreamInfoBar(
                             )
                         }
                         Spacer(Modifier.width(4.dp))
+                        // In fiat mode the surrounding wallet UX uses
+                        // "Send Money" / "Send $X.XX" wording — match it
+                        // here so the user doesn't see "Zap" / "Zapping…"
+                        // alongside dollar amounts on the same screen.
+                        val ctx = LocalContext.current
+                        val zapFiatPrefs = remember { com.wisp.app.repo.FiatPreferences.get(ctx) }
+                        val zapFiatMode by zapFiatPrefs.fiatMode.collectAsState()
                         Text(
                             text = when {
                                 isZapAnimating -> "Sent!"
-                                isZapInProgress -> "Zapping..."
-                                else -> "Zap"
+                                isZapInProgress -> if (zapFiatMode) "Sending..." else "Zapping..."
+                                else -> if (zapFiatMode) "Send" else "Zap"
                             },
                             style = MaterialTheme.typography.labelMedium,
                             fontWeight = FontWeight.Bold,

--- a/app/src/main/kotlin/com/wisp/app/ui/util/AmountFormatter.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/util/AmountFormatter.kt
@@ -59,11 +59,16 @@ object AmountFormatter {
 
     private fun renderCurrency(amount: Double, currency: FiatCurrency): String {
         val abs = kotlin.math.abs(amount)
+        // Sub-dollar tiers use `#` (optional) past the decimal so trailing
+        // zeros drop — "$0.84" instead of "$0.840", "$0.8" instead of
+        // "$0.800". The cap grows as the value shrinks so we don't lose
+        // precision on tiny amounts. Whole-dollar amounts keep two decimal
+        // places (the expected retail convention: "$1.00", not "$1").
         val pattern = when {
             abs == 0.0 -> "#,##0.00"
-            abs < 0.001 -> "#,##0.000000"
-            abs < 0.01 -> "#,##0.0000"
-            abs < 1.0 -> "#,##0.000"
+            abs < 0.001 -> "#,##0.######"
+            abs < 0.01 -> "#,##0.####"
+            abs < 1.0 -> "#,##0.###"
             abs >= 1000.0 -> "#,##0"
             else -> "#,##0.00"
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="placeholder_lightning_or_invoice">Lightning address or invoice</string>
     <string name="placeholder_user_domain">user@domain.com or lnbc…</string>
     <string name="placeholder_amount_sats">Amount (sats)</string>
+    <string name="placeholder_amount_currency">Amount (%1$s)</string>
     <string name="placeholder_message_optional">Message (optional)</string>
     <string name="placeholder_new_list_name">New list name</string>
     <string name="placeholder_add_word_phrase">Add a word or phrase</string>
@@ -833,7 +834,7 @@
     <string name="fiat_settings_rate_line">1 BTC ≈ %1$s %2$,.2f</string>
 
     <string name="zap_send_money">Send Money</string>
-    <string name="zap_x_amount">Zap %1$s</string>
+    <string name="zap_x_amount">Send %1$s</string>
 
     <string name="amount_sats_format">%1$s sats</string>
     <string name="wallet_fee_money">fee: %1$s</string>


### PR DESCRIPTION
## Summary

Mirrors the iOS PR (https://github.com/barrydeen/wisp-ios/pull/82). Custom-amount input on the zap dialog is fiat-aware. In fiat mode the user types digits register-style — they fill from the cents place, so `21` reads as `$0.21` and `2100` reads as `$21.00`. The hero amount, custom input, and Send button all show the formatted dollar string with the configured currency's symbol. The Send-button label is "Send $X.XX" (was "Zap $X.XX") and the in-progress label on the live-stream zap button is "Sending…" / "Send" instead of "Zapping…" / "Zap" when fiat mode is on. Sub-dollar fiat amounts across the app drop trailing zeros (`$0.84` instead of `$0.840`, `$0.8` instead of `$0.800`).

### Implementation notes

- **`VisualTransformation` for the live cursor**: the field is bound to the raw digit string ("21") and a `CentsVisualTransformation` renders the formatted dollar view (`$0.21`). Compose's cursor lives in raw-string coordinates and the `OffsetMapping` pegs it to the end of the formatted view, so backspace removes the rightmost digit cleanly. The earlier String-only attempt — bind the field to the formatted string and re-format in `onValueChange` — broke backspace on Android: when Compose's internal text changed from `$0.2` to our re-formatted `$0.02`, it couldn't map the old cursor position into the new string and snapped it to the start, so subsequent backspaces just moved the cursor instead of deleting.
- **`ExchangeRateRepository.fiatToSats(majorAmount, currency)`** — inverse of `satsToFiat`. Used at the input boundary to convert `(cents / 100)` dollars → sats via the cached BTC-to-fiat rate.
- **`AmountFormatter.renderCurrency`** patterns switch to `#` (optional) past the decimal for sub-dollar tiers so trailing zeros drop. Whole-dollar amounts still pad to two places (`$1.00`) matching retail convention.
- **`zap_x_amount`** string changes from `"Zap %1\$s"` to `"Send %1\$s"` (English only — other locales fall back to English; this string isn't translated yet).

### Files

- `app/src/main/kotlin/com/wisp/app/repo/ExchangeRateRepository.kt`
- `app/src/main/kotlin/com/wisp/app/ui/component/ZapDialog.kt`
- `app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt`
- `app/src/main/kotlin/com/wisp/app/ui/util/AmountFormatter.kt`
- `app/src/main/res/values/strings.xml`

## Test plan
- [ ] Fiat mode on, tap a profile or post → Zap → Custom → type `21` → field reads `$0.21`, hero matches, Send button reads `Send $0.21`.
- [ ] Continue to type `2100` → field reads `$21.00`. Backspace → `$2.10` → `$0.21`. Cursor stays at the end; backspace removes the rightmost digit (no cursor-stuck-left-of-symbol bug).
- [ ] Open a live stream in fiat mode → header zap button reads `Send` / `Sending…` / `Sent!` (was `Zap` / `Zapping…` / `Sent!`). Toggle fiat mode off — wording reverts.
- [ ] Sub-dollar quick-amount chips render as `$0.84` (not `$0.840`); whole-dollar values still render as `$1.00`.
- [ ] Fiat mode off — input is plain integer sats, button reads `Zap N sats`, no behavioural change.