### PR TITLE
Pause/resume local relay on app lifecycle events

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
@@ -97,6 +97,7 @@ class RelayLifecycleManager(
         Log.d("RLC", "[Lifecycle] onAppPause — connectedCount=${relayPool.connectedCount.value}")
         relayPool.appIsActive = false
         relayPool.healthTracker?.closeAllSessions()
+        relayPool.pauseLocalRelay()
     }
 
     /**
@@ -111,6 +112,7 @@ class RelayLifecycleManager(
         // Set suppression window to prevent network-change reconnects from
         // firing shortly after this resume and causing a double reconnect.
         resumeReconnectUntilMs = System.currentTimeMillis() + RESUME_SUPPRESSION_MS
+        relayPool.resumeLocalRelay()
         reconnect(force = force)
     }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -1295,7 +1295,9 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         localRelayConfig = config
 
         if (oldUrl == config.url && oldRelay != null) {
-            // URL unchanged — just update config, reconnect if needed
+            // URL unchanged — just update config, reconnect if needed.
+            // Re-enable auto-reconnect in case the relay was paused via pauseLocalRelay().
+            oldRelay.reconnectEnabled = true
             if (!oldRelay.isConnected) oldRelay.connect()
             return
         }
@@ -1316,6 +1318,25 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
 
         relay.connect()
         Log.d("RLC", "[Pool] local relay connected: ${config.url}")
+    }
+
+    /** Disconnect local relay socket but preserve references for cheap resume. */
+    fun pauseLocalRelay() {
+        val relay = localRelay ?: return
+        relay.reconnectEnabled = false
+        relay.disconnect()
+        Log.d("RLC", "[Pool] local relay paused: ${relay.config.url}")
+    }
+
+    /** Reconnect local relay if still configured and enabled. Safe to call repeatedly. */
+    fun resumeLocalRelay() {
+        val relay = localRelay ?: return
+        val cfg = localRelayConfig ?: return
+        if (!cfg.enabled) return
+        relay.reconnectEnabled = true
+        relay.resetBackoff()
+        if (!relay.isConnected) relay.connect()
+        Log.d("RLC", "[Pool] local relay resumed: ${relay.config.url}")
     }
 
     fun getLocalRelayUrl(): String? = localRelayConfig?.url


### PR DESCRIPTION
## Summary
Add lifecycle-aware pause/resume functionality for the local relay to gracefully handle app backgrounding and foregrounding without losing the relay connection state.

## Key Changes
- **New methods in RelayPool**:
  - `pauseLocalRelay()`: Disables auto-reconnect and disconnects the local relay socket while preserving references for quick resumption
  - `resumeLocalRelay()`: Re-enables the relay, resets backoff timers, and reconnects if configured and enabled
  
- **Updated RelayLifecycleManager**:
  - Call `pauseLocalRelay()` in `onAppPause()` to cleanly disconnect when app goes to background
  - Call `resumeLocalRelay()` in `onAppResume()` to restore connection when app returns to foreground
  
- **Enhanced config update logic**:
  - When updating local relay config with unchanged URL, explicitly re-enable `reconnectEnabled` flag in case relay was previously paused

## Implementation Details
- The pause/resume pattern preserves the relay object reference, avoiding expensive reconnection setup
- `reconnectEnabled` flag is used to prevent automatic reconnection attempts while paused
- `resetBackoff()` is called on resume to clear any accumulated backoff delays from the pause period
- All operations include defensive null checks and logging for debugging
- The approach is safe to call repeatedly and respects the relay's enabled configuration state

https://claude.ai/code/session_01YHsgf89CpMXtj2wETzX588