### PR TITLE
feat(compose): countdown progress bar + auto-scroll preview

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -99,6 +99,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -110,6 +111,8 @@ import kotlinx.coroutines.delay
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -214,6 +217,16 @@ fun ComposeScreen(
             countdownProgress = (elapsed.toFloat() / totalMs).coerceIn(0f, 1f)
             if (countdownProgress >= 1f) break
             delay(16)
+        }
+    }
+
+    // Scroll preview to top of viewport when countdown active and keyboard gone
+    val scrollState = rememberScrollState()
+    var previewTopOffsetPx by remember { mutableIntStateOf(0) }
+    LaunchedEffect(imeVisible, countdownSeconds) {
+        if (!imeVisible && countdownSeconds != null) {
+            val showPreview = content.text.isNotBlank() || (pollEnabled && pollOptions.any { it.isNotBlank() })
+            if (showPreview) scrollState.animateScrollTo(previewTopOffsetPx)
         }
     }
 
@@ -545,7 +558,7 @@ fun ComposeScreen(
                         .weight(1f)
                         .padding(horizontal = 16.dp)
                         .padding(top = 16.dp)
-                        .verticalScroll(rememberScrollState())
+                        .verticalScroll(scrollState)
                 ) {
                     // Reply context (expandable)
                     replyTo?.let {
@@ -1101,6 +1114,11 @@ fun ComposeScreen(
                             }
                         }
                     }
+
+                    // Anchor for scroll-to-preview (always in layout so position is always valid)
+                    Spacer(modifier = Modifier.onGloballyPositioned { coords ->
+                        previewTopOffsetPx = coords.positionInParent().y.toInt()
+                    })
 
                     // Live preview
                     AnimatedVisibility(

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -23,7 +23,9 @@ import androidx.compose.foundation.content.contentReceiver
 import androidx.compose.foundation.content.hasMediaType
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -96,6 +98,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -103,6 +106,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import kotlinx.coroutines.delay
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
@@ -166,6 +170,8 @@ fun ComposeScreen(
     val uploadedUrls by viewModel.uploadedUrls.collectAsState()
     val uploadProgress by viewModel.uploadProgress.collectAsState()
     val countdownSeconds by viewModel.countdownSeconds.collectAsState()
+    val countdownTotalSeconds by viewModel.countdownTotalSeconds.collectAsState()
+    val countdownStartedAt by viewModel.countdownStartedAt.collectAsState()
     val mentionCandidates by viewModel.mentionCandidates.collectAsState()
     val mentionQuery by viewModel.mentionQuery.collectAsState()
     val explicit by viewModel.explicit.collectAsState()
@@ -196,6 +202,20 @@ fun ComposeScreen(
     var pendingDateMillis by remember { mutableStateOf<Long?>(null) }
 
     val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+
+    // Countdown progress (smooth, ~60fps)
+    var countdownProgress by remember { mutableFloatStateOf(0f) }
+    LaunchedEffect(countdownStartedAt) {
+        if (countdownStartedAt == null) { countdownProgress = 0f; return@LaunchedEffect }
+        val totalMs = countdownTotalSeconds * 1000L
+        val startTime = countdownStartedAt!!
+        while (true) {
+            val elapsed = System.currentTimeMillis() - startTime
+            countdownProgress = (elapsed.toFloat() / totalMs).coerceIn(0f, 1f)
+            if (countdownProgress >= 1f) break
+            delay(16)
+        }
+    }
 
     val photoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickMultipleVisualMedia()
@@ -1181,26 +1201,45 @@ fun ComposeScreen(
             }
 
             // Bottom bar — always visible above keyboard (shared by both modes)
-            Column(modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp).padding(vertical = 12.dp)) {
                     if (countdownSeconds != null) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        OutlinedButton(
-                            onClick = { viewModel.cancelPublish() },
-                            colors = ButtonDefaults.outlinedButtonColors(
-                                contentColor = MaterialTheme.colorScheme.error
+                        // Cancel — red circle with X
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .size(44.dp)
+                                .background(Color(0xFFE53935), CircleShape)
+                                .clickable { viewModel.cancelPublish() }
+                        ) {
+                            Icon(
+                                Icons.Filled.Close,
+                                contentDescription = stringResource(R.string.btn_undo),
+                                tint = Color.White,
+                                modifier = Modifier.size(20.dp)
                             )
-                        ) {
-                            Text(stringResource(R.string.btn_undo))
                         }
-                        Spacer(Modifier.width(8.dp))
-                        Button(
-                            onClick = { viewModel.publishNow() },
-                            modifier = Modifier.weight(1f)
+                        // Progress bar pill — fills left-to-right over the undo window
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(44.dp)
+                                .clip(CircleShape)
+                                .clickable { viewModel.publishNow() }
                         ) {
-                            Text(stringResource(R.string.compose_post_now, countdownSeconds!!))
+                            Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.primary.copy(alpha = 0.25f)))
+                            Box(modifier = Modifier.fillMaxHeight().fillMaxWidth(countdownProgress).background(MaterialTheme.colorScheme.primary))
+                            Text(
+                                text = stringResource(R.string.compose_post_now, countdownSeconds!!),
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
                         }
                     }
                 } else {
@@ -1220,7 +1259,8 @@ fun ComposeScreen(
                             )
                         },
                         enabled = !publishing && !isMiningBusy,
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth().height(44.dp),
+                        contentPadding = PaddingValues(0.dp)
                     ) {
                         Text(
                             when {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -357,7 +357,7 @@ fun ComposeScreen(
                     OutlinedTextField(
                         value = content,
                         onValueChange = { viewModel.updateContent(it) },
-                        label = { Text(stringResource(R.string.compose_gallery_placeholder)) },
+                        placeholder = { Text(stringResource(R.string.compose_gallery_placeholder)) },
                         enabled = !publishing && countdownSeconds == null,
                         visualTransformation = galleryEmojiVisual,
                         modifier = Modifier
@@ -755,7 +755,7 @@ fun ComposeScreen(
                                 singleLine = false,
                                 visualTransformation = androidx.compose.ui.text.input.VisualTransformation.None,
                                 interactionSource = interactionSource,
-                                label = { Text(stringResource(R.string.compose_placeholder)) }
+                                placeholder = { Text(stringResource(R.string.compose_placeholder)) }
                             )
                         }
                     )

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ComposeViewModel.kt
@@ -100,6 +100,12 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
     private val _countdownSeconds = MutableStateFlow<Int?>(null)
     val countdownSeconds: StateFlow<Int?> = _countdownSeconds
 
+    private val _countdownTotalSeconds = MutableStateFlow<Int>(10)
+    val countdownTotalSeconds: StateFlow<Int> = _countdownTotalSeconds
+
+    private val _countdownStartedAt = MutableStateFlow<Long?>(null)
+    val countdownStartedAt: StateFlow<Long?> = _countdownStartedAt
+
     private val _mentionQuery = MutableStateFlow<String?>(null)
     val mentionQuery: StateFlow<String?> = _mentionQuery
 
@@ -611,6 +617,8 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             }
         }
         _countdownSeconds.value = seconds
+        _countdownTotalSeconds.value = seconds
+        _countdownStartedAt.value = System.currentTimeMillis()
         countdownJob = viewModelScope.launch {
             for (i in (seconds - 1) downTo 1) {
                 delay(1000)
@@ -618,6 +626,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
             }
             delay(1000)
             _countdownSeconds.value = null
+            _countdownStartedAt.value = null
             pendingPublish?.invoke()
             pendingPublish = null
         }
@@ -628,6 +637,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         countdownJob = null
         pendingPublish = null
         _countdownSeconds.value = null
+        _countdownStartedAt.value = null
         _publishing.value = false
     }
 
