### PR TITLE
feat(mention): query search relay when local results are insufficient

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -2478,7 +2478,7 @@ fun WispNavHost(
                     hostPubkey, dTag, feedViewModel.liveStreamRepo,
                     feedViewModel.relayPool, feedViewModel.relayListRepo,
                     feedViewModel.outboxRouter, feedViewModel.subManager,
-                    feedViewModel.contactRepo, naddrHints
+                    feedViewModel.contactRepo, feedViewModel.profileRepo, naddrHints
                 )
             }
             DisposableEffect(hostPubkey, dTag) {

--- a/app/src/main/kotlin/com/wisp/app/repo/MentionSearchRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/MentionSearchRepository.kt
@@ -1,11 +1,18 @@
 package com.wisp.app.repo
 
 import com.wisp.app.db.EventPersistence
+import com.wisp.app.nostr.ClientMessage
+import com.wisp.app.nostr.Filter
 import com.wisp.app.nostr.ProfileData
 import com.wisp.app.relay.RelayPool
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 data class MentionCandidate(
     val profile: ProfileData,
@@ -23,7 +30,12 @@ class MentionSearchRepository(
 
     var eventPersistence: EventPersistence? = null
 
+    private var relaySearchJob: Job? = null
+
     fun search(query: String, scope: CoroutineScope) {
+        relaySearchJob?.cancel()
+        relaySearchJob = null
+
         if (query.isBlank()) {
             val contacts = contactRepo.getFollowList().take(5).mapNotNull { entry ->
                 profileRepo.get(entry.pubkey)?.let { MentionCandidate(it, isContact = true) }
@@ -35,7 +47,6 @@ class MentionSearchRepository(
         val lowerQuery = query.lowercase()
         val followPubkeys = contactRepo.getFollowList().map { it.pubkey }.toSet()
 
-        // First: search contacts only via ProfileRepository
         val contactResults = followPubkeys.mapNotNull { pubkey ->
             val profile = profileRepo.get(pubkey) ?: return@mapNotNull null
             val nameMatch = profile.name?.lowercase()?.contains(lowerQuery) == true
@@ -49,29 +60,63 @@ class MentionSearchRepository(
             return
         }
 
-        // Fill remaining slots from ObjectBox
+        val seenPubkeys = contactResults.map { it.profile.pubkey }.toMutableSet()
+        var localResults = contactResults
+
         val persistence = eventPersistence
-        if (persistence == null) {
-            _candidates.value = contactResults
-            return
+        if (persistence != null) {
+            val remaining = 5 - contactResults.size
+            val events = persistence.searchProfiles(query, limit = 500)
+            val dbResults = events.mapNotNull { event ->
+                if (!seenPubkeys.add(event.pubkey)) return@mapNotNull null
+                val profile = ProfileData.fromEvent(event) ?: return@mapNotNull null
+                val nameMatch = profile.name?.lowercase()?.contains(lowerQuery) == true
+                val displayMatch = profile.displayName?.lowercase()?.contains(lowerQuery) == true
+                if (!nameMatch && !displayMatch) return@mapNotNull null
+                MentionCandidate(profile, isContact = false)
+            }.take(remaining)
+            localResults = contactResults + dbResults
+            seenPubkeys.addAll(dbResults.map { it.profile.pubkey })
         }
 
-        val seenPubkeys = contactResults.map { it.profile.pubkey }.toMutableSet()
-        val remaining = 5 - contactResults.size
-        val events = persistence.searchProfiles(query, limit = 500)
-        val dbResults = events.mapNotNull { event ->
-            if (!seenPubkeys.add(event.pubkey)) return@mapNotNull null
-            val profile = ProfileData.fromEvent(event) ?: return@mapNotNull null
-            val nameMatch = profile.name?.lowercase()?.contains(lowerQuery) == true
-            val displayMatch = profile.displayName?.lowercase()?.contains(lowerQuery) == true
-            if (!nameMatch && !displayMatch) return@mapNotNull null
-            MentionCandidate(profile, isContact = false)
-        }.take(remaining)
+        _candidates.value = localResults
+        if (localResults.size >= 5) return
 
-        _candidates.value = contactResults + dbResults
+        val capturedLocal = localResults
+        relaySearchJob = scope.launch(Dispatchers.IO) {
+            val subId = "mention-${System.nanoTime()}"
+            val filter = Filter(kinds = listOf(0), search = query, limit = 10)
+            relayPool.sendToRelayOrEphemeral(SEARCH_RELAY, ClientMessage.req(subId, filter))
+
+            val relayResults = mutableListOf<MentionCandidate>()
+            val eventJob = launch {
+                relayPool.relayEvents.collect { ev ->
+                    if (ev.subscriptionId != subId) return@collect
+                    val profile = ProfileData.fromEvent(ev.event) ?: return@collect
+                    if (seenPubkeys.add(profile.pubkey)) {
+                        relayResults += MentionCandidate(profile, isContact = false)
+                        _candidates.value = capturedLocal + relayResults
+                    }
+                }
+            }
+            try {
+                withTimeoutOrNull(3_000L) {
+                    relayPool.eoseSignals.first { it == subId }
+                }
+            } finally {
+                eventJob.cancel()
+                relayPool.closeOnAllRelays(subId)
+            }
+        }
     }
 
     fun clear() {
+        relaySearchJob?.cancel()
+        relaySearchJob = null
         _candidates.value = emptyList()
+    }
+
+    private companion object {
+        const val SEARCH_RELAY = "wss://search.nostrarchives.com"
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt
@@ -73,9 +73,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -87,6 +89,7 @@ import com.wisp.app.nostr.NostrSigner
 import com.wisp.app.nostr.hexToByteArray
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.repo.LiveChatMessage
+import com.wisp.app.repo.MentionCandidate
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.ui.component.EmojiReactionPopup
 import com.wisp.app.ui.component.InlineVideoPlayerWithFullscreen
@@ -125,6 +128,16 @@ fun LiveStreamScreen(
     val messageText by viewModel.messageText.collectAsState()
     val sending by viewModel.sending.collectAsState()
     val replyTarget by viewModel.replyTarget.collectAsState()
+    val mentionCandidates by viewModel.mentionCandidates.collectAsState()
+    var tfv by remember { mutableStateOf(TextFieldValue()) }
+    LaunchedEffect(messageText) {
+        if (tfv.text != messageText) tfv = TextFieldValue(messageText, TextRange(messageText.length))
+    }
+    val mentionAutocomplete = remember(tfv) { detectLiveMentionAutocomplete(tfv) }
+    LaunchedEffect(mentionAutocomplete) {
+        if (mentionAutocomplete != null) viewModel.searchMention(mentionAutocomplete.query)
+        else viewModel.clearMentionState()
+    }
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     // Auto-scroll to bottom when new messages arrive
@@ -289,6 +302,47 @@ fun LiveStreamScreen(
             }
         }
 
+        // Mention candidates
+        if (mentionCandidates.isNotEmpty() && mentionAutocomplete != null) {
+            Surface(
+                shape = RoundedCornerShape(8.dp),
+                tonalElevation = 3.dp,
+                shadowElevation = 2.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 200.dp)
+                    .padding(horizontal = 8.dp, vertical = 2.dp)
+            ) {
+                LazyColumn {
+                    items(mentionCandidates, key = { it.profile.pubkey }) { candidate ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    val uri = "nostr:" + Nip19.nprofileEncode(candidate.profile.pubkey)
+                                    val newTfv = insertLiveMentionAutocomplete(
+                                        tfv, mentionAutocomplete.triggerIndex, uri
+                                    )
+                                    tfv = newTfv
+                                    viewModel.updateText(newTfv.text)
+                                    viewModel.clearMentionState()
+                                }
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            ProfilePicture(url = candidate.profile.picture, size = 28)
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = candidate.profile.displayString,
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 1
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
         // Input bar
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -299,8 +353,8 @@ fun LiveStreamScreen(
                 .padding(horizontal = 8.dp, vertical = 6.dp)
         ) {
             BasicTextField(
-                value = messageText,
-                onValueChange = { viewModel.updateText(it) },
+                value = tfv,
+                onValueChange = { new -> tfv = new; viewModel.updateText(new.text) },
                 modifier = Modifier
                     .weight(1f)
                     .heightIn(min = 40.dp, max = 120.dp)
@@ -322,7 +376,7 @@ fun LiveStreamScreen(
                 ),
                 decorationBox = { innerTextField ->
                     Box {
-                        if (messageText.isEmpty()) {
+                        if (tfv.text.isEmpty()) {
                             Text(
                                 text = "Chat...",
                                 style = MaterialTheme.typography.bodyMedium,
@@ -336,7 +390,7 @@ fun LiveStreamScreen(
             Spacer(Modifier.width(4.dp))
             IconButton(
                 onClick = { viewModel.sendMessage(signer) },
-                enabled = messageText.isNotBlank() && !sending
+                enabled = tfv.text.isNotBlank() && !sending
             ) {
                 if (sending) {
                     CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
@@ -344,13 +398,46 @@ fun LiveStreamScreen(
                     Icon(
                         Icons.AutoMirrored.Filled.Send,
                         contentDescription = "Send",
-                        tint = if (messageText.isNotBlank()) MaterialTheme.colorScheme.primary
+                        tint = if (tfv.text.isNotBlank()) MaterialTheme.colorScheme.primary
                         else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
                     )
                 }
             }
         }
     }
+}
+
+private data class LiveMentionAutocomplete(val triggerIndex: Int, val query: String)
+
+private fun detectLiveMentionAutocomplete(tfv: TextFieldValue): LiveMentionAutocomplete? {
+    val text = tfv.text
+    val cursor = tfv.selection.end
+    if (cursor <= 0) return null
+    var i = cursor - 1
+    while (i >= 0) {
+        val c = text[i]
+        when {
+            c == '@' -> {
+                val query = text.substring(i + 1, cursor)
+                if (query.contains(' ') || query.contains('\n')) return null
+                val before = if (i > 0) text[i - 1] else ' '
+                return if (before == ' ' || before == '\n') LiveMentionAutocomplete(i, query) else null
+            }
+            c == ' ' || c == '\n' -> return null
+        }
+        i--
+    }
+    if (i < 0 && text.isNotEmpty() && text[0] == '@') {
+        val query = text.substring(1, cursor)
+        if (!query.contains(' ') && !query.contains('\n')) return LiveMentionAutocomplete(0, query)
+    }
+    return null
+}
+
+private fun insertLiveMentionAutocomplete(tfv: TextFieldValue, triggerIndex: Int, insertion: String): TextFieldValue {
+    val newText = tfv.text.substring(0, triggerIndex) + insertion + " " + tfv.text.substring(tfv.selection.end)
+    val newCursor = triggerIndex + insertion.length + 1
+    return TextFieldValue(newText, TextRange(newCursor))
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/LiveStreamViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/LiveStreamViewModel.kt
@@ -15,8 +15,12 @@ import com.wisp.app.relay.RelayConfig
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.relay.SubscriptionManager
 import com.wisp.app.repo.ContactRepository
+import com.wisp.app.repo.KeyRepository
 import com.wisp.app.repo.LiveChatMessage
 import com.wisp.app.repo.LiveStreamRepository
+import com.wisp.app.repo.MentionCandidate
+import com.wisp.app.repo.MentionSearchRepository
+import com.wisp.app.repo.ProfileRepository
 import com.wisp.app.repo.RelayListRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -54,6 +58,16 @@ class LiveStreamViewModel(app: Application) : AndroidViewModel(app) {
     private val _replyTarget = MutableStateFlow<LiveChatMessage?>(null)
     val replyTarget: StateFlow<LiveChatMessage?> = _replyTarget
 
+    private var mentionSearchRepo: MentionSearchRepository? = null
+    private val _mentionCandidates = MutableStateFlow<List<MentionCandidate>>(emptyList())
+    val mentionCandidates: StateFlow<List<MentionCandidate>> = _mentionCandidates
+
+    fun searchMention(query: String) { mentionSearchRepo?.search(query, viewModelScope) }
+    fun clearMentionState() {
+        _mentionCandidates.value = emptyList()
+        mentionSearchRepo?.clear()
+    }
+
     fun init(
         hostPubkey: String,
         dTag: String,
@@ -63,6 +77,7 @@ class LiveStreamViewModel(app: Application) : AndroidViewModel(app) {
         outboxRouter: OutboxRouter,
         subManager: SubscriptionManager,
         contactRepo: ContactRepository,
+        profileRepo: ProfileRepository,
         naddrRelayHints: List<String> = emptyList()
     ) {
         if (this.hostPubkey == hostPubkey && this.dTag == dTag) return
@@ -71,6 +86,13 @@ class LiveStreamViewModel(app: Application) : AndroidViewModel(app) {
         this.liveStreamRepo = liveStreamRepo
         this.relayPool = relayPool
         this.contactRepo = contactRepo
+        if (mentionSearchRepo == null) {
+            mentionSearchRepo = MentionSearchRepository(
+                profileRepo, contactRepo, relayPool, KeyRepository(getApplication())
+            ).also { repo ->
+                viewModelScope.launch { repo.candidates.collect { _mentionCandidates.value = it } }
+            }
+        }
         this.aTagValue = Nip53.aTagValue(hostPubkey, dTag)
 
         // Set current stream in repo


### PR DESCRIPTION
When typing @mentions, first check local follows and cached profiles. If fewer than 5 matches are found, query wss://search.nostrarchives.com (NIP-50) and stream results into the suggestion list as they arrive. The relay subscription is cancelled on each new keystroke and cleaned up on EOSE or after a 3-second timeout.

Also adds @mention autocomplete to the livestream chat input, which previously had no mention support.