### PR TITLE
fix(wallet): disable relay backup writes for NIP-46 remote-signer accounts

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -424,6 +424,7 @@ fun WalletScreen(
                         relayBackupCheckLoading = viewModel.relayBackupCheckLoading.collectAsState().value,
                         deleteBackupStatus = viewModel.deleteBackupStatus.collectAsState().value,
                         isLoggedIn = viewModel.keyRepo.isLoggedIn(),
+                        relayBackupSupported = viewModel.isRelayBackupSupported(),
                         onCheckRelayBackups = { viewModel.checkRelayBackupStatuses() },
                         onDeleteRelayBackup = { viewModel.deleteRelayBackup() },
                         modifier = Modifier.padding(padding)
@@ -2647,6 +2648,7 @@ private fun WalletSettingsContent(
     relayBackupCheckLoading: Boolean = false,
     deleteBackupStatus: DeleteBackupStatus = DeleteBackupStatus.Idle,
     isLoggedIn: Boolean = false,
+    relayBackupSupported: Boolean = true,
     onCheckRelayBackups: () -> Unit = {},
     onDeleteRelayBackup: () -> Unit = {},
     modifier: Modifier = Modifier
@@ -2853,19 +2855,21 @@ private fun WalletSettingsContent(
                 Text("Backup Recovery Phrase")
             }
 
-            Spacer(Modifier.height(8.dp))
+            if (relayBackupSupported) {
+                Spacer(Modifier.height(8.dp))
 
-            OutlinedButton(
-                onClick = onBackupToRelay,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Icon(Icons.Default.CloudUpload, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
-                Text("Backup to Nostr Relays")
+                OutlinedButton(
+                    onClick = onBackupToRelay,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Default.CloudUpload, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Backup to Nostr Relays")
+                }
             }
 
-            // Relay backup status section (when logged in)
-            if (isLoggedIn) {
+            // Relay backup status section (when logged in and supported)
+            if (isLoggedIn && relayBackupSupported) {
                 Spacer(Modifier.height(16.dp))
 
                 Row(

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
@@ -1301,6 +1301,13 @@ class WalletViewModel(
 
     // --- Relay Backup / Restore ---
 
+    /// False for NIP-46 remote-signer accounts. Relay backup writes are gated
+    /// off as a precaution until cross-client backup decryption is verified for
+    /// every remote-signer path the app might be used with. Restore stays
+    /// enabled — legacy backups that already decrypt remain usable.
+    fun isRelayBackupSupported(): Boolean =
+        keyRepo.getSigningMode() != SigningMode.REMOTE
+
     private fun buildSigner(): NostrSigner? {
         return when (keyRepo.getSigningMode()) {
             SigningMode.LOCAL -> {
@@ -1318,6 +1325,13 @@ class WalletViewModel(
     }
 
     fun backupToRelay() {
+        if (!isRelayBackupSupported()) {
+            _backupStatus.value = BackupStatus.Error(
+                "Cloud backup is disabled for remote-signer accounts. " +
+                    "Write down your recovery phrase instead."
+            )
+            return
+        }
         val mnemonic = sparkRepo.getMnemonic() ?: return
         val signer = buildSigner() ?: run {
             _backupStatus.value = BackupStatus.Error("No signing key available")
@@ -1509,6 +1523,10 @@ class WalletViewModel(
     // --- Relay Backup Status & Delete ---
 
     fun checkRelayBackupStatuses() {
+        // No relay backup is ever written for remote-signer accounts, so the
+        // auto-check on connect would always come back "missing" and surface a
+        // bogus "needs backup" indicator. Skip entirely for those accounts.
+        if (!isRelayBackupSupported()) return
         val mnemonic = sparkRepo.getMnemonic() ?: return
         val pubkey = keyRepo.getPubkeyHex() ?: return
 


### PR DESCRIPTION
## Summary

Disables relay backup writes (kind:30078 NIP-78 events with d-tag `spark-wallet-backup:<walletId>`) for accounts using a **NIP-46 remote signer**. Restore-from-relays stays enabled so any legacy backup that does decrypt remains usable.

This is a precautionary measure until cross-client backup decryption is verified for every remote-signer path the app might be used with. Some remote-signer implementations have produced NIP-44 ciphertext that can't be decrypted by other clients using the same nsec, which would leave the user with a backup event on relays that they cannot restore from elsewhere. Until we can verify each path round-trips end-to-end (write via Wisp + remote signer → restore via a different client + same nsec, and vice versa), it's safer not to encourage users on those paths to create new backups they may not be able to recover.

## Behaviour

| Account type | Relay backup writes | Restore from relays |
| --- | --- | --- |
| Local nsec | ✅ unchanged | ✅ unchanged |
| NIP-46 remote signer | 🚫 hidden in UI, blocked at viewmodel | ✅ unchanged |

The Security section in Wallet Settings shows only the "Backup Recovery Phrase" entry for remote-signer accounts — no "Backup to Nostr Relays" button, no per-relay status indicator. Recovery-phrase backup (write-it-down) remains the path for those users.

## Changes

- `WalletViewModel`: new `isRelayBackupSupported()` returning false when `keyRepo.getSigningMode() == SigningMode.REMOTE`. `backupToRelay()` early-returns with an error if called for a remote-signer account, even if a UI path slips through. `checkRelayBackupStatuses()` early-returns so the "backup missing" red banner on the wallet home never fires for accounts that will never write a backup.
- `WalletScreen.WalletSettingsContent`: the "Backup to Nostr Relays" `OutlinedButton` and the per-relay status block are wrapped in `if (relayBackupSupported)`. The 8.dp spacer between the recovery-phrase button and the relay-backup button moves inside that guard so there's no orphan vertical gap.

## Out of scope

- No change to the signup auto-backup path (always runs against a freshly-generated local nsec by construction).
- No change to restore. Legacy backups on relays from before this gate still decrypt and restore normally if the original encrypt path was correct.
- No tombstoning of existing backups.

## Cross-platform

The iOS equivalent is at https://github.com/barrydeen/wisp-ios/pull/105. Both PRs implement the same gate so behaviour is consistent across the two platforms.

## Test plan

- [x] Signed in via a NIP-46 remote signer: open Wallet → Settings → Security. Confirm only "Backup Recovery Phrase" is shown; no "Backup to Nostr Relays" button, no relay-status indicator.
- [x] Signed in via a NIP-46 remote signer: scroll the wallet home. Confirm the red "Backup missing" warning banner does not appear.
- [x] Signed in with a local nsec: confirm the "Backup to Nostr Relays" button, the per-relay status section, and the backup-missing banner all behave as before.
- [x] Signed in with a local nsec: write a new backup, then restore it via a known-good third-party reader using the same nsec. Confirm round-trip succeeds.