### PR TITLE
feat(nip05): drop `_` from root-domain identifiers on display

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Nip05.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Nip05.kt
@@ -62,4 +62,8 @@ object Nip05 {
                 Nip05Result.ERROR
             }
         }
+
+    /** Strip the `_` root-domain local part for display (`_@domain` → `@domain`). */
+    fun formatForDisplay(identifier: String): String =
+        if (identifier.startsWith("_@")) identifier.substring(1) else identifier
 }

--- a/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/PostCard.kt
@@ -68,6 +68,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Surface
+import com.wisp.app.nostr.Nip05
 import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.Nip13
 import com.wisp.app.nostr.Nip19
@@ -1321,7 +1322,7 @@ internal fun Nip05Badge(
         )
     ) {
         Text(
-            text = nip05,
+            text = Nip05.formatForDisplay(nip05),
             style = MaterialTheme.typography.bodySmall,
             color = textColor,
             maxLines = maxLines,

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.wisp.app.nostr.Nip05
 import com.wisp.app.nostr.ProfileData
 import com.wisp.app.repo.AccountInfo
 
@@ -188,7 +189,7 @@ fun WispDrawerContent(
             Spacer(Modifier.height(2.dp))
             if (!profile?.nip05.isNullOrBlank()) {
                 Text(
-                    text = profile!!.nip05!!,
+                    text = Nip05.formatForDisplay(profile!!.nip05!!),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/CommunityScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/CommunityScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.wisp.app.nostr.Nip05
 import com.wisp.app.nostr.ProfileData
 import com.wisp.app.repo.ContactRepository
 import com.wisp.app.ui.component.FollowButton
@@ -163,7 +164,7 @@ private fun ProfileCard(
                 )
                 if (!profile.nip05.isNullOrBlank()) {
                     Text(
-                        text = profile.nip05,
+                        text = Nip05.formatForDisplay(profile.nip05),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ContactPickerScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ContactPickerScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wisp.app.R
+import com.wisp.app.nostr.Nip05
 import com.wisp.app.repo.ContactRepository
 import com.wisp.app.repo.EventRepository
 import com.wisp.app.ui.component.ProfilePicture
@@ -156,7 +157,7 @@ fun ContactPickerScreen(
                         )
                         if (profile?.nip05 != null) {
                             Text(
-                                text = profile.nip05,
+                                text = Nip05.formatForDisplay(profile.nip05),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 maxLines = 1,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DraftsScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DraftsScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.wisp.app.nostr.Nip05
 import com.wisp.app.nostr.Nip30
 import com.wisp.app.nostr.Nip37
 import com.wisp.app.nostr.NostrEvent
@@ -222,7 +223,7 @@ private fun DraftItem(
                 )
                 if (!userProfile?.nip05.isNullOrBlank()) {
                     Text(
-                        text = userProfile!!.nip05!!,
+                        text = Nip05.formatForDisplay(userProfile!!.nip05!!),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.primary,
                         maxLines = 1,
@@ -308,7 +309,7 @@ private fun ScheduledPostItem(
                 )
                 if (!userProfile?.nip05.isNullOrBlank()) {
                     Text(
-                        text = userProfile!!.nip05!!,
+                        text = Nip05.formatForDisplay(userProfile!!.nip05!!),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.primary,
                         maxLines = 1,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/FeedScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wisp.app.nostr.FollowSet
+import com.wisp.app.nostr.Nip05
 import com.wisp.app.nostr.Nip10
 import com.wisp.app.nostr.Nip69
 import com.wisp.app.nostr.NostrEvent
@@ -2644,7 +2645,7 @@ private fun TrendingUsersContent(
                             )
                             if (!profile.nip05.isNullOrBlank()) {
                                 Text(
-                                    profile.nip05,
+                                    Nip05.formatForDisplay(profile.nip05),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     maxLines = 1,

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SearchScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wisp.app.nostr.Nip02
+import com.wisp.app.nostr.Nip05
 import com.wisp.app.nostr.Nip69
 import com.wisp.app.nostr.NostrEvent
 import com.wisp.app.nostr.ProfileData
@@ -765,7 +766,7 @@ private fun AuthorFilter(
                         )
                         if (!profile.nip05.isNullOrBlank()) {
                             Text(
-                                text = profile.nip05,
+                                text = Nip05.formatForDisplay(profile.nip05),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 maxLines = 1,
@@ -804,7 +805,7 @@ private fun UserResultItem(
             )
             if (!profile.nip05.isNullOrBlank()) {
                 Text(
-                    text = profile.nip05,
+                    text = Nip05.formatForDisplay(profile.nip05),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,


### PR DESCRIPTION
## Summary
- Per NIP-05, a local part of `_` denotes the root domain (`_@damus.io` → identity for `damus.io`).
- Added `Nip05.formatForDisplay()` and applied it at every NIP-05 render site so `_@domain.com` shows as `@domain.com`.
- Verification (`Nip05.verify`) still operates on the raw stored value — display-only change.

## Test plan
- [ ] Build debug APK with `JAVA_HOME=~/Downloads/android-studio/jbr ./gradlew assembleDebug`
- [ ] Find a profile using `_@domain` form (e.g. a damus.io root account) and confirm the badge under the display name renders as `@domain.com`
- [ ] Confirm regular `name@domain.com` identifiers are unchanged
- [ ] Confirm the verified checkmark still appears
- [ ] Spot-check search results, community member list, contact picker, drafts screen, and drawer