@@ -635,6 +645,7 @@ class ComposeViewModel(app: Application, private val savedStateHandle: SavedStat
         countdownJob?.cancel()
         countdownJob = null
         _countdownSeconds.value = null
+        _countdownStartedAt.value = null
         pendingPublish?.invoke()
         pendingPublish = null
     }


### PR DESCRIPTION
Android port of barrydeen/wisp-ios#134.

Three composer changes that make the undo-countdown window feel intentional rather than a passive wait.

## Summary
1. **`feat(compose): countdown progress bar + compact cancel button`** — replace the symmetric Undo / Post Now pill pair with a single progress-bar pill that fills left-to-right over the undo window. Tapping the bar publishes immediately. Cancel collapses to a small red circle with an X glyph so the affirmative action gets the visual weight (and the destructive one is still one tap away but doesn't compete for attention). Smooth motion is driven by a ~60fps `LaunchedEffect` reading a snapshot `countdownStartedAt` timestamp on the view model — not one-second-per-step. Also locks the Publish button to 44dp with zero content padding so both states share identical bottom-bar geometry.
2. **`feat(compose): scroll preview into view when undo countdown starts`** — for a long body or one with attachments, the preview card sits below the fold. When the user taps Publish the countdown starts but the preview they're meant to spot-check is still off-screen. Hoist the scroll state, anchor a zero-height `Spacer` just before the preview card (always present in layout so its position is always valid), and animate-scroll to that anchor once the keyboard has actually dismissed. Gated on non-empty body.
3. **`refactor(compose): inline placeholder instead of floating label`** — small Android-only parity tweak. The compose field used a Material-3 floating label; swap it for an inline placeholder that disappears on first keystroke, matching the iOS hint style.

## Test plan
- [ ] Compose a long note (10+ lines), tap Publish — preview card scrolls to the top of the visible area when the countdown starts
- [ ] Compose a short note, tap Publish — preview was already visible, no jarring scroll
- [ ] During the countdown, the progress bar fills smoothly from left to right
- [ ] At progress < 100%, both ends of the outer button stay rounded (fill is masked to the capsule)
- [ ] Tapping the progress bar publishes immediately (`publishNow()`)
- [ ] Tapping the red X cancels and returns the bottom bar to the regular Publish button
- [ ] After cancel or publish-immediately, the next post starts the countdown cleanly (no lingering filled state)
- [ ] Publish-button and countdown-row states show identical surrounding padding
- [ ] Placeholder text "What's on your mind?" sits inline and disappears on first keystroke

## iOS counterpart
barrydeen/wisp-ios#134