### PR TITLE
chore: update Google OAuth client ID and bump to 1.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = baseApplicationId
         minSdk = 26
         targetSdk = 35
-        versionCode = 79
-        versionName = "1.0.5"
+        versionCode = 80
+        versionName = "1.1.0"
         resValue("string", "app_name", "Wisp")
 
         ndk {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
 
     <!-- Google Sign-In / Drive Backup -->
     <!-- Replace this empty string with your OAuth 2.0 Web Client ID from Google Cloud Console. -->
-    <string name="google_web_client_id" translatable="false">410412439051-mhcgeuvc2sjp75v8snucstfr5smrg03g.apps.googleusercontent.com</string>
+    <string name="google_web_client_id" translatable="false">410412439051-6h77f1666dtbgmo1o3r7fkk1egpf7a7p.apps.googleusercontent.com</string>
     <string name="google_auth_starting">Starting…</string>
     <string name="google_auth_signing_in">Signing in with Google…</string>
     <string name="google_auth_checking_drive">Checking your Google Drive backup…</string>


### PR DESCRIPTION
## Summary
- Update `google_web_client_id` to the new OAuth 2.0 Web Client ID
- Bump `versionName` to `1.1.0` (versionCode 80)

## Test plan
- [ ] Verify Google Sign-In flow succeeds with the new client ID
- [ ] Confirm version displays as 1.1.0 in app