### PR TITLE
feat(auth): Continue with Google + encrypted nsec backup to Nostr relays

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,4 +114,8 @@ dependencies {
     implementation(libs.camerax.lifecycle)
     implementation(libs.camerax.view)
     implementation(libs.camerax.mlkit)
+    implementation(libs.androidx.credentials)
+    implementation(libs.androidx.credentials.play.services.auth)
+    implementation(libs.googleid)
+    implementation(libs.play.services.auth)
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -62,3 +62,11 @@
 # JNA (used by Breez SDK UniFFI)
 -keep class com.sun.jna.** { *; }
 -dontwarn com.sun.jna.**
+
+# Credential Manager + Google Identity
+-keep class androidx.credentials.** { *; }
+-dontwarn androidx.credentials.**
+-keep class com.google.android.libraries.identity.googleid.** { *; }
+-dontwarn com.google.android.libraries.identity.googleid.**
+-keep class com.google.android.gms.auth.** { *; }
+-dontwarn com.google.android.gms.auth.**

--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -133,6 +133,7 @@ import kotlinx.coroutines.launch
 object Routes {
     const val SPLASH = "splash"
     const val AUTH = "auth"
+    const val GOOGLE_AUTH = "google_auth"
     const val FEED = "feed"
     const val COMPOSE = "compose"
     const val RELAYS = "relays"
@@ -403,7 +404,7 @@ fun WispNavHost(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
-    val nonAppRoutes = setOf(Routes.SPLASH, Routes.AUTH, Routes.LOADING, Routes.ONBOARDING_PROFILE, Routes.ONBOARDING_SUGGESTIONS, Routes.ONBOARDING_TOPICS, Routes.ONBOARDING_FIRST_POST, Routes.EXISTING_USER_ONBOARDING)
+    val nonAppRoutes = setOf(Routes.SPLASH, Routes.AUTH, Routes.GOOGLE_AUTH, Routes.LOADING, Routes.ONBOARDING_PROFILE, Routes.ONBOARDING_SUGGESTIONS, Routes.ONBOARDING_TOPICS, Routes.ONBOARDING_FIRST_POST, Routes.EXISTING_USER_ONBOARDING)
     val hideBottomBarRoutes = nonAppRoutes + Routes.DM_CONVERSATION + Routes.DM_CONVERSATION_GROUP + Routes.CONTACT_PICKER + Routes.GROUP_ROOM + Routes.GROUP_DETAIL + Routes.LIVE_STREAM
     val socialGraphDiscoveryState by feedViewModel.extendedNetworkRepo.discoveryState.collectAsState()
     val socialGraphComputing = currentRoute == Routes.SOCIAL_GRAPH && (
@@ -653,6 +654,52 @@ fun WispNavHost(
                 },
                 onLogIn = {
                     navController.navigate(Routes.AUTH)
+                },
+                onContinueWithGoogle = {
+                    navController.navigate(Routes.GOOGLE_AUTH)
+                }
+            )
+        }
+
+        composable(Routes.GOOGLE_AUTH) {
+            val googleAuthViewModel: com.wisp.app.viewmodel.GoogleAuthViewModel = viewModel()
+            com.wisp.app.ui.screen.GoogleAuthScreen(
+                viewModel = googleAuthViewModel,
+                onCancel = {
+                    googleAuthViewModel.reset()
+                    navController.popBackStack()
+                },
+                onDone = { isNewAccount ->
+                    val wasAddingAccount = authViewModel.isAddingAccount
+                    authViewModel.isAddingAccount = false
+                    authViewModel.refreshAfterExternalLogin()
+
+                    if (isNewAccount) {
+                        navController.navigate(Routes.ONBOARDING_PROFILE) {
+                            popUpTo(Routes.SPLASH) { inclusive = true }
+                        }
+                    } else if (wasAddingAccount && authViewModel.keyRepo.isOnboardingComplete()) {
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        blossomServersViewModel.reload()
+                        composeViewModel.reloadBlossomRepo()
+                        feedViewModel.initRelays()
+                        walletViewModel.refreshState()
+                        navController.navigate(Routes.LOADING) {
+                            popUpTo(Routes.GOOGLE_AUTH) { inclusive = true }
+                        }
+                    } else {
+                        feedViewModel.reloadForNewAccount()
+                        relayViewModel.reload()
+                        blossomServersViewModel.reload()
+                        composeViewModel.reloadBlossomRepo()
+                        feedViewModel.initRelays()
+                        walletViewModel.refreshState()
+                        authViewModel.keyRepo.markOnboardingComplete()
+                        navController.navigate(Routes.EXISTING_USER_ONBOARDING) {
+                            popUpTo(Routes.GOOGLE_AUTH) { inclusive = true }
+                        }
+                    }
                 }
             )
         }

--- a/app/src/main/kotlin/com/wisp/app/auth/BackupCrypto.kt
+++ b/app/src/main/kotlin/com/wisp/app/auth/BackupCrypto.kt
@@ -1,0 +1,43 @@
+package com.wisp.app.auth
+
+import com.wisp.app.nostr.Nip44
+import com.wisp.app.nostr.hexToByteArray
+import com.wisp.app.nostr.toHex
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Backup encryption for the Google Drive nsec backup blob.
+ *
+ * The encryption key is derived from the Google ID token's `sub` claim, which is
+ * stable per (Google account, OAuth client). This means the same Google account
+ * always produces the same key, enabling passphrase-less restore. Tradeoff: anyone
+ * with access to the Google account can decrypt the backup.
+ *
+ * The encrypted payload is just NIP-44 v2 over the hex-encoded nsec, with the
+ * derived key in place of the usual ECDH conversation key. Reuses Nip44 verbatim
+ * so we don't introduce new crypto code.
+ */
+object BackupCrypto {
+    private const val SALT = "wisp-google-backup-v1"
+
+    fun deriveBackupKey(sub: String): ByteArray {
+        require(sub.isNotEmpty()) { "Google sub claim must not be empty" }
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(SALT.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        return mac.doFinal(sub.toByteArray(Charsets.UTF_8))
+    }
+
+    fun encryptNsec(nsec: ByteArray, key: ByteArray): String {
+        require(nsec.size == 32) { "nsec must be 32 bytes" }
+        require(key.size == 32) { "backup key must be 32 bytes" }
+        return Nip44.encrypt(nsec.toHex(), key)
+    }
+
+    fun decryptNsec(payload: String, key: ByteArray): ByteArray {
+        require(key.size == 32) { "backup key must be 32 bytes" }
+        val hex = Nip44.decrypt(payload, key)
+        require(hex.length == 64) { "decrypted backup is not a 32-byte hex string" }
+        return hex.hexToByteArray()
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/auth/DriveBackupService.kt
+++ b/app/src/main/kotlin/com/wisp/app/auth/DriveBackupService.kt
@@ -1,0 +1,148 @@
+package com.wisp.app.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.util.UUID
+
+/**
+ * Minimal Drive REST v3 client targeted at the user's appDataFolder.
+ *
+ * One backup file per Nostr account. Filenames follow `wisp_nsec_<npub>.bin`
+ * so we can list every account on the user's Drive and surface the npub
+ * without downloading each file. Legacy single-file backups (`wisp_nsec.bin`,
+ * from before multi-account support) are also surfaced in the list.
+ */
+class DriveBackupService(
+    private val httpClient: OkHttpClient = OkHttpClient()
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    data class BackupFile(val fileId: String, val name: String) {
+        /** `npub1…` parsed from the filename, or null for the legacy unnamed backup. */
+        val npubFromName: String?
+            get() = when {
+                name.startsWith(BACKUP_PREFIX) && name.endsWith(BACKUP_SUFFIX) -> {
+                    name.removePrefix(BACKUP_PREFIX).removeSuffix(BACKUP_SUFFIX)
+                        .takeIf { it.isNotEmpty() && it.startsWith("npub1") }
+                }
+                else -> null
+            }
+    }
+
+    suspend fun listBackups(accessToken: String): List<BackupFile> = withContext(Dispatchers.IO) {
+        val nameQuery = "name = '$LEGACY_FILENAME' or name contains '$BACKUP_PREFIX'"
+        val url = "https://www.googleapis.com/drive/v3/files" +
+            "?spaces=appDataFolder" +
+            "&q=" + java.net.URLEncoder.encode(nameQuery, "UTF-8") +
+            "&fields=files(id,name,modifiedTime)" +
+            "&pageSize=100"
+
+        val req = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $accessToken")
+            .get()
+            .build()
+
+        httpClient.newCall(req).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Drive list failed: ${response.code} ${response.message}")
+            }
+            val body = response.body?.string() ?: return@withContext emptyList()
+            val root = json.parseToJsonElement(body) as? JsonObject ?: return@withContext emptyList()
+            val files = root["files"]?.jsonArray ?: return@withContext emptyList()
+            files.mapNotNull { element ->
+                val obj = element as? JsonObject ?: return@mapNotNull null
+                val id = obj["id"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                val name = obj["name"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                BackupFile(id, name)
+            }
+        }
+    }
+
+    suspend fun downloadBackup(accessToken: String, fileId: String): String =
+        withContext(Dispatchers.IO) {
+            val req = Request.Builder()
+                .url("https://www.googleapis.com/drive/v3/files/$fileId?alt=media")
+                .header("Authorization", "Bearer $accessToken")
+                .get()
+                .build()
+
+            httpClient.newCall(req).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("Drive download failed: ${response.code} ${response.message}")
+                }
+                response.body?.string() ?: throw IOException("Empty download body")
+            }
+        }
+
+    /**
+     * Creates a new backup file in appDataFolder. If a backup for the same npub
+     * already exists, deletes it first so we keep one file per account rather
+     * than accumulating duplicate revisions.
+     */
+    suspend fun uploadBackup(accessToken: String, npub: String, payload: String) =
+        withContext(Dispatchers.IO) {
+            require(npub.startsWith("npub1")) { "npub must be bech32-encoded" }
+            val filename = "$BACKUP_PREFIX$npub$BACKUP_SUFFIX"
+
+            // Remove any existing file with the same name to avoid duplicates.
+            listBackups(accessToken).filter { it.name == filename }.forEach { existing ->
+                deleteBackup(accessToken, existing.fileId)
+            }
+
+            val metadata = """{"name":"$filename","parents":["$APP_DATA_FOLDER"]}"""
+            val boundary = "wisp-${UUID.randomUUID()}"
+            val crlf = "\r\n"
+            val body = buildString {
+                append("--").append(boundary).append(crlf)
+                append("Content-Type: application/json; charset=UTF-8").append(crlf).append(crlf)
+                append(metadata).append(crlf)
+                append("--").append(boundary).append(crlf)
+                append("Content-Type: application/octet-stream").append(crlf).append(crlf)
+                append(payload).append(crlf)
+                append("--").append(boundary).append("--").append(crlf)
+            }
+
+            val requestBody: RequestBody = body.toRequestBody(
+                "multipart/related; boundary=$boundary".toMediaType()
+            )
+
+            val req = Request.Builder()
+                .url("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart")
+                .header("Authorization", "Bearer $accessToken")
+                .post(requestBody)
+                .build()
+
+            httpClient.newCall(req).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("Drive upload failed: ${response.code} ${response.message}")
+                }
+            }
+        }
+
+    suspend fun deleteBackup(accessToken: String, fileId: String) = withContext(Dispatchers.IO) {
+        val req = Request.Builder()
+            .url("https://www.googleapis.com/drive/v3/files/$fileId")
+            .header("Authorization", "Bearer $accessToken")
+            .delete()
+            .build()
+        httpClient.newCall(req).execute().close()
+    }
+
+    companion object {
+        private const val APP_DATA_FOLDER = "appDataFolder"
+        private const val BACKUP_PREFIX = "wisp_nsec_"
+        private const val BACKUP_SUFFIX = ".bin"
+        private const val LEGACY_FILENAME = "wisp_nsec.bin"
+    }
+}

--- a/app/src/main/kotlin/com/wisp/app/auth/GoogleSignInManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/auth/GoogleSignInManager.kt
@@ -1,0 +1,138 @@
+package com.wisp.app.auth
+
+import android.app.PendingIntent
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialException
+import com.google.android.gms.auth.api.identity.AuthorizationRequest
+import com.google.android.gms.auth.api.identity.Identity
+import com.google.android.gms.common.api.Scope
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import kotlinx.coroutines.tasks.await
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Two-step Google sign-in:
+ *   1. Credential Manager returns a GoogleIdTokenCredential whose `id` field is
+ *      stable per (Google account, OAuth client). We treat it as the `sub` and
+ *      derive the backup encryption key from it.
+ *   2. AuthorizationClient requests an OAuth access token with the
+ *      drive.appdata scope. May return a token directly, or a PendingIntent
+ *      requiring the user to grant consent the first time.
+ */
+class GoogleSignInManager(
+    context: Context,
+    private val webClientId: String
+) {
+    private val credentialManager = CredentialManager.create(context)
+
+    data class GoogleAuthResult(
+        val sub: String,
+        val accessToken: String,
+        val email: String?
+    )
+
+    suspend fun signIn(activity: ComponentActivity): GoogleAuthResult {
+        val sub = getGoogleSubFromCredentialManager(activity)
+        val accessToken = getDriveAccessToken(activity)
+        return GoogleAuthResult(
+            sub = sub,
+            accessToken = accessToken,
+            email = sub.takeIf { it.contains("@") }
+        )
+    }
+
+    private suspend fun getGoogleSubFromCredentialManager(activity: ComponentActivity): String {
+        val option = GetGoogleIdOption.Builder()
+            .setServerClientId(webClientId)
+            .setFilterByAuthorizedAccounts(false)
+            .setAutoSelectEnabled(false)
+            .build()
+
+        val request = GetCredentialRequest.Builder()
+            .addCredentialOption(option)
+            .build()
+
+        val response = try {
+            credentialManager.getCredential(activity, request)
+        } catch (e: GetCredentialException) {
+            throw GoogleSignInException("Google sign-in cancelled or unavailable: ${e.message}", e)
+        }
+
+        val credential = response.credential
+        if (credential !is CustomCredential ||
+            credential.type != GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
+        ) {
+            throw GoogleSignInException("Unexpected credential type: ${credential.javaClass.simpleName}")
+        }
+
+        val parsed = try {
+            GoogleIdTokenCredential.createFrom(credential.data)
+        } catch (e: GoogleIdTokenParsingException) {
+            throw GoogleSignInException("Failed to parse Google ID token", e)
+        }
+        return parsed.id
+    }
+
+    private suspend fun getDriveAccessToken(activity: ComponentActivity): String {
+        val authClient = Identity.getAuthorizationClient(activity)
+        val request = AuthorizationRequest.Builder()
+            .setRequestedScopes(listOf(Scope(DRIVE_APPDATA_SCOPE)))
+            .build()
+
+        val authResult = authClient.authorize(request).await()
+
+        if (authResult.hasResolution()) {
+            val pendingIntent = authResult.pendingIntent
+                ?: throw GoogleSignInException("Authorization required but no pending intent provided")
+            return resolveAuthorization(activity, pendingIntent)
+        }
+
+        return authResult.accessToken
+            ?: throw GoogleSignInException("No access token returned")
+    }
+
+    private suspend fun resolveAuthorization(
+        activity: ComponentActivity,
+        pendingIntent: PendingIntent
+    ): String = suspendCoroutine { cont ->
+        val key = "wisp_google_auth_${System.currentTimeMillis()}"
+        var launcher: androidx.activity.result.ActivityResultLauncher<IntentSenderRequest>? = null
+        launcher = activity.activityResultRegistry.register(
+            key,
+            ActivityResultContracts.StartIntentSenderForResult()
+        ) { result ->
+            launcher?.unregister()
+            try {
+                val authResult = Identity.getAuthorizationClient(activity)
+                    .getAuthorizationResultFromIntent(result.data)
+                val token = authResult.accessToken
+                    ?: throw GoogleSignInException("Authorization granted but no access token returned")
+                cont.resume(token)
+            } catch (e: Exception) {
+                cont.resumeWithException(
+                    if (e is GoogleSignInException) e
+                    else GoogleSignInException("Authorization resolution failed: ${e.message}", e)
+                )
+            }
+        }
+        launcher.launch(
+            IntentSenderRequest.Builder(pendingIntent.intentSender).build()
+        )
+    }
+
+    companion object {
+        private const val DRIVE_APPDATA_SCOPE = "https://www.googleapis.com/auth/drive.appdata"
+    }
+}
+
+class GoogleSignInException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/app/src/main/kotlin/com/wisp/app/repo/KeyRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/KeyRepository.kt
@@ -204,6 +204,15 @@ class KeyRepository(private val context: Context) {
         _accounts.value = accounts
     }
 
+    /**
+     * Re-read the account list from encrypted prefs. Useful when another
+     * KeyRepository instance has written to the same backing store and our
+     * cached _accounts flow is stale.
+     */
+    fun refreshAccounts() {
+        _accounts.value = loadAccountList()
+    }
+
     private fun loadAccountList(): List<AccountInfo> {
         val str = encPrefs.getString("accounts", null) ?: return emptyList()
         return try {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/GoogleAuthScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/GoogleAuthScreen.kt
@@ -1,0 +1,339 @@
+package com.wisp.app.ui.screen
+
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wisp.app.R
+import com.wisp.app.viewmodel.GoogleAuthViewModel
+
+private const val TAG = "GoogleAuth"
+
+@Composable
+fun GoogleAuthScreen(
+    viewModel: GoogleAuthViewModel,
+    onCancel: () -> Unit,
+    onDone: (isNewAccount: Boolean) -> Unit
+) {
+    val context = LocalContext.current
+    val state by viewModel.state.collectAsState()
+    val webClientId = stringResource(R.string.google_web_client_id)
+
+    LaunchedEffect(Unit) {
+        Log.d(TAG, "GoogleAuthScreen LaunchedEffect(Unit) fired, state=${state::class.simpleName}, contextClass=${context.javaClass.simpleName}, webClientIdLen=${webClientId.length}")
+        if (state is GoogleAuthViewModel.State.Idle) {
+            val activity = context as? ComponentActivity
+            if (activity == null) {
+                Log.w(TAG, "context is not a ComponentActivity — cancelling")
+                onCancel()
+                return@LaunchedEffect
+            }
+            if (webClientId.isBlank()) {
+                Log.w(TAG, "google_web_client_id is blank — cancelling")
+                onCancel()
+                return@LaunchedEffect
+            }
+            viewModel.beginSignIn(activity, webClientId)
+        }
+    }
+
+    LaunchedEffect(state) {
+        Log.d(TAG, "GoogleAuthScreen state changed -> ${state::class.simpleName}")
+        val current = state
+        if (current is GoogleAuthViewModel.State.Done) {
+            Log.d(TAG, "calling onDone(isNewAccount=${current.isNewAccount})")
+            onDone(current.isNewAccount)
+            viewModel.reset()
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        IconButton(
+            onClick = {
+                Log.d(TAG, "back arrow tapped")
+                viewModel.reset()
+                onCancel()
+            },
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .statusBarsPadding()
+                .padding(8.dp)
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(R.string.cd_back)
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 32.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Header()
+            Spacer(Modifier.height(32.dp))
+
+            when (val s = state) {
+                GoogleAuthViewModel.State.Idle,
+                GoogleAuthViewModel.State.SigningIn,
+                GoogleAuthViewModel.State.CheckingDrive,
+                GoogleAuthViewModel.State.Working -> {
+                    LoadingBlock(
+                        label = when (s) {
+                            GoogleAuthViewModel.State.SigningIn -> stringResource(R.string.google_auth_signing_in)
+                            GoogleAuthViewModel.State.CheckingDrive -> stringResource(R.string.google_auth_checking_drive)
+                            GoogleAuthViewModel.State.Working -> stringResource(R.string.google_auth_working)
+                            else -> stringResource(R.string.google_auth_starting)
+                        }
+                    )
+                }
+
+                is GoogleAuthViewModel.State.Choose -> ChooseBlock(
+                    backups = s.backups,
+                    onRestore = { viewModel.restoreAccount(it.fileId) },
+                    onCreate = { viewModel.createNewAccount() }
+                )
+
+                is GoogleAuthViewModel.State.Error -> {
+                    Text(
+                        text = s.message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(Modifier.height(24.dp))
+                    Button(
+                        onClick = { viewModel.reset() },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.btn_retry))
+                    }
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = onCancel,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.btn_cancel))
+                    }
+                }
+
+                is GoogleAuthViewModel.State.Done -> {
+                    LoadingBlock(label = stringResource(R.string.google_auth_working))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Header() {
+    Icon(
+        painter = painterResource(R.drawable.ic_wisp_logo),
+        contentDescription = stringResource(R.string.onboarding_wisp_logo),
+        tint = Color.Unspecified,
+        modifier = Modifier
+            .size(96.dp)
+            .drawBehind {
+                drawCircle(
+                    brush = Brush.radialGradient(
+                        colors = listOf(
+                            Color.Black,
+                            Color.Black.copy(alpha = 0.6f),
+                            Color.Transparent
+                        ),
+                        radius = size.minDimension * 0.65f
+                    ),
+                    radius = size.minDimension * 0.65f
+                )
+            }
+    )
+    Text(
+        text = stringResource(R.string.auth_wisp),
+        style = MaterialTheme.typography.titleLarge.copy(
+            fontFamily = FontFamily.SansSerif,
+            fontSize = 36.sp,
+            fontWeight = FontWeight.W500
+        ),
+        color = MaterialTheme.colorScheme.primary
+    )
+}
+
+@Composable
+private fun LoadingBlock(label: String) {
+    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChooseBlock(
+    backups: List<GoogleAuthViewModel.BackupSummary>,
+    onRestore: (GoogleAuthViewModel.BackupSummary) -> Unit,
+    onCreate: () -> Unit
+) {
+    val titleRes = if (backups.isEmpty())
+        R.string.google_auth_choose_title_empty
+    else
+        R.string.google_auth_choose_title_with_backups
+
+    Text(
+        text = stringResource(titleRes),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+        text = stringResource(
+            if (backups.isEmpty()) R.string.google_auth_choose_body_empty
+            else R.string.google_auth_choose_body_with_backups
+        ),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center
+    )
+
+    if (backups.isNotEmpty()) {
+        Spacer(Modifier.height(16.dp))
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 280.dp)
+        ) {
+            items(backups, key = { it.npub }) { backup ->
+                BackupRow(backup = backup, onClick = { onRestore(backup) })
+                Spacer(Modifier.height(8.dp))
+            }
+        }
+    }
+
+    Spacer(Modifier.height(20.dp))
+    HorizontalDivider(color = MaterialTheme.colorScheme.outline)
+    Spacer(Modifier.height(20.dp))
+
+    Button(
+        onClick = onCreate,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(
+            stringResource(
+                if (backups.isEmpty()) R.string.google_auth_create_first
+                else R.string.google_auth_create_another
+            )
+        )
+    }
+}
+
+@Composable
+private fun BackupRow(
+    backup: GoogleAuthViewModel.BackupSummary,
+    onClick: () -> Unit
+) {
+    val context = LocalContext.current
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { onClick() }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface)
+            ) {
+                if (!backup.picture.isNullOrBlank()) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(context)
+                            .data(backup.picture)
+                            .crossfade(true)
+                            .build(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.matchParentSize()
+                    )
+                }
+            }
+            Spacer(Modifier.size(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = backup.displayName?.takeIf { it.isNotBlank() }
+                        ?: formatShortNpub(backup.npub),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+    }
+}
+
+private fun formatShortNpub(npub: String): String {
+    if (npub.length <= 18) return npub
+    return npub.take(12) + "…" + npub.takeLast(6)
+}

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SplashScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SplashScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -56,7 +58,8 @@ private val AVATAR_GAP = 4.dp
 fun SplashScreen(
     viewModel: SplashViewModel,
     onSignUp: () -> Unit,
-    onLogIn: () -> Unit
+    onLogIn: () -> Unit,
+    onContinueWithGoogle: () -> Unit
 ) {
     val profilePictures by viewModel.profilePictures.collectAsState()
     val liveMetrics by viewModel.liveMetrics.collectAsState()
@@ -184,6 +187,37 @@ fun SplashScreen(
             Spacer(Modifier.height(32.dp))
 
             Button(
+                onClick = onContinueWithGoogle,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(24.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.White,
+                    contentColor = Color(0xFF1F1F1F)
+                ),
+                border = BorderStroke(1.dp, Color(0xFFDADCE0))
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_google_g),
+                    contentDescription = null,
+                    tint = Color.Unspecified,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.splash_continue_with_google),
+                    style = MaterialTheme.typography.labelLarge.copy(
+                        fontFamily = FontFamily.SansSerif,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 15.sp
+                    )
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedButton(
                 onClick = onSignUp,
                 modifier = Modifier.fillMaxWidth()
             ) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/AuthViewModel.kt
@@ -134,6 +134,18 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
         _error.value = null
     }
 
+    /**
+     * Re-sync npub/signing-mode flows after another component (e.g. GoogleAuthViewModel)
+     * has saved a keypair directly through KeyRepository. Without this, the
+     * AuthViewModel's flows still reflect the pre-login state.
+     */
+    fun refreshAfterExternalLogin() {
+        keyRepo.refreshAccounts()
+        _npub.value = keyRepo.getNpub()
+        _signingMode.value = if (keyRepo.isLoggedIn()) keyRepo.getSigningMode() else null
+        _error.value = null
+    }
+
     fun switchAccount(pubkeyHex: String) {
         keyRepo.switchToAccount(pubkeyHex)
         keyRepo.reloadPrefs(pubkeyHex)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/GoogleAuthViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/GoogleAuthViewModel.kt
@@ -1,0 +1,296 @@
+package com.wisp.app.viewmodel
+
+import android.app.Application
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.wisp.app.auth.BackupCrypto
+import com.wisp.app.auth.DriveBackupService
+import com.wisp.app.auth.GoogleSignInException
+import com.wisp.app.auth.GoogleSignInManager
+import com.wisp.app.nostr.Keys
+import com.wisp.app.nostr.Nip19
+import com.wisp.app.nostr.toHex
+import com.wisp.app.repo.FiatPreferences
+import com.wisp.app.repo.KeyRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import java.util.concurrent.TimeUnit
+
+private const val TAG = "GoogleAuth"
+
+/**
+ * Orchestrates the "Continue with Google" flow:
+ *   1. Sign in via GoogleSignInManager → derive backup key from sub claim.
+ *   2. List every backup in the user's Drive appDataFolder. Each filename
+ *      embeds the npub (`wisp_nsec_<npub>.bin`) so we can show the chooser
+ *      without downloading every file.
+ *   3. UI shows a list of restorable accounts (if any) plus a "Create new
+ *      account" option that's always available — users can keep adding new
+ *      Nostr identities to the same Google account's backup space.
+ *
+ * The plaintext nsec only leaves Drive when the user actually picks Restore;
+ * generation only happens when they pick Create.
+ */
+class GoogleAuthViewModel(app: Application) : AndroidViewModel(app) {
+    private val keyRepo = KeyRepository(app)
+    private val driveService = DriveBackupService()
+
+    /** One restorable account entry surfaced in the chooser. */
+    data class BackupSummary(
+        val fileId: String,
+        val npub: String,
+        val pubkeyHex: String,
+        val displayName: String? = null,
+        val picture: String? = null
+    )
+
+    sealed class State {
+        object Idle : State()
+        object SigningIn : State()
+        object CheckingDrive : State()
+        data class Choose(val backups: List<BackupSummary>) : State()
+        object Working : State()
+        data class Done(val isNewAccount: Boolean) : State()
+        data class Error(val message: String) : State()
+    }
+
+    private val _state = MutableStateFlow<State>(State.Idle)
+    val state: StateFlow<State> = _state
+
+    private var pendingBackupKey: ByteArray? = null
+    private var pendingAccessToken: String? = null
+    private var profileFetchJob: Job? = null
+
+    fun beginSignIn(activity: ComponentActivity, webClientId: String) {
+        Log.d(TAG, "beginSignIn called, current state=${_state.value::class.simpleName}, webClientId.length=${webClientId.length}")
+        if (_state.value !is State.Idle && _state.value !is State.Error) {
+            Log.d(TAG, "beginSignIn early-return: state is not Idle/Error")
+            return
+        }
+        val manager = GoogleSignInManager(activity.applicationContext, webClientId)
+        _state.value = State.SigningIn
+        Log.d(TAG, "state -> SigningIn")
+        viewModelScope.launch {
+            try {
+                Log.d(TAG, "calling manager.signIn(activity)…")
+                val result = manager.signIn(activity)
+                Log.d(TAG, "signIn returned: sub-len=${result.sub.length}, hasToken=${result.accessToken.isNotEmpty()}")
+                val backupKey = BackupCrypto.deriveBackupKey(result.sub)
+                pendingBackupKey = backupKey
+                pendingAccessToken = result.accessToken
+
+                _state.value = State.CheckingDrive
+                Log.d(TAG, "state -> CheckingDrive")
+
+                val files = driveService.listBackups(result.accessToken)
+                Log.d(TAG, "listBackups returned ${files.size} file(s)")
+
+                val summaries = files.mapNotNull { file ->
+                    val npub = file.npubFromName ?: try {
+                        // Legacy file with no npub in the filename — decrypt to learn it.
+                        val payload = driveService.downloadBackup(result.accessToken, file.fileId)
+                        val nsec = BackupCrypto.decryptNsec(payload, backupKey)
+                        Nip19.npubEncode(Keys.xOnlyPubkey(nsec))
+                    } catch (e: Exception) {
+                        Log.w(TAG, "couldn't resolve npub for ${file.name}; skipping", e)
+                        null
+                    }
+                    npub?.let {
+                        val pubkeyHex = try {
+                            Nip19.npubDecode(it).toHex()
+                        } catch (e: Exception) {
+                            Log.w(TAG, "couldn't decode npub $it", e)
+                            return@let null
+                        }
+                        BackupSummary(fileId = file.fileId, npub = it, pubkeyHex = pubkeyHex)
+                    }
+                }.distinctBy { it.npub }
+
+                _state.value = State.Choose(summaries)
+                Log.d(TAG, "state -> Choose with ${summaries.size} restorable account(s)")
+                if (summaries.isNotEmpty()) {
+                    fetchProfilesInBackground(summaries.map { it.pubkeyHex })
+                }
+            } catch (e: GoogleSignInException) {
+                Log.w(TAG, "GoogleSignInException", e)
+                _state.value = State.Error(e.message ?: "Google sign-in failed.")
+            } catch (e: Exception) {
+                Log.w(TAG, "Exception during sign-in flow", e)
+                _state.value = State.Error(e.message ?: "Something went wrong.")
+            }
+        }
+    }
+
+    fun restoreAccount(fileId: String) {
+        Log.d(TAG, "restoreAccount tapped, fileId=$fileId")
+        val key = pendingBackupKey ?: return
+        val accessToken = pendingAccessToken ?: return
+        _state.value = State.Working
+        viewModelScope.launch {
+            try {
+                val payload = driveService.downloadBackup(accessToken, fileId)
+                val nsec = BackupCrypto.decryptNsec(payload, key)
+                val keypair = Keys.fromPrivkey(nsec)
+                keyRepo.saveKeypair(keypair)
+                keyRepo.reloadPrefs(keypair.pubkey.toHex())
+                _state.value = State.Done(isNewAccount = false)
+                Log.d(TAG, "state -> Done(isNewAccount=false)")
+            } catch (e: Exception) {
+                Log.w(TAG, "restoreAccount failed", e)
+                _state.value = State.Error(e.message ?: "Failed to restore account.")
+            }
+        }
+    }
+
+    fun createNewAccount() {
+        Log.d(TAG, "createNewAccount tapped")
+        val key = pendingBackupKey ?: return
+        val accessToken = pendingAccessToken ?: return
+        _state.value = State.Working
+        viewModelScope.launch {
+            try {
+                val keypair = Keys.generate()
+                val npub = Nip19.npubEncode(keypair.pubkey)
+                val payload = BackupCrypto.encryptNsec(keypair.privkey, key)
+                driveService.uploadBackup(accessToken, npub, payload)
+                keyRepo.saveKeypair(keypair)
+                keyRepo.reloadPrefs(keypair.pubkey.toHex())
+                val fiatPrefs = FiatPreferences.get(getApplication())
+                fiatPrefs.setFiatMode(true)
+                fiatPrefs.setCurrency("USD")
+                _state.value = State.Done(isNewAccount = true)
+                Log.d(TAG, "state -> Done(isNewAccount=true)")
+            } catch (e: Exception) {
+                Log.w(TAG, "createNewAccount failed", e)
+                _state.value = State.Error(e.message ?: "Failed to create account.")
+            }
+        }
+    }
+
+    fun reset() {
+        profileFetchJob?.cancel()
+        profileFetchJob = null
+        pendingBackupKey = null
+        pendingAccessToken = null
+        _state.value = State.Idle
+    }
+
+    /**
+     * Opens ephemeral WebSocket connections to a couple of widely-used relays,
+     * requests kind-0 profile metadata for each backup's pubkey, and merges the
+     * parsed display name + picture into the Choose state as results arrive.
+     * Cancelled when the user moves past the chooser.
+     */
+    private fun fetchProfilesInBackground(pubkeyHexList: List<String>) {
+        profileFetchJob?.cancel()
+        profileFetchJob = viewModelScope.launch(Dispatchers.IO) {
+            val client = OkHttpClient.Builder()
+                .connectTimeout(8, TimeUnit.SECONDS)
+                .readTimeout(0, TimeUnit.MILLISECONDS)
+                .build()
+            val pubkeys = pubkeyHexList.distinct()
+            if (pubkeys.isEmpty()) return@launch
+
+            val pubkeyJsonArray = pubkeys.joinToString(",") { "\"$it\"" }
+            val reqMessage = """["REQ","wisp-google-profiles",{"kinds":[0],"authors":[$pubkeyJsonArray]}]"""
+
+            val sockets = PROFILE_RELAYS.map { url ->
+                try {
+                    client.newWebSocket(
+                        Request.Builder().url(url).build(),
+                        object : WebSocketListener() {
+                            override fun onOpen(webSocket: WebSocket, response: Response) {
+                                webSocket.send(reqMessage)
+                            }
+
+                            override fun onMessage(webSocket: WebSocket, text: String) {
+                                handleProfileMessage(text)
+                            }
+
+                            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                                Log.w(TAG, "profile relay $url failed", t)
+                            }
+                        }
+                    )
+                } catch (e: Exception) {
+                    Log.w(TAG, "couldn't open profile relay $url", e)
+                    null
+                }
+            }
+
+            try {
+                kotlinx.coroutines.delay(PROFILE_FETCH_TIMEOUT_MS)
+            } finally {
+                for (socket in sockets.filterNotNull()) {
+                    try {
+                        socket.send("""["CLOSE","wisp-google-profiles"]""")
+                        socket.close(1000, null)
+                    } catch (_: Exception) {}
+                }
+                client.dispatcher.cancelAll()
+                client.connectionPool.evictAll()
+            }
+        }
+    }
+
+    private fun handleProfileMessage(text: String) {
+        val arr = try { profileJson.parseToJsonElement(text) as? JsonArray } catch (_: Exception) { return } ?: return
+        if (arr.size < 3) return
+        if (arr[0].jsonPrimitive.content != "EVENT") return
+        val event = arr[2] as? JsonObject ?: return
+        if (event["kind"]?.jsonPrimitive?.content != "0") return
+        val pubkey = event["pubkey"]?.jsonPrimitive?.content ?: return
+        val content = event["content"]?.jsonPrimitive?.content ?: return
+        val profile = try { profileJson.parseToJsonElement(content).jsonObject } catch (_: Exception) { return }
+
+        val name = profile["display_name"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+            ?: profile["name"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        val picture = profile["picture"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+
+        if (name == null && picture == null) return
+
+        // Merge into current Choose state if still active.
+        val current = _state.value
+        if (current !is State.Choose) return
+        val updated = current.backups.map { backup ->
+            if (backup.pubkeyHex == pubkey && (backup.displayName == null || backup.picture == null)) {
+                backup.copy(
+                    displayName = backup.displayName ?: name,
+                    picture = backup.picture ?: picture
+                )
+            } else backup
+        }
+        _state.value = State.Choose(updated)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        profileFetchJob?.cancel()
+        pendingBackupKey = null
+        pendingAccessToken = null
+    }
+
+    companion object {
+        private val profileJson = Json { ignoreUnknownKeys = true }
+        private val PROFILE_RELAYS = listOf(
+            "wss://relay.damus.io",
+            "wss://relay.primal.net"
+        )
+        private const val PROFILE_FETCH_TIMEOUT_MS = 8_000L
+    }
+}

--- a/app/src/main/res/drawable/ic_google_g.xml
+++ b/app/src/main/res/drawable/ic_google_g.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#4285F4"
+        android:pathData="M22.56,12.25c0,-0.78 -0.07,-1.53 -0.2,-2.25H12v4.26h5.92c-0.26,1.37 -1.04,2.53 -2.21,3.31v2.77h3.57c2.08,-1.92 3.28,-4.74 3.28,-8.09z" />
+    <path
+        android:fillColor="#34A853"
+        android:pathData="M12,23c2.97,0 5.46,-0.98 7.28,-2.66l-3.57,-2.77c-0.98,0.66 -2.23,1.06 -3.71,1.06 -2.86,0 -5.29,-1.93 -6.16,-4.53H2.18v2.84C3.99,20.53 7.7,23 12,23z" />
+    <path
+        android:fillColor="#FBBC05"
+        android:pathData="M5.84,14.09c-0.22,-0.66 -0.35,-1.36 -0.35,-2.09s0.13,-1.43 0.35,-2.09V7.07H2.18C1.43,8.55 1,10.22 1,12s0.43,3.45 1.18,4.93l2.85,-2.22 0.81,-0.62z" />
+    <path
+        android:fillColor="#EA4335"
+        android:pathData="M12,5.38c1.62,0 3.06,0.56 4.21,1.64l3.15,-3.15C17.45,2.09 14.97,1 12,1 7.7,1 3.99,3.47 2.18,7.07l3.66,2.84c0.87,-2.6 3.3,-4.53 6.16,-4.53z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,22 @@
     <!-- Splash Screen -->
     <string name="splash_create_account">Create Account</string>
     <string name="splash_log_in">Log In</string>
+    <string name="splash_continue_with_google">Continue with Google</string>
+
+    <!-- Google Sign-In / Drive Backup -->
+    <!-- Replace this empty string with your OAuth 2.0 Web Client ID from Google Cloud Console. -->
+    <string name="google_web_client_id" translatable="false">410412439051-mhcgeuvc2sjp75v8snucstfr5smrg03g.apps.googleusercontent.com</string>
+    <string name="google_auth_starting">Starting…</string>
+    <string name="google_auth_signing_in">Signing in with Google…</string>
+    <string name="google_auth_checking_drive">Checking your Google Drive backup…</string>
+    <string name="google_auth_working">Almost there…</string>
+    <string name="google_auth_choose_title_with_backups">Your backed-up accounts</string>
+    <string name="google_auth_choose_body_with_backups">Tap an account to restore it, or create a new one. New accounts are encrypted and added to your Google Drive backup.</string>
+    <string name="google_auth_choose_title_empty">Create your account</string>
+    <string name="google_auth_choose_body_empty">Wisp will generate a new Nostr key and save an encrypted backup to a hidden folder in your Google Drive. The encryption key is derived from your Google account, so anyone with access to it can recover your identity.</string>
+    <string name="google_auth_restore">Restore</string>
+    <string name="google_auth_create_first">Create account &amp; back up</string>
+    <string name="google_auth_create_another">Create another account</string>
     <string name="splash_people_online">%d people online now</string>
     <string name="online_now">Online Now</string>
     <string name="online_in_network">%d online in your network</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,9 @@ breez-sdk-spark = "0.11.0"
 activity-compose = "1.9.3"
 navigation-compose = "2.8.5"
 lifecycle = "2.8.7"
+credentials = "1.3.0"
+googleid = "1.1.1"
+play-services-auth = "21.3.0"
 
 [libraries]
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
@@ -66,6 +69,10 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 objectbox-android = { group = "io.objectbox", name = "objectbox-android", version.ref = "objectbox" }
 objectbox-kotlin = { group = "io.objectbox", name = "objectbox-kotlin", version.ref = "objectbox" }
 breez-sdk-spark = { group = "breez_sdk_spark", name = "bindings-android", version.ref = "breez-sdk-spark" }
+androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
+googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "play-services-auth" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- New "Continue with Google" splash entry: signs in via Credential Manager (no Drive consent dialog), then routes to a chooser of restorable accounts (or straight to a "create new account" prompt).
- Backups are encrypted and published as NIP-78 (kind 30078) events to a handful of widely-used public relays — they survive app deletion, aren't subject to Drive retention policy, and the user never sees a "Wisp wants to access your Google Drive" permission ask.
- One Google account can back up many Nostr identities — each one is a separate replaceable event under the same Google-derived signing key, distinguished by `d="wisp-backup:<target_npub>"`. The chooser shows every backup found with avatar + display name (fetched via a separate `kind:0` relay query).
- "Create another account" is always available even when prior backups exist.
- Splash button uses Google's dark-mode brand spec (Sign in with Google guidelines): #131314 container, full-color G logo, #8E918F stroke.

## How it works
- `BackupCrypto.deriveKeys(sub)` HKDFs the Google ID token's `sub` claim into two distinct keys — a 32-byte XChaCha20 encryption key for the NIP-44 payload, and a 32-byte secp256k1 signing privkey for the backup event author.
- `RelayBackupService` opens parallel WebSocket REQ subscriptions to `relay.damus.io`, `relay.primal.net`, `nos.lol`, `relay.nostr.band`, `nostr.wine`. Events are deduped by `d` tag (latest `created_at` wins). Publish considers itself successful as soon as ≥1 relay returns `OK true`.
- Local keypair save only happens after a successful publish, so a failed publish doesn't leave the user in a half-state where a key exists locally with no backup.

## Security model
Same as the Drive version: anyone who can sign in to the user's Google account can derive the same keys and recover the nsec. Other apps using Google sign-in get a different `sub` (per OAuth client ID) and cannot recover. Relays see only ciphertext + a deterministic-looking author pubkey.

## Setup before this works in a build
The OAuth client must be configured in Google Cloud Console:
1. Create credentials:
   - **Web** client → paste its ID into `<string name="google_web_client_id">…</string>` in `strings.xml` (this is the `serverClientId` for Credential Manager).
   - **Android** client for debug build (package `com.wisp.app.debug` + debug-keystore SHA-1).
   - **Android** client for release build (package `com.wisp.app` + release-keystore SHA-1) before shipping.

No Drive API enablement, no OAuth scope additions required — Credential Manager only needs the basic profile info.

## Test plan
- [ ] Fresh Google account, no backups yet → tap Continue with Google → "Create your account" prompt with disclosure → confirm → lands in onboarding; sign in with same Google account on a fresh install → restore list shows the previously-created account with avatar + display name.
- [ ] Create a second account on the same Google login → backup count goes from 1 → 2; both appear in the chooser on next sign-in.
- [ ] "Create another account" while backups already exist → makes a new account without touching the existing ones.
- [ ] Different Google account on the same device → empty chooser, only "Create your account" prompt visible.
- [ ] Offline / all relays blocked → create flow shows the "couldn't reach any backup relay" error and does NOT save the keypair locally (retry-safe).
- [ ] Existing flows untouched: Sign Up still generates a random nsec with no relay interaction; Log In with pasted nsec still works; Amber / NIP-46 signer login still works from `AuthScreen`.
- [ ] Back arrow on the Google auth screen pops back to splash from any state.