### PR TITLE
feat(wallet): universal credit-card wallet icon

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
@@ -40,10 +40,11 @@ enum class BottomTab(
     val labelResId: Int,
     val selectedIcon: ImageVector?,
     val unselectedIcon: ImageVector?,
-    val iconResId: Int? = null
+    val selectedIconRes: Int? = null,
+    val unselectedIconRes: Int? = null
 ) {
     HOME(Routes.FEED, R.string.nav_home, Icons.Filled.Home, Icons.Outlined.Home),
-    WALLET(Routes.WALLET, R.string.nav_wallet, null, null, R.drawable.ic_wallet),
+    WALLET(Routes.WALLET, R.string.nav_wallet, null, null, R.drawable.ic_wallet, R.drawable.ic_wallet_outlined),
     SEARCH(Routes.SEARCH, R.string.nav_search, Icons.Filled.Search, Icons.Outlined.Search),
     MESSAGES(Routes.DM_LIST, R.string.nav_messages, Icons.Filled.Forum, Icons.Outlined.Forum),
     NOTIFICATIONS(Routes.NOTIFICATIONS, R.string.nav_notifications, Icons.Filled.Notifications, Icons.Outlined.Notifications)
@@ -101,11 +102,12 @@ fun WispBottomBar(
                                 contentDescription = stringResource(tab.labelResId),
                                 tint = zapTint
                             )
-                        } else if (tab.iconResId != null) {
-                            // Wallet (and any other tab using a drawable resource)
-                            // — fixed icon, doesn't switch on selected/zap-icon prefs.
+                        } else if (tab.selectedIconRes != null && tab.unselectedIconRes != null) {
+                            // Drawable-backed tabs (wallet) — solid when selected,
+                            // outlined when not.
+                            val iconRes = if (selected) tab.selectedIconRes else tab.unselectedIconRes
                             Icon(
-                                painter = painterResource(tab.iconResId),
+                                painter = painterResource(iconRes),
                                 contentDescription = stringResource(tab.labelResId),
                                 tint = zapTint
                             )

--- a/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/BottomBar.kt
@@ -7,12 +7,10 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Notifications
@@ -40,11 +38,12 @@ import com.wisp.app.Routes
 enum class BottomTab(
     val route: String,
     val labelResId: Int,
-    val selectedIcon: ImageVector,
-    val unselectedIcon: ImageVector
+    val selectedIcon: ImageVector?,
+    val unselectedIcon: ImageVector?,
+    val iconResId: Int? = null
 ) {
     HOME(Routes.FEED, R.string.nav_home, Icons.Filled.Home, Icons.Outlined.Home),
-    WALLET(Routes.WALLET, R.string.nav_wallet, Icons.Filled.AccountBalanceWallet, Icons.Outlined.AccountBalanceWallet),
+    WALLET(Routes.WALLET, R.string.nav_wallet, null, null, R.drawable.ic_wallet),
     SEARCH(Routes.SEARCH, R.string.nav_search, Icons.Filled.Search, Icons.Outlined.Search),
     MESSAGES(Routes.DM_LIST, R.string.nav_messages, Icons.Filled.Forum, Icons.Outlined.Forum),
     NOTIFICATIONS(Routes.NOTIFICATIONS, R.string.nav_notifications, Icons.Filled.Notifications, Icons.Outlined.Notifications)
@@ -102,11 +101,19 @@ fun WispBottomBar(
                                 contentDescription = stringResource(tab.labelResId),
                                 tint = zapTint
                             )
+                        } else if (tab.iconResId != null) {
+                            // Wallet (and any other tab using a drawable resource)
+                            // — fixed icon, doesn't switch on selected/zap-icon prefs.
+                            Icon(
+                                painter = painterResource(tab.iconResId),
+                                contentDescription = stringResource(tab.labelResId),
+                                tint = zapTint
+                            )
                         } else {
                             val icon = if (tab == BottomTab.NOTIFICATIONS && isZapAnimating)
                                 Icons.Outlined.CurrencyBitcoin
-                            else if (selected) tab.selectedIcon
-                            else tab.unselectedIcon
+                            else if (selected) tab.selectedIcon!!
+                            else tab.unselectedIcon!!
                             Icon(
                                 imageVector = icon,
                                 contentDescription = stringResource(tab.labelResId),

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -398,7 +398,7 @@ fun WispDrawerContent(
         NavigationDrawerItem(
             icon = {
                 Icon(
-                    painter = painterResource(R.drawable.ic_wallet),
+                    painter = painterResource(R.drawable.ic_wallet_outlined),
                     contentDescription = null,
                     modifier = Modifier.size(24.dp)
                 )
@@ -562,7 +562,7 @@ fun WispDrawerContent(
                             Spacer(Modifier.height(14.dp))
                             Row(verticalAlignment = Alignment.Top) {
                                 Icon(
-                                    painter = painterResource(R.drawable.ic_wallet),
+                                    painter = painterResource(R.drawable.ic_wallet_outlined),
                                     contentDescription = null,
                                     modifier = Modifier.size(20.dp),
                                     tint = MaterialTheme.colorScheme.error

--- a/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/WispDrawerContent.kt
@@ -35,7 +35,6 @@ import androidx.compose.material.icons.outlined.LightMode
 import androidx.compose.material.icons.outlined.QrCodeScanner
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.KeyboardArrowRight
-import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.FavoriteBorder
@@ -396,21 +395,13 @@ fun WispDrawerContent(
             onClick = onMessages,
             modifier = Modifier.height(48.dp).padding(horizontal = 12.dp)
         )
-        val useZapBolt = com.wisp.app.ui.util.useBoltIcon()
-        val fiatMode = com.wisp.app.ui.util.isFiatMode()
         NavigationDrawerItem(
             icon = {
-                if (fiatMode) {
-                    Icon(Icons.Outlined.AccountBalanceWallet, contentDescription = null)
-                } else if (useZapBolt) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_bolt),
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp)
-                    )
-                } else {
-                    Icon(Icons.Outlined.CurrencyBitcoin, contentDescription = null)
-                }
+                Icon(
+                    painter = painterResource(R.drawable.ic_wallet),
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp)
+                )
             },
             label = { Text(stringResource(R.string.nav_wallet)) },
             selected = false,
@@ -571,7 +562,7 @@ fun WispDrawerContent(
                             Spacer(Modifier.height(14.dp))
                             Row(verticalAlignment = Alignment.Top) {
                                 Icon(
-                                    Icons.Outlined.AccountBalanceWallet,
+                                    painter = painterResource(R.drawable.ic_wallet),
                                     contentDescription = null,
                                     modifier = Modifier.size(20.dp),
                                     tint = MaterialTheme.colorScheme.error

--- a/app/src/main/res/drawable/ic_wallet.xml
+++ b/app/src/main/res/drawable/ic_wallet.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <!--
+        Wisp wallet icon — credit-card silhouette matching iOS
+        `creditcard.fill`. Three subpaths combined under evenOdd fill:
+          1. Outer card body (solid, rounded corners).
+          2. Horizontal magnetic stripe near the top (cut out).
+          3. Microchip rectangle on the lower-left (cut out).
+        The stripe and chip read as distinct shapes because the
+        evenOdd rule subtracts them from the card silhouette.
+    -->
+    <path
+        android:fillColor="#FF000000"
+        android:fillType="evenOdd"
+        android:pathData="M3,5 L21,5 A2,2 0 0 1 23,7 L23,17 A2,2 0 0 1 21,19 L3,19 A2,2 0 0 1 1,17 L1,7 A2,2 0 0 1 3,5 Z M1,7.5 L23,7.5 L23,10 L1,10 Z M4.5,12.5 L8.5,12.5 A0.5,0.5 0 0 1 9,13 L9,16 A0.5,0.5 0 0 1 8.5,16.5 L4.5,16.5 A0.5,0.5 0 0 1 4,16 L4,13 A0.5,0.5 0 0 1 4.5,12.5 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_wallet_outlined.xml
+++ b/app/src/main/res/drawable/ic_wallet_outlined.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <!--
+        Outlined twin of `ic_wallet.xml` — same body / stripe / chip
+        geometry, just stroked instead of filled so the unselected
+        bottom-nav state and the drawer wallet row read as a hollow
+        card. Matches iOS `creditcard` (no `.fill`).
+
+        Card body: stroked rectangle (no fill).
+        Magnetic stripe: kept filled so it stays the focal element —
+        matches SF Symbol behavior where the band remains solid even
+        on the outlined glyph.
+        Microchip: solid filled block (matches iOS — the chip stays
+        opaque even in the outlined state for visual weight).
+    -->
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.5"
+        android:pathData="M3,5 L21,5 A2,2 0 0 1 23,7 L23,17 A2,2 0 0 1 21,19 L3,19 A2,2 0 0 1 1,17 L1,7 A2,2 0 0 1 3,5 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M1.75,7.75 L22.25,7.75 L22.25,10 L1.75,10 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4.5,12.5 L8.5,12.5 A0.5,0.5 0 0 1 9,13 L9,15.5 A0.5,0.5 0 0 1 8.5,16 L4.5,16 A0.5,0.5 0 0 1 4,15.5 L4,13 A0.5,0.5 0 0 1 4.5,12.5 Z" />
+</vector>


### PR DESCRIPTION
First slice of the wallet cross-platform parity work — see
[WALLET_PARITY.md §3.1](https://github.com/barrydeen/wisp/blob/main/WALLET_PARITY.md#31-universal-wallet-icon)
(forthcoming in the larger parity train).

## Summary

Replace the Material `AccountBalanceWallet` glyph with a credit-card
silhouette vector drawable used uniformly wherever "wallet" is referenced:

- Bottom nav wallet tab
- Sidebar drawer wallet row
- Logout-warning embedded-wallet bullet

The drawer wallet row previously switched between three icons based on
the user's zap-icon preference / fiat-mode setting (`CurrencyBitcoin` /
`ic_bolt` / `AccountBalanceWallet`). That conditional is removed — the
wallet icon is fixed because wallet ≠ zap glyph; the two settings
control different visuals.

The new vector is a solid card with a horizontal magnetic-stripe
cutout near the top and a microchip rectangle cutout on the lower-left,
matching iOS `creditcard.fill`. Single `evenOdd` path so a Compose
`Icon(tint = …)` color override applies cleanly across themes and nav
states without per-call `colorFilter` plumbing.

This is intentionally a tiny, low-risk PR so it can land ahead of the
larger wallet-flow refactor that's in progress.

## iOS counterpart

iOS already ships the same icon (`creditcard.fill` via SF Symbols);
this brings Android visually in line.

## Test plan

- [ ] Wallet tab in bottom nav renders the credit-card icon; tint
      tracks selected (accent) vs. unselected (secondary) correctly.
- [ ] Sidebar drawer wallet row shows the same credit-card icon.
- [ ] Toggling "Lightning bolt" zap-icon preference or fiat mode no
      longer changes the wallet icon.
- [ ] Logout-warning embedded-wallet bullet uses the same icon.