### PR TITLE
feat(live): keep screen awake while watching a live stream

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/LiveStreamScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -144,6 +145,15 @@ fun LiveStreamScreen(
     LaunchedEffect(messages.size) {
         if (messages.isNotEmpty()) {
             listState.animateScrollToItem(0)
+        }
+    }
+
+    val context = LocalContext.current
+    DisposableEffect(context) {
+        val window = context.findHostActivity()?.window
+        window?.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
 
@@ -1087,4 +1097,13 @@ private fun formatZapSats(sats: Long): String = when {
     sats >= 1_000_000 -> "${"%.1f".format(sats / 1_000_000.0)}M"
     sats >= 1_000 -> "${"%.1f".format(sats / 1_000.0)}k"
     else -> sats.toString()
+}
+
+private fun android.content.Context.findHostActivity(): android.app.Activity? {
+    var ctx: android.content.Context = this
+    while (ctx is android.content.ContextWrapper) {
+        if (ctx is android.app.Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
 }


### PR DESCRIPTION
## Summary
- Add `FLAG_KEEP_SCREEN_ON` to the host activity window while `LiveStreamScreen` is on screen, so the device doesn't lock or dim mid-stream
- Clear the flag in `onDispose` so it doesn't leak to other screens
- Mirrors the same pattern already used by `FullScreenVideoPlayer`

## Test plan
- [ ] Open a live stream, leave the device idle past the lock timeout — screen stays on
- [ ] Back out of the live stream — lock timeout resumes as normal on the feed
- [ ] Enter fullscreen video from the live stream and back out — screen stays on throughout, then resumes normal lock behavior after leaving the stream screen