### PR TITLE
refactor: remove local relay functionality

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -277,15 +277,6 @@ class OutboxRouter(
             targetedRelays.addAll(relayPool.getRelayUrls())
         }
 
-        // Also query local relay for own notes
-        if (pubkey == relayPool.localRelayUserPubkey) {
-            val localUrl = relayPool.getLocalRelayUrl()
-            if (localUrl != null) {
-                relayPool.sendToLocalRelay(ClientMessage.req(subId, filter))
-                targetedRelays.add(localUrl)
-            }
-        }
-
         return targetedRelays
     }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayConfig.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayConfig.kt
@@ -2,22 +2,11 @@ package com.wisp.app.relay
 
 import kotlinx.serialization.Serializable
 
-enum class LocalRelayWritePolicy { OWN_NOTES, TAGGED, ALL_NOTES }
-
-@Serializable
-data class LocalRelayConfig(
-    val url: String,
-    val enabled: Boolean = true,
-    val writePolicy: LocalRelayWritePolicy = LocalRelayWritePolicy.OWN_NOTES,
-    val kinds: Set<Int> = setOf(1, 1059, 9735)
-)
-
 enum class RelaySetType(val displayName: String, val eventKind: Int) {
     GENERAL("General", 10002),
     DM("DM", 10050),
     SEARCH("Search", 10007),
-    BLOCKED("Blocked", 10006),
-    LOCAL("Local", 0)
+    BLOCKED("Blocked", 10006)
 }
 
 @Serializable
@@ -67,18 +56,5 @@ data class RelayConfig(
             return true
         }
 
-        private val LOCAL_HOST_REGEX = Regex(
-            "^ws://(" +
-                "localhost|" +
-                "127\\.0\\.0\\.1|" +
-                "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" +
-                "192\\.168\\.\\d{1,3}\\.\\d{1,3}|" +
-                "172\\.(1[6-9]|2\\d|3[01])\\.\\d{1,3}\\.\\d{1,3}|" +
-                "[\\w.-]+:\\d+" +    // any host with explicit port
-            ")(:\\d+)?(/.*)?$"
-        )
-
-        /** Returns true if the URL is a local/private relay (ws:// with localhost, loopback, or private IP). */
-        fun isLocalRelayUrl(url: String): Boolean = LOCAL_HOST_REGEX.matches(url)
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayLifecycleManager.kt
@@ -97,7 +97,6 @@ class RelayLifecycleManager(
         Log.d("RLC", "[Lifecycle] onAppPause — connectedCount=${relayPool.connectedCount.value}")
         relayPool.appIsActive = false
         relayPool.healthTracker?.closeAllSessions()
-        relayPool.pauseLocalRelay()
     }
 
     /**
@@ -112,7 +111,6 @@ class RelayLifecycleManager(
         // Set suppression window to prevent network-change reconnects from
         // firing shortly after this resume and causing a double reconnect.
         resumeReconnectUntilMs = System.currentTimeMillis() + RESUME_SUPPRESSION_MS
-        relayPool.resumeLocalRelay()
         reconnect(force = force)
     }
 

--- a/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/RelayPool.kt
@@ -47,11 +47,6 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
     private var blockedUrls = emptySet<String>()
     fun getBlockedUrls(): Set<String> = blockedUrls
 
-    // --- Local relay ---
-    private var localRelay: Relay? = null
-    private var localRelayConfig: LocalRelayConfig? = null
-    @Volatile var localRelayUserPubkey: String? = null
-
     /** URLs tagged as recipient DM delivery relays (tier 2 for AUTH). */
     private val dmDeliveryTargets: MutableSet<String> = java.util.concurrent.ConcurrentHashMap.newKeySet()
 
@@ -409,10 +404,6 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
                             }
                             _events.tryEmit(msg.event)
                             _relayEvents.tryEmit(RelayEvent(msg.event, relay.config.url, msg.subscriptionId))
-                            // Forward to local relay (fire-and-forget)
-                            if (localRelay != null && relay !== localRelay && shouldForwardToLocalRelay(msg.event)) {
-                                localRelay?.send(ClientMessage.event(msg.event))
-                            }
                             subEventCounts.getOrPut(msg.subscriptionId) { java.util.concurrent.atomic.AtomicInteger(0) }.incrementAndGet()
                             if (msg.subscriptionId.startsWith("feed")) {
                                 val count = ++feedEventCounter
@@ -606,10 +597,6 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
                 if (relay.send(message)) sentCount++
                 if (isEvent && appIsActive) healthTracker?.onEventSent(relay.config.url, message.length)
             }
-        }
-        // Also forward to local relay for own published events
-        if (isEvent && localRelay != null && localRelayConfig?.enabled == true) {
-            localRelay?.send(message)
         }
         return sentCount
     }
@@ -846,7 +833,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
      */
     fun connectEphemeralRelay(url: String) {
         if (url in blockedUrls) return
-        if (!RelayConfig.isValidUrl(url) && !RelayConfig.isLocalRelayUrl(url)) return
+        if (!RelayConfig.isValidUrl(url)) return
         if (ephemeralRelays.containsKey(url) || relayIndex.containsKey(url)) return
         if (ephemeralRelays.size >= MAX_EPHEMERAL) return
         ephemeralRelays.computeIfAbsent(url) {
@@ -870,7 +857,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
     ): Boolean {
         if (url in blockedUrls) return false
         if (!skipBadCheck && healthTracker?.isBad(url) == true) return false
-        if (!RelayConfig.isValidUrl(url) && !RelayConfig.isLocalRelayUrl(url)) return false
+        if (!RelayConfig.isValidUrl(url)) return false
 
         // Check cooldown for failed relays
         val cooldownUntil = relayCooldowns[url]
@@ -1199,7 +1186,7 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
      */
     fun preConnectEphemeral(url: String) {
         if (url in blockedUrls) return
-        if (!RelayConfig.isValidUrl(url) && !RelayConfig.isLocalRelayUrl(url)) return
+        if (!RelayConfig.isValidUrl(url)) return
         if (ephemeralRelays.containsKey(url)) return
         if (ephemeralRelays.size >= MAX_EPHEMERAL) return
         val relay = Relay(RelayConfig(url, read = true, write = false), client, scope)
@@ -1272,97 +1259,6 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         }
     }
 
-    // --- Local relay management ---
-
-    fun updateLocalRelay(config: LocalRelayConfig?, userPubkey: String?) {
-        localRelayUserPubkey = userPubkey
-        val oldRelay = localRelay
-        val oldUrl = oldRelay?.config?.url
-
-        if (config == null || !config.enabled) {
-            // Remove local relay
-            if (oldRelay != null) {
-                oldRelay.forceDisconnect()
-                cancelRelayJobs(oldRelay.config.url)
-                relayIndex.remove(oldRelay.config.url)
-                localRelay = null
-                localRelayConfig = null
-                Log.d("RLC", "[Pool] local relay removed: $oldUrl")
-            }
-            return
-        }
-
-        localRelayConfig = config
-
-        if (oldUrl == config.url && oldRelay != null) {
-            // URL unchanged — just update config, reconnect if needed.
-            // Re-enable auto-reconnect in case the relay was paused via pauseLocalRelay().
-            oldRelay.reconnectEnabled = true
-            if (!oldRelay.isConnected) oldRelay.connect()
-            return
-        }
-
-        // Disconnect old if URL changed
-        if (oldRelay != null) {
-            oldRelay.forceDisconnect()
-            cancelRelayJobs(oldRelay.config.url)
-            relayIndex.remove(oldRelay.config.url)
-        }
-
-        // Create new local relay connection
-        val relayConfig = RelayConfig(config.url, read = true, write = true)
-        val relay = Relay(relayConfig, client)
-        localRelay = relay
-        relayIndex[config.url] = relay
-        collectMessages(relay)
-
-        relay.connect()
-        Log.d("RLC", "[Pool] local relay connected: ${config.url}")
-    }
-
-    /** Disconnect local relay socket but preserve references for cheap resume. */
-    fun pauseLocalRelay() {
-        val relay = localRelay ?: return
-        relay.reconnectEnabled = false
-        relay.disconnect()
-        Log.d("RLC", "[Pool] local relay paused: ${relay.config.url}")
-    }
-
-    /** Reconnect local relay if still configured and enabled. Safe to call repeatedly. */
-    fun resumeLocalRelay() {
-        val relay = localRelay ?: return
-        val cfg = localRelayConfig ?: return
-        if (!cfg.enabled) return
-        relay.reconnectEnabled = true
-        relay.resetBackoff()
-        if (!relay.isConnected) relay.connect()
-        Log.d("RLC", "[Pool] local relay resumed: ${relay.config.url}")
-    }
-
-    fun getLocalRelayUrl(): String? = localRelayConfig?.url
-
-    /** Send a message to the local relay if configured and connected. Fire-and-forget. */
-    fun sendToLocalRelay(message: String): Boolean {
-        val relay = localRelay ?: return false
-        if (localRelayConfig?.enabled != true) return false
-        return relay.send(message)
-    }
-
-    private fun shouldForwardToLocalRelay(event: NostrEvent): Boolean {
-        val config = localRelayConfig ?: return false
-        if (!config.enabled) return false
-        if (localRelay == null) return false
-        if (event.kind !in config.kinds) return false
-        return when (config.writePolicy) {
-            LocalRelayWritePolicy.OWN_NOTES -> event.pubkey == localRelayUserPubkey
-            LocalRelayWritePolicy.TAGGED -> {
-                event.pubkey == localRelayUserPubkey ||
-                    event.tags.any { it.size >= 2 && it[0] == "p" && it[1] == localRelayUserPubkey }
-            }
-            LocalRelayWritePolicy.ALL_NOTES -> true
-        }
-    }
-
     fun disconnectAll() {
         relays.forEach { it.forceDisconnect() }
         relays.clear()
@@ -1374,9 +1270,6 @@ class RelayPool(private val prefs: SharedPreferences? = null) {
         ephemeralRelays.clear()
         ephemeralLastUsed.clear()
         relayCooldowns.clear()
-        localRelay?.forceDisconnect()
-        localRelay = null
-        localRelayConfig = null
         relayIndex.clear()
         relayJobs.values.forEach { it.cancel() }
         relayJobs.clear()

--- a/app/src/main/kotlin/com/wisp/app/repo/BlossomRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/BlossomRepository.kt
@@ -55,7 +55,7 @@ class BlossomRepository(private val context: Context, pubkeyHex: String? = null)
 
     // In-memory reset only. `prefs` is shared with KeyRepository
     // (`wisp_prefs_{pubkey}`), so `prefs.edit().clear()` would also wipe
-    // `local_relay`, `relays`, `dm_relays`, etc. `reload(newPubkey)` below
+    // `relays`, `dm_relays`, etc. `reload(newPubkey)` below
     // repoints to the new account's file.
     fun clear() {
         _servers.value = listOf(Blossom.DEFAULT_SERVER)

--- a/app/src/main/kotlin/com/wisp/app/repo/KeyRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/KeyRepository.kt
@@ -8,7 +8,6 @@ import com.wisp.app.nostr.Keys
 import com.wisp.app.nostr.Nip19
 import com.wisp.app.nostr.hexToByteArray
 import com.wisp.app.nostr.toHex
-import com.wisp.app.relay.LocalRelayConfig
 import com.wisp.app.relay.RelayConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -63,9 +62,6 @@ class KeyRepository(private val context: Context) {
     private val _blockedRelays = MutableStateFlow(loadBlockedRelays())
     val blockedRelaysFlow: StateFlow<List<String>> = _blockedRelays
 
-    private val _localRelay = MutableStateFlow(loadLocalRelay())
-    val localRelayFlow: StateFlow<LocalRelayConfig?> = _localRelay
-
     // Strong reference to prevent GC — listener syncs flows when prefs change from any instance
     private val prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
         when (key) {
@@ -73,7 +69,6 @@ class KeyRepository(private val context: Context) {
             "dm_relays" -> _dmRelays.value = loadDmRelays()
             "search_relays" -> _searchRelays.value = loadSearchRelays()
             "blocked_relays" -> _blockedRelays.value = loadBlockedRelays()
-            "local_relay" -> _localRelay.value = loadLocalRelay()
         }
     }
 
@@ -324,7 +319,7 @@ class KeyRepository(private val context: Context) {
         _dmRelays.value = loadDmRelays()
         _searchRelays.value = loadSearchRelays()
         _blockedRelays.value = loadBlockedRelays()
-        _localRelay.value = loadLocalRelay()
+        prefs.edit().remove("local_relay").apply()
     }
 
     fun saveRelays(relays: List<RelayConfig>) {
@@ -377,22 +372,6 @@ class KeyRepository(private val context: Context) {
     private fun loadBlockedRelays(): List<String> {
         val str = prefs.getString("blocked_relays", null) ?: return emptyList()
         return try { json.decodeFromString(str) } catch (_: Exception) { emptyList() }
-    }
-
-    fun saveLocalRelay(config: LocalRelayConfig?) {
-        if (config != null) {
-            prefs.edit().putString("local_relay", json.encodeToString(config)).apply()
-        } else {
-            prefs.edit().remove("local_relay").apply()
-        }
-        _localRelay.value = config
-    }
-
-    fun getLocalRelay(): LocalRelayConfig? = _localRelay.value
-
-    private fun loadLocalRelay(): LocalRelayConfig? {
-        val str = prefs.getString("local_relay", null) ?: return null
-        return try { json.decodeFromString(str) } catch (_: Exception) { null }
     }
 
     fun isOnboardingComplete(): Boolean {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
@@ -292,7 +291,6 @@ fun FeedScreen(
     val newNotesButtonHidden by viewModel.newNotesButtonHidden.collectAsState()
     val initLoadingState by viewModel.initLoadingState.collectAsState()
     val relayFeedStatus by viewModel.relayFeedStatus.collectAsState()
-    val localRelayConfig by viewModel.keyRepo.localRelayFlow.collectAsState()
     val pendingFirstFollow by viewModel.pendingFirstFollow.collectAsState()
     val firstFollowCheckDone by viewModel.firstFollowCheckDone.collectAsState()
     val zapInProgress by viewModel.zapInProgress.collectAsState()
@@ -466,7 +464,6 @@ fun FeedScreen(
             favoriteRelays = favoriteRelays,
             relaySets = ownRelaySets,
             relayInfoRepo = viewModel.relayInfoRepo,
-            localRelayUrl = localRelayConfig?.let { if (it.enabled) it.url else null },
             onSelect = { url ->
                 viewModel.setSelectedRelay(url)
                 viewModel.setFeedType(FeedType.RELAY)
@@ -1670,7 +1667,6 @@ private fun RelayPickerDialog(
     favoriteRelays: List<String>,
     relaySets: List<RelaySet>,
     relayInfoRepo: RelayInfoRepository,
-    localRelayUrl: String? = null,
     onSelect: (String) -> Unit,
     onSelectRelaySet: (RelaySet) -> Unit,
     onCreateRelaySet: (String) -> Unit,
@@ -1751,44 +1747,6 @@ private fun RelayPickerDialog(
                 Spacer(Modifier.size(12.dp))
 
                 LazyColumn(modifier = Modifier.heightIn(max = 400.dp)) {
-                    // Local relay — always first when configured
-                    if (localRelayUrl != null) {
-                        item(key = "local-relay") {
-                            Surface(
-                                onClick = { onSelect(localRelayUrl) },
-                                shape = RoundedCornerShape(8.dp),
-                                color = MaterialTheme.colorScheme.surfaceVariant,
-                                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Icon(
-                                        Icons.Filled.Home,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                    Spacer(Modifier.width(8.dp))
-                                    Column {
-                                        Text(
-                                            stringResource(R.string.local_relay_my_relay),
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            fontWeight = FontWeight.Medium,
-                                            color = MaterialTheme.colorScheme.onSurface
-                                        )
-                                        Text(
-                                            localRelayUrl.removePrefix("ws://").removePrefix("wss://").removeSuffix("/"),
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-
                     // Favorites section
                     if (favoriteRelays.isNotEmpty()) {
                         item {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/RelayScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/RelayScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -23,35 +22,25 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScrollableTabRow
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import com.wisp.app.relay.LocalRelayConfig
-import com.wisp.app.relay.LocalRelayWritePolicy
 import com.wisp.app.relay.RelayConfig
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.relay.RelaySetType
 import com.wisp.app.R
-import com.wisp.app.ui.theme.wispSwitchColors
 import com.wisp.app.viewmodel.RelayViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -69,7 +58,6 @@ fun RelayScreen(
     val searchRelays by viewModel.searchRelays.collectAsState()
     val blockedRelays by viewModel.blockedRelays.collectAsState()
     val newRelayUrl by viewModel.newRelayUrl.collectAsState()
-    val localRelayConfig by viewModel.localRelay.collectAsState()
 
     val tabs = RelaySetType.entries
 
@@ -108,81 +96,53 @@ fun RelayScreen(
             }
 
             Column(modifier = Modifier.padding(16.dp)) {
-                if (selectedTab == RelaySetType.LOCAL) {
-                    // Local tab: show URL input only when no relay is configured
-                    if (localRelayConfig == null) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            OutlinedTextField(
-                                value = newRelayUrl,
-                                onValueChange = { viewModel.updateNewRelayUrl(it) },
-                                label = { Text(stringResource(R.string.local_relay_url_hint)) },
-                                singleLine = true,
-                                modifier = Modifier.weight(1f)
-                            )
-                            Spacer(Modifier.width(8.dp))
-                            IconButton(onClick = { viewModel.addRelay() }) {
-                                Icon(Icons.Default.Add, stringResource(R.string.cd_add_relay))
-                            }
-                        }
-                        Spacer(Modifier.height(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedTextField(
+                        value = newRelayUrl,
+                        onValueChange = { viewModel.updateNewRelayUrl(it) },
+                        label = { Text(stringResource(R.string.placeholder_relay_url)) },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    IconButton(onClick = { viewModel.addRelay() }) {
+                        Icon(Icons.Default.Add, stringResource(R.string.cd_add_relay))
                     }
+                }
 
-                    LocalRelayTab(localRelayConfig, viewModel)
-                } else {
-                    // Network relay tabs: URL input + broadcast
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
+                Spacer(Modifier.height(8.dp))
+
+                if (relayPool != null) {
+                    val buttonLabel = when (selectedTab) {
+                        RelaySetType.GENERAL -> stringResource(R.string.broadcast_nip65)
+                        RelaySetType.DM -> stringResource(R.string.broadcast_dm_relays)
+                        RelaySetType.SEARCH -> stringResource(R.string.broadcast_search_relays)
+                        RelaySetType.BLOCKED -> stringResource(R.string.broadcast_blocked_relays)
+                    }
+                    val successMsg = stringResource(R.string.error_relay_broadcast)
+                    val failureMsg = stringResource(R.string.error_broadcast_failed)
+                    Button(
+                        onClick = {
+                            val ok = viewModel.publishRelayList(relayPool, signer = signer)
+                            val msg = if (ok) successMsg else failureMsg
+                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        },
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        OutlinedTextField(
-                            value = newRelayUrl,
-                            onValueChange = { viewModel.updateNewRelayUrl(it) },
-                            label = { Text(stringResource(R.string.placeholder_relay_url)) },
-                            singleLine = true,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        IconButton(onClick = { viewModel.addRelay() }) {
-                            Icon(Icons.Default.Add, stringResource(R.string.cd_add_relay))
-                        }
+                        Text(buttonLabel)
                     }
+                }
 
-                    Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(16.dp))
 
-                    if (relayPool != null) {
-                        val buttonLabel = when (selectedTab) {
-                            RelaySetType.GENERAL -> stringResource(R.string.broadcast_nip65)
-                            RelaySetType.DM -> stringResource(R.string.broadcast_dm_relays)
-                            RelaySetType.SEARCH -> stringResource(R.string.broadcast_search_relays)
-                            RelaySetType.BLOCKED -> stringResource(R.string.broadcast_blocked_relays)
-                            RelaySetType.LOCAL -> "" // unreachable
-                        }
-                        val successMsg = stringResource(R.string.error_relay_broadcast)
-                        val failureMsg = stringResource(R.string.error_broadcast_failed)
-                        Button(
-                            onClick = {
-                                val ok = viewModel.publishRelayList(relayPool, signer = signer)
-                                val msg = if (ok) successMsg else failureMsg
-                                Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
-                            },
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text(buttonLabel)
-                        }
-                    }
-
-                    Spacer(Modifier.height(16.dp))
-
-                    when (selectedTab) {
-                        RelaySetType.GENERAL -> GeneralRelayList(relays, viewModel)
-                        RelaySetType.DM -> SimpleRelayList(dmRelays, viewModel)
-                        RelaySetType.SEARCH -> SimpleRelayList(searchRelays, viewModel)
-                        RelaySetType.BLOCKED -> SimpleRelayList(blockedRelays, viewModel)
-                        RelaySetType.LOCAL -> {} // handled above
-                    }
+                when (selectedTab) {
+                    RelaySetType.GENERAL -> GeneralRelayList(relays, viewModel)
+                    RelaySetType.DM -> SimpleRelayList(dmRelays, viewModel)
+                    RelaySetType.SEARCH -> SimpleRelayList(searchRelays, viewModel)
+                    RelaySetType.BLOCKED -> SimpleRelayList(blockedRelays, viewModel)
                 }
             }
         }
@@ -231,145 +191,6 @@ private fun GeneralRelayList(relays: List<RelayConfig>, viewModel: RelayViewMode
                     )
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun LocalRelayTab(config: LocalRelayConfig?, viewModel: RelayViewModel) {
-    if (config == null) return
-
-    Column {
-        // URL + enabled toggle
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = config.url,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-            }
-            Switch(
-                checked = config.enabled,
-                onCheckedChange = { viewModel.toggleLocalRelayEnabled() },
-                colors = wispSwitchColors()
-            )
-        }
-
-        Spacer(Modifier.height(12.dp))
-
-        // Write policy selector
-        Text(
-            text = stringResource(R.string.local_relay_write_policy),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        LocalRelayWritePolicy.entries.forEach { policy ->
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                RadioButton(
-                    selected = config.writePolicy == policy,
-                    onClick = { viewModel.updateLocalRelayPolicy(policy) }
-                )
-                Text(
-                    text = when (policy) {
-                        LocalRelayWritePolicy.OWN_NOTES -> stringResource(R.string.local_relay_own_notes)
-                        LocalRelayWritePolicy.TAGGED -> stringResource(R.string.local_relay_tagged)
-                        LocalRelayWritePolicy.ALL_NOTES -> stringResource(R.string.local_relay_all_notes)
-                    },
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
-        }
-
-        Spacer(Modifier.height(12.dp))
-
-        // Kind chips
-        Text(
-            text = stringResource(R.string.local_relay_kinds),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(Modifier.height(4.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            FilterChip(
-                selected = 1 in config.kinds,
-                onClick = {
-                    val updated = if (1 in config.kinds) config.kinds - 1 else config.kinds + 1
-                    viewModel.updateLocalRelayKinds(updated)
-                },
-                label = { Text(stringResource(R.string.local_relay_kind_notes)) }
-            )
-            FilterChip(
-                selected = 1059 in config.kinds,
-                onClick = {
-                    val updated = if (1059 in config.kinds) config.kinds - 1059 else config.kinds + 1059
-                    viewModel.updateLocalRelayKinds(updated)
-                },
-                label = { Text(stringResource(R.string.local_relay_kind_dms)) }
-            )
-            FilterChip(
-                selected = 9735 in config.kinds,
-                onClick = {
-                    val updated = if (9735 in config.kinds) config.kinds - 9735 else config.kinds + 9735
-                    viewModel.updateLocalRelayKinds(updated)
-                },
-                label = { Text(stringResource(R.string.local_relay_kind_zaps)) }
-            )
-        }
-
-        // Custom kind input
-        var customKindInput by remember { mutableStateOf("") }
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(top = 4.dp)
-        ) {
-            OutlinedTextField(
-                value = customKindInput,
-                onValueChange = { customKindInput = it.filter { c -> c.isDigit() } },
-                label = { Text(stringResource(R.string.local_relay_add_kind)) },
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                modifier = Modifier.weight(1f)
-            )
-            Spacer(Modifier.width(8.dp))
-            IconButton(onClick = {
-                val kind = customKindInput.toIntOrNull()
-                if (kind != null && kind !in config.kinds) {
-                    viewModel.updateLocalRelayKinds(config.kinds + kind)
-                    customKindInput = ""
-                }
-            }) {
-                Icon(Icons.Default.Add, stringResource(R.string.cd_add_relay))
-            }
-        }
-
-        // Show custom kinds as removable chips
-        val customKinds = config.kinds - setOf(1, 1059, 9735)
-        if (customKinds.isNotEmpty()) {
-            Spacer(Modifier.height(4.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                customKinds.forEach { kind ->
-                    FilterChip(
-                        selected = true,
-                        onClick = { viewModel.updateLocalRelayKinds(config.kinds - kind) },
-                        label = { Text("Kind $kind") }
-                    )
-                }
-            }
-        }
-
-        Spacer(Modifier.height(16.dp))
-        TextButton(
-            onClick = { viewModel.removeRelay(config.url) },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(
-                stringResource(R.string.local_relay_remove),
-                color = MaterialTheme.colorScheme.error
-            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/RelayViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/RelayViewModel.kt
@@ -9,8 +9,6 @@ import com.wisp.app.nostr.Nip51
 import com.wisp.app.nostr.Nip65
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.NostrSigner
-import com.wisp.app.relay.LocalRelayConfig
-import com.wisp.app.relay.LocalRelayWritePolicy
 import com.wisp.app.relay.RelayConfig
 import com.wisp.app.relay.RelayPool
 import com.wisp.app.relay.RelaySetType
@@ -30,7 +28,6 @@ class RelayViewModel(app: Application) : AndroidViewModel(app) {
     val dmRelays: StateFlow<List<String>> = keyRepo.dmRelaysFlow
     val searchRelays: StateFlow<List<String>> = keyRepo.searchRelaysFlow
     val blockedRelays: StateFlow<List<String>> = keyRepo.blockedRelaysFlow
-    val localRelay: StateFlow<LocalRelayConfig?> = keyRepo.localRelayFlow
 
     /** Re-point prefs at the current user's file so flows pick up their relay data. */
     fun reload() {
@@ -52,36 +49,26 @@ class RelayViewModel(app: Application) : AndroidViewModel(app) {
     fun addRelay(): Boolean {
         val url = _newRelayUrl.value.trim().trimEnd('/')
         if (url.isBlank()) return false
+        if (!RelayConfig.isValidUrl(url)) return false
 
         when (_selectedTab.value) {
-            RelaySetType.LOCAL -> {
-                if (!RelayConfig.isLocalRelayUrl(url)) return false
-                if (localRelay.value != null) return false
-                keyRepo.saveLocalRelay(LocalRelayConfig(url))
+            RelaySetType.GENERAL -> {
+                if (relays.value.any { it.url == url }) return false
+                keyRepo.saveRelays(relays.value + RelayConfig(url))
             }
-            else -> {
-                if (!RelayConfig.isValidUrl(url)) return false
-                when (_selectedTab.value) {
-                    RelaySetType.GENERAL -> {
-                        if (relays.value.any { it.url == url }) return false
-                        keyRepo.saveRelays(relays.value + RelayConfig(url))
-                    }
-                    RelaySetType.DM -> {
-                        if (url in dmRelays.value) return false
-                        keyRepo.saveDmRelays(dmRelays.value + url)
-                    }
-                    RelaySetType.SEARCH -> {
-                        if (url in searchRelays.value) return false
-                        keyRepo.saveSearchRelays(searchRelays.value + url)
-                    }
-                    RelaySetType.BLOCKED -> {
-                        if (url in blockedRelays.value) return false
-                        val updated = blockedRelays.value + url
-                        keyRepo.saveBlockedRelays(updated)
-                        relayPool?.updateBlockedUrls(updated)
-                    }
-                    else -> {}
-                }
+            RelaySetType.DM -> {
+                if (url in dmRelays.value) return false
+                keyRepo.saveDmRelays(dmRelays.value + url)
+            }
+            RelaySetType.SEARCH -> {
+                if (url in searchRelays.value) return false
+                keyRepo.saveSearchRelays(searchRelays.value + url)
+            }
+            RelaySetType.BLOCKED -> {
+                if (url in blockedRelays.value) return false
+                val updated = blockedRelays.value + url
+                keyRepo.saveBlockedRelays(updated)
+                relayPool?.updateBlockedUrls(updated)
             }
         }
         _newRelayUrl.value = ""
@@ -103,9 +90,6 @@ class RelayViewModel(app: Application) : AndroidViewModel(app) {
                 val updated = blockedRelays.value.filter { it != url }
                 keyRepo.saveBlockedRelays(updated)
                 relayPool?.updateBlockedUrls(updated)
-            }
-            RelaySetType.LOCAL -> {
-                keyRepo.saveLocalRelay(null)
             }
         }
     }
@@ -131,46 +115,26 @@ class RelayViewModel(app: Application) : AndroidViewModel(app) {
         keyRepo.saveRelays(updated)
     }
 
-    fun toggleLocalRelayEnabled() {
-        val current = localRelay.value ?: return
-        keyRepo.saveLocalRelay(current.copy(enabled = !current.enabled))
-    }
-
-    fun updateLocalRelayPolicy(writePolicy: LocalRelayWritePolicy) {
-        val current = localRelay.value ?: return
-        keyRepo.saveLocalRelay(current.copy(writePolicy = writePolicy))
-    }
-
-    fun updateLocalRelayKinds(kinds: Set<Int>) {
-        val current = localRelay.value ?: return
-        keyRepo.saveLocalRelay(current.copy(kinds = kinds))
-    }
-
     fun publishRelayList(relayPool: RelayPool, signer: NostrSigner? = null): Boolean {
         val s = signer ?: keyRepo.getKeypair()?.let { LocalSigner(it.privkey, it.pubkey) } ?: return false
         return try {
             val tab = _selectedTab.value
             val tags: List<List<String>>
-            val kind: Int
+            val kind: Int = tab.eventKind
 
             when (tab) {
                 RelaySetType.GENERAL -> {
                     tags = Nip65.buildRelayTags(relays.value)
-                    kind = tab.eventKind
                 }
                 RelaySetType.DM -> {
                     tags = Nip51.buildRelaySetTags(dmRelays.value)
-                    kind = tab.eventKind
                 }
                 RelaySetType.SEARCH -> {
                     tags = Nip51.buildRelaySetTags(searchRelays.value)
-                    kind = tab.eventKind
                 }
                 RelaySetType.BLOCKED -> {
                     tags = Nip51.buildRelaySetTags(blockedRelays.value)
-                    kind = tab.eventKind
                 }
-                RelaySetType.LOCAL -> return false // Local relays are never published
             }
 
             viewModelScope.launch {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -227,16 +227,6 @@ class StartupCoordinator(
         relayPool.updateDmRelays(dmRelays)
         eventRepo.dmRelayUrls = dmRelays.toSet()
 
-        // Connect local relay if configured
-        relayPool.updateLocalRelay(keyRepo.getLocalRelay(), getUserPubkey())
-
-        // Observe local relay config changes
-        scope.launch {
-            keyRepo.localRelayFlow.drop(1).collectLatest { config ->
-                relayPool.updateLocalRelay(config, getUserPubkey())
-            }
-        }
-
         scope.launch {
             relayInfoRepo.prefetchAll(initialRelays.map { it.url })
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -680,18 +680,4 @@
     <string name="title_delete_note">Notiz löschen?</string>
     <string name="msg_delete_note_confirm">Eine Löschanfrage für diese Notiz an die Relays senden? Dies kann nicht garantiert werden.</string>
 
-    <!-- Local Relay -->
-    <string name="local_relay_my_relay">Mein lokales Relay</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">Lokales Relay entfernen</string>
-    <string name="local_relay_write_policy">Schreibrichtlinie</string>
-    <string name="local_relay_own_notes">Meine Notizen</string>
-    <string name="local_relay_tagged">Meine Notizen und Notizen, in denen ich markiert bin</string>
-    <string name="local_relay_all_notes">Alle Notizen</string>
-    <string name="local_relay_kinds">Event-Typen</string>
-    <string name="local_relay_kind_notes">Notizen (1)</string>
-    <string name="local_relay_kind_dms">DMs (1059)</string>
-    <string name="local_relay_kind_zaps">Zaps (9735)</string>
-    <string name="local_relay_add_kind">Typ hinzufügen</string>
-    <string name="local_relay_invalid_url">Ungültige lokale Relay-URL</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -680,17 +680,4 @@
     <string name="title_delete_note">¿Eliminar nota?</string>
     <string name="msg_delete_note_confirm">¿Enviar una solicitud de eliminación de esta nota a los relays? No se puede garantizar.</string>
 
-    <string name="local_relay_my_relay">Mi Relay Local</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">Eliminar Relay Local</string>
-    <string name="local_relay_write_policy">Política de escritura</string>
-    <string name="local_relay_own_notes">Mis notas</string>
-    <string name="local_relay_tagged">Mis notas y notas en las que me etiquetan</string>
-    <string name="local_relay_all_notes">Todas las notas</string>
-    <string name="local_relay_kinds">Tipos de evento</string>
-    <string name="local_relay_kind_notes">Notas (1)</string>
-    <string name="local_relay_kind_dms">DMs (1059)</string>
-    <string name="local_relay_kind_zaps">Zaps (9735)</string>
-    <string name="local_relay_add_kind">Añadir tipo</string>
-    <string name="local_relay_invalid_url">URL de relay local no válida</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -680,18 +680,4 @@
     <string name="title_delete_note">Supprimer la note ?</string>
     <string name="msg_delete_note_confirm">Envoyer une demande de suppression de cette note aux relays ? Cela ne peut pas être garanti.</string>
 
-    <!-- Local Relay -->
-    <string name="local_relay_my_relay">Mon relais local</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">Supprimer le relais local</string>
-    <string name="local_relay_write_policy">Politique d\'écriture</string>
-    <string name="local_relay_own_notes">Mes notes</string>
-    <string name="local_relay_tagged">Mes notes et notes où je suis mentionné</string>
-    <string name="local_relay_all_notes">Toutes les notes</string>
-    <string name="local_relay_kinds">Types d\'événements</string>
-    <string name="local_relay_kind_notes">Notes (1)</string>
-    <string name="local_relay_kind_dms">DMs (1059)</string>
-    <string name="local_relay_kind_zaps">Zaps (9735)</string>
-    <string name="local_relay_add_kind">Ajouter un type</string>
-    <string name="local_relay_invalid_url">URL de relais local invalide</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -680,17 +680,4 @@
     <string name="title_delete_note">Eliminare la nota?</string>
     <string name="msg_delete_note_confirm">Inviare una richiesta di eliminazione di questa nota ai relay? Non può essere garantita.</string>
 
-    <string name="local_relay_my_relay">Il mio relay locale</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">Rimuovi relay locale</string>
-    <string name="local_relay_write_policy">Politica di scrittura</string>
-    <string name="local_relay_own_notes">Le mie note</string>
-    <string name="local_relay_tagged">Le mie note e note in cui sono taggato</string>
-    <string name="local_relay_all_notes">Tutte le note</string>
-    <string name="local_relay_kinds">Tipi di evento</string>
-    <string name="local_relay_kind_notes">Note (1)</string>
-    <string name="local_relay_kind_dms">DM (1059)</string>
-    <string name="local_relay_kind_zaps">Zap (9735)</string>
-    <string name="local_relay_add_kind">Aggiungi tipo</string>
-    <string name="local_relay_invalid_url">URL relay locale non valido</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -680,17 +680,4 @@
     <string name="title_delete_note">ノートを削除しますか？</string>
     <string name="msg_delete_note_confirm">このノートの削除リクエストをリレーに送信しますか？保証はされません。</string>
 
-    <string name="local_relay_my_relay">マイローカルリレー</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">ローカルリレーを削除</string>
-    <string name="local_relay_write_policy">書き込みポリシー</string>
-    <string name="local_relay_own_notes">自分のノート</string>
-    <string name="local_relay_tagged">自分のノートとタグ付けされたノート</string>
-    <string name="local_relay_all_notes">すべてのノート</string>
-    <string name="local_relay_kinds">イベントの種類</string>
-    <string name="local_relay_kind_notes">ノート (1)</string>
-    <string name="local_relay_kind_dms">DM (1059)</string>
-    <string name="local_relay_kind_zaps">Zap (9735)</string>
-    <string name="local_relay_add_kind">種類を追加</string>
-    <string name="local_relay_invalid_url">無効なローカルリレーURL</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -680,18 +680,4 @@
     <string name="title_delete_note">노트를 삭제하시겠습니까?</string>
     <string name="msg_delete_note_confirm">이 노트에 대한 삭제 요청을 릴레이로 보내시겠습니까? 보장되지는 않습니다.</string>
 
-    <!-- Local Relay -->
-    <string name="local_relay_my_relay">내 로컬 릴레이</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">로컬 릴레이 제거</string>
-    <string name="local_relay_write_policy">쓰기 정책</string>
-    <string name="local_relay_own_notes">내 노트</string>
-    <string name="local_relay_tagged">내 노트 및 태그된 노트</string>
-    <string name="local_relay_all_notes">모든 노트</string>
-    <string name="local_relay_kinds">이벤트 종류</string>
-    <string name="local_relay_kind_notes">노트 (1)</string>
-    <string name="local_relay_kind_dms">DM (1059)</string>
-    <string name="local_relay_kind_zaps">Zap (9735)</string>
-    <string name="local_relay_add_kind">종류 추가</string>
-    <string name="local_relay_invalid_url">잘못된 로컬 릴레이 URL</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -680,17 +680,4 @@
     <string name="title_delete_note">Notitie verwijderen?</string>
     <string name="msg_delete_note_confirm">Een verwijderverzoek voor deze notitie naar de relays sturen? Dit kan niet worden gegarandeerd.</string>
 
-    <string name="local_relay_my_relay">Mijn lokale relay</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">Lokale relay verwijderen</string>
-    <string name="local_relay_write_policy">Schrijfbeleid</string>
-    <string name="local_relay_own_notes">Mijn notities</string>
-    <string name="local_relay_tagged">Mijn notities en notities waarin ik ben getagd</string>
-    <string name="local_relay_all_notes">Alle notities</string>
-    <string name="local_relay_kinds">Evenementtypen</string>
-    <string name="local_relay_kind_notes">Notities (1)</string>
-    <string name="local_relay_kind_dms">DM\'s (1059)</string>
-    <string name="local_relay_kind_zaps">Zaps (9735)</string>
-    <string name="local_relay_add_kind">Type toevoegen</string>
-    <string name="local_relay_invalid_url">Ongeldige lokale relay-URL</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -680,17 +680,4 @@
     <string name="title_delete_note">Excluir nota?</string>
     <string name="msg_delete_note_confirm">Enviar uma solicitação de exclusão desta nota para os relays? Não pode ser garantido.</string>
 
-    <string name="local_relay_my_relay">Meu relay local</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">Remover relay local</string>
-    <string name="local_relay_write_policy">Política de escrita</string>
-    <string name="local_relay_own_notes">Minhas notas</string>
-    <string name="local_relay_tagged">Minhas notas e notas em que fui marcado</string>
-    <string name="local_relay_all_notes">Todas as notas</string>
-    <string name="local_relay_kinds">Tipos de evento</string>
-    <string name="local_relay_kind_notes">Notas (1)</string>
-    <string name="local_relay_kind_dms">DMs (1059)</string>
-    <string name="local_relay_kind_zaps">Zaps (9735)</string>
-    <string name="local_relay_add_kind">Adicionar tipo</string>
-    <string name="local_relay_invalid_url">URL de relay local inválida</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -641,17 +641,4 @@
     <string name="title_delete_note">Удалить заметку?</string>
     <string name="msg_delete_note_confirm">Отправить запрос на удаление этой заметки на реле? Это не может быть гарантировано.</string>
 
-    <string name="local_relay_my_relay">Моё локальное реле</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">Удалить локальное реле</string>
-    <string name="local_relay_write_policy">Политика записи</string>
-    <string name="local_relay_own_notes">Мои заметки</string>
-    <string name="local_relay_tagged">Мои заметки и заметки с моим упоминанием</string>
-    <string name="local_relay_all_notes">Все заметки</string>
-    <string name="local_relay_kinds">Типы событий</string>
-    <string name="local_relay_kind_notes">Заметки (1)</string>
-    <string name="local_relay_kind_dms">ЛС (1059)</string>
-    <string name="local_relay_kind_zaps">Zap (9735)</string>
-    <string name="local_relay_add_kind">Добавить тип</string>
-    <string name="local_relay_invalid_url">Недопустимый URL локального реле</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -680,18 +680,4 @@
     <string name="title_delete_note">删除笔记？</string>
     <string name="msg_delete_note_confirm">向中继发送删除此笔记的请求？无法保证一定成功。</string>
 
-    <!-- Local Relay -->
-    <string name="local_relay_my_relay">我的本地中继</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">移除本地中继</string>
-    <string name="local_relay_write_policy">写入策略</string>
-    <string name="local_relay_own_notes">我的笔记</string>
-    <string name="local_relay_tagged">我的笔记和提及我的笔记</string>
-    <string name="local_relay_all_notes">所有笔记</string>
-    <string name="local_relay_kinds">事件类型</string>
-    <string name="local_relay_kind_notes">笔记 (1)</string>
-    <string name="local_relay_kind_dms">私信 (1059)</string>
-    <string name="local_relay_kind_zaps">Zap (9735)</string>
-    <string name="local_relay_add_kind">添加类型</string>
-    <string name="local_relay_invalid_url">无效的本地中继URL</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -610,21 +610,6 @@
     <string name="broadcast_search_relays">Broadcast Search Relays</string>
     <string name="broadcast_blocked_relays">Broadcast Blocked Relays</string>
 
-    <!-- Local Relay -->
-    <string name="local_relay_my_relay">My Local Relay</string>
-    <string name="local_relay_url_hint">ws://localhost:7777</string>
-    <string name="local_relay_remove">Remove Local Relay</string>
-    <string name="local_relay_write_policy">Write Policy</string>
-    <string name="local_relay_own_notes">My Notes</string>
-    <string name="local_relay_tagged">My Notes and Notes I\'m Tagged In</string>
-    <string name="local_relay_all_notes">All Notes</string>
-    <string name="local_relay_kinds">Event Kinds</string>
-    <string name="local_relay_kind_notes">Notes (1)</string>
-    <string name="local_relay_kind_dms">DMs (1059)</string>
-    <string name="local_relay_kind_zaps">Zaps (9735)</string>
-    <string name="local_relay_add_kind">Add Kind</string>
-    <string name="local_relay_invalid_url">Invalid local relay URL</string>
-
     <!-- Post Card -->
     <string name="post_retweeted">reposted</string>
     <string name="post_and_others_retweeted">and %d others reposted</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!--
-      Allow cleartext (ws://) globally. This is safe because:
-      - All network relay validation (isValidUrl) requires wss://
-      - Only local relays (isLocalRelayUrl) accept ws://
-      - Needed because Android's domain-config doesn't match IP addresses
-        (127.0.0.1, 192.168.*, 10.*) which local relays commonly use.
-    -->
-    <base-config cleartextTrafficPermitted="true">
+    <!-- All relay URLs are validated as wss://; cleartext is never required. -->
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
## Summary
- Removes all local-relay code: `LocalRelayConfig`, `LocalRelayWritePolicy`, the `LOCAL` value in `RelaySetType`, `isLocalRelayUrl`, runtime forwarding in `RelayPool`, lifecycle pause/resume, the `OutboxRouter` own-notes branch, and the `local_relay` SharedPrefs key.
- Drops the LOCAL tab + `LocalRelayTab` composable from `RelayScreen`, and the "My Local Relay" row from `FeedScreen`'s relay picker.
- Deletes all 13 `local_relay_*` string resources across English and 10 translated locales.
- Tightens `network_security_config.xml` to `cleartextTrafficPermitted="false"` now that no relay URL ever needs `ws://`.
- `KeyRepository.reloadPrefs` clears the orphaned `local_relay` SharedPrefs entry on account switch so existing installs don't carry it forever.

## Test plan
- [x] `./gradlew assembleDebug` builds clean
- [ ] Open relay settings → 4 tabs only (General / DM / Search / Blocked); no LOCAL tab
- [ ] Open the feed relay picker → no "My Local Relay" / home-icon row; favorites/scored/sets render normally
- [ ] Publish a note → goes to wss:// write relays only, no extra forwarding
- [ ] Background + foreground the app → no errors from the now-removed pause/resume hooks
- [ ] Install on a device that previously had a `local_relay` pref → app starts normally and the orphaned key is cleared on account switch