### PR TITLE
feat(wallet): derive default wallet from nsec during onboarding

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/OnboardingViewModel.kt
@@ -160,7 +160,8 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
         _error.value = null
 
         // Use real keypair if available, otherwise generate a throwaway for probing
-        val keypair = keyRepo.getKeypair() ?: Keys.generate()
+        val realKeypair = keyRepo.getKeypair()
+        val keypair = realKeypair ?: Keys.generate()
         val pubHex = keyRepo.getPubkeyHex() ?: keypair.pubkey.toHex()
         keyRepo.reloadPrefs(pubHex)
         blossomRepo.reload(pubHex)
@@ -168,14 +169,15 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
         // Reload wallet repos so mnemonic + mode are stored under the correct pubkey prefs
         walletModeRepo?.reload(pubHex)
 
-        // Pre-generate mnemonic (CPU only, no network contention with relay probing)
-        if (sparkRepo != null) {
+        // Derive the default Spark wallet deterministically from the user's nsec
+        // so it is recoverable on any device by signing in with the same key.
+        // Skip if no real keypair yet (we're only probing relays with a throwaway).
+        if (sparkRepo != null && realKeypair != null) {
             sparkRepo.reload(pubHex)
             try {
-                val mnemonic = sparkRepo.newMnemonic()
-                sparkRepo.saveMnemonic(mnemonic)
+                sparkRepo.generateDefaultFromPrivkey(realKeypair.privkey)
             } catch (e: Exception) {
-                Log.w(TAG, "Mnemonic generation failed: ${e.message}")
+                Log.w(TAG, "Default wallet derivation failed: ${e.message}")
             }
         }
 
@@ -282,8 +284,11 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
                 }
             }
 
-            // Backup mnemonic to relays via NIP-78
-            if (sparkRepo != null && lightningAddress != null) {
+            // NIP-78 relay backup is only useful for non-default wallets — the
+            // default wallet's mnemonic is derived from the nsec, and Breez
+            // remembers its lightning address registration server-side, so
+            // there's nothing extra to persist on relays.
+            if (sparkRepo != null && !sparkRepo.isDefaultWallet()) {
                 val mnemonic = sparkRepo.getMnemonic()
                 if (mnemonic != null) {
                     viewModelScope.launch {


### PR DESCRIPTION
## Summary
- New-user onboarding was generating a random BIP39 mnemonic in `startDiscovery`, so a brand-new account's wallet couldn't be restored by signing in with the same nsec on another device. Replace with `generateDefaultFromPrivkey` so the default wallet is deterministic from the user's key (and marked as the default — skipping the seed-backup nag).
- Lightning-address registration with Breez in `finishProfile` is unchanged — it now operates on the nsec-derived wallet instead of the random one.
- Drop the NIP-78 relay backup for default wallets. The mnemonic is recoverable from the nsec, and Breez retains the lightning-address registration server-side, so there's nothing extra to persist. Manual relay backup for non-default (random) wallets is unchanged.

## Test plan
- [ ] Fresh install, create a new account, complete onboarding, confirm wallet auto-connects and shows a `@spark` lightning address on Home.
- [ ] Note the address, fully sign out, sign back in with the same nsec on a clean install; confirm the wallet connects and `getLightningAddress()` returns the same address (no manual restore step).
- [ ] Confirm no `spark-wallet-backup:*` kind-30078 event is published during onboarding for default-wallet users (relay log / inspector).
- [ ] On an account with a non-default Spark wallet, run "Backup to relay" from settings and confirm it still works (legacy path).