### PR TITLE
fix(wallet): NWC connect screen — iOS 1:1 redesign

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -80,6 +81,7 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
@@ -95,6 +97,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -587,85 +590,162 @@ private fun WalletConnectionContent(
     onDisconnect: () -> Unit
 ) {
     val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
     val isConnecting = walletState is WalletState.Connecting
+    var showScanner by remember { mutableStateOf(false) }
 
+    // iOS 1:1 layout — centered NWC logo + title + subtitle, paste/scan
+    // card, helper text, full-width Connect button. The Recommended
+    // wallets stack is removed: NWC ecosystem links live on a separate
+    // discovery surface; this screen is purely "paste your string and
+    // connect."
+    val accent = WispThemeColors.zapColor
+    Spacer(Modifier.height(24.dp))
+
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_nwc_logo),
+            contentDescription = null,
+            modifier = Modifier.height(56.dp)
+        )
+    }
     Spacer(Modifier.height(16.dp))
-
     Text(
         stringResource(R.string.wallet_nwc_title),
-        style = MaterialTheme.typography.headlineSmall,
-        color = MaterialTheme.colorScheme.onSurface
+        style = MaterialTheme.typography.titleLarge,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurface,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth()
     )
     Spacer(Modifier.height(8.dp))
     Text(
-        stringResource(R.string.wallet_connect_lightning),
+        stringResource(R.string.wallet_nwc_paste_prompt),
         style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
     )
 
     Spacer(Modifier.height(24.dp))
 
-    Text(
-        stringResource(R.string.wallet_recommended),
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.onSurface
-    )
-    Spacer(Modifier.height(12.dp))
-
-    val wallets = listOf(
-        "rizful.com" to "Rizful",
-        "coinos.io" to "Coinos",
-        "getalby.com" to "Alby",
-        "cashu.me" to "Cashu.me",
-        "minibits.cash" to "Minibits"
-    )
-
-    wallets.forEach { (domain, name) ->
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp)
-                .clickable {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://$domain"))
-                    context.startActivity(intent)
-                },
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant
-            )
-        ) {
+    // Paste / Scan card — top half displays the pasted string (or
+    // stays empty while the user hasn't pasted anything); bottom row
+    // splits a Paste button and a Scan QR button with a vertical
+    // divider. Matches iOS 1:1 — no separate text field, no trailing
+    // icon, no Recommended-wallets stack.
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(140.dp)
+                    .padding(14.dp)
+            ) {
+                if (connectionString.isBlank()) {
+                    Text(
+                        "nostr+walletconnect://…",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
+                    )
+                } else {
+                    Text(
+                        connectionString,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 6,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.25f))
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(12.dp),
+                    .height(IntrinsicSize.Min),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                AsyncImage(
-                    model = "https://$domain/favicon.ico",
-                    contentDescription = name,
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(Modifier.width(12.dp))
-                Text(
-                    name,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
+                Row(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable(enabled = !isConnecting) {
+                            val pasted = clipboardManager.getText()?.text.orEmpty()
+                            if (pasted.isNotBlank()
+                                && !NsecPasteGuard.blockIfNsec(connectionString, pasted)
+                            ) {
+                                onConnectionStringChange(pasted.trim())
+                            }
+                        }
+                        .padding(vertical = 14.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Default.ContentPaste,
+                        contentDescription = null,
+                        tint = accent,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        stringResource(R.string.wallet_paste),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = accent
+                    )
+                }
+                VerticalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.25f))
+                Row(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable(enabled = !isConnecting) { showScanner = true }
+                        .padding(vertical = 14.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Default.QrCode,
+                        contentDescription = null,
+                        tint = accent,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        stringResource(R.string.wallet_scan_qr),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = accent
+                    )
+                }
             }
         }
     }
 
-    Spacer(Modifier.height(24.dp))
-
-    OutlinedTextField(
-        value = connectionString,
-        onValueChange = { new -> if (!NsecPasteGuard.blockIfNsec(connectionString, new)) onConnectionStringChange(new) },
-        label = { Text(stringResource(R.string.wallet_nwc_connection_string)) },
-        placeholder = { Text("nostr+walletconnect://...") },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = false,
-        maxLines = 3,
-        enabled = !isConnecting
-    )
+    Spacer(Modifier.height(12.dp))
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Icon(
+            Icons.Outlined.Info,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(14.dp)
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            stringResource(R.string.wallet_nwc_connection_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
 
     if (walletState is WalletState.Error) {
         Spacer(Modifier.height(8.dp))
@@ -676,11 +756,14 @@ private fun WalletConnectionContent(
         )
     }
 
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(20.dp))
 
     Button(
         onClick = onConnect,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        shape = RoundedCornerShape(14.dp),
         enabled = connectionString.isNotBlank() && !isConnecting
     ) {
         if (isConnecting) {
@@ -720,6 +803,47 @@ private fun WalletConnectionContent(
     }
 
     Spacer(Modifier.height(32.dp))
+
+    if (showScanner) {
+        // Reuses the existing QrScanner dialog pattern from the send-
+        // payment flow. Successful scan populates the connection
+        // string field directly; user can then tap Connect.
+        androidx.compose.ui.window.Dialog(
+            onDismissRequest = { showScanner = false }
+        ) {
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surface,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        stringResource(R.string.wallet_scan_qr_code),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    com.wisp.app.ui.component.QrScanner(
+                        onResult = { value ->
+                            showScanner = false
+                            onConnectionStringChange(value.trim())
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(320.dp),
+                        promptText = stringResource(R.string.wallet_point_camera)
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    TextButton(onClick = { showScanner = false }) {
+                        Text(stringResource(R.string.btn_cancel))
+                    }
+                }
+            }
+        }
+    }
 }
 
 // --- Home screen ---

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -181,13 +181,19 @@ fun WalletScreen(
 
     // Hide the wallet app bar on the Home dashboard — the bottom-nav wallet
     // tab is the entry point, and the dashboard's own top row (brand logo +
-    // refresh + settings) plays the role of the toolbar. Sub-pages keep the
-    // app bar so back-nav stays reachable.
-    val isHome = currentPage is WalletPage.Home || currentPage is WalletPage.ModeSelection
+    // refresh + settings) plays the role of the toolbar. The mode picker
+    // and the wallet-setup sub-screens (NWC, Spark, Spark restore-seed)
+    // render their own top-right Close pill instead of an app bar to match
+    // iOS — leaves more headroom for the centered logo + title layout.
+    val hideAppBar = currentPage is WalletPage.Home ||
+        currentPage is WalletPage.ModeSelection ||
+        currentPage is WalletPage.NwcSetup ||
+        currentPage is WalletPage.SparkSetup ||
+        currentPage is WalletPage.SparkRestoreSeed
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
-            if (!isHome) {
+            if (!hideAppBar) {
                 TopAppBar(
                     title = { Text(stringResource(R.string.title_wallet)) },
                     navigationIcon = {
@@ -242,10 +248,18 @@ fun WalletScreen(
                         )
                     }
                 } else {
+                    // Setup screens (NwcSetup / SparkSetup / SparkRestoreSeed)
+                    // render with no TopAppBar, so the Column itself owns the
+                    // status-bar inset to keep the top-right Close pill clear
+                    // of the device chrome.
+                    val needsStatusInset = currentPage is WalletPage.NwcSetup ||
+                        currentPage is WalletPage.SparkSetup ||
+                        currentPage is WalletPage.SparkRestoreSeed
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(padding)
+                            .then(if (needsStatusInset) Modifier.statusBarsPadding() else Modifier)
                             .padding(horizontal = 16.dp)
                             .verticalScroll(rememberScrollState())
                     ) {
@@ -256,7 +270,8 @@ fun WalletScreen(
                                 statusLines = viewModel.statusLines.collectAsState().value,
                                 onConnectionStringChange = { viewModel.updateConnectionString(it) },
                                 onConnect = { viewModel.connectNwcWallet() },
-                                onDisconnect = { viewModel.disconnectWallet() }
+                                onDisconnect = { viewModel.disconnectWallet() },
+                                onClose = { viewModel.navigateHome() }
                             )
                             is WalletPage.SparkSetup -> SparkSetupContent(
                                 walletState = walletState,
@@ -587,20 +602,41 @@ private fun WalletConnectionContent(
     statusLines: List<String>,
     onConnectionStringChange: (String) -> Unit,
     onConnect: () -> Unit,
-    onDisconnect: () -> Unit
+    onDisconnect: () -> Unit,
+    onClose: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val clipboardManager = LocalClipboardManager.current
     val isConnecting = walletState is WalletState.Connecting
     var showScanner by remember { mutableStateOf(false) }
 
-    // iOS 1:1 layout — centered NWC logo + title + subtitle, paste/scan
-    // card, helper text, full-width Connect button. The Recommended
-    // wallets stack is removed: NWC ecosystem links live on a separate
-    // discovery surface; this screen is purely "paste your string and
-    // connect."
+    // iOS 1:1 layout — top-right Close pill (no app bar), centered NWC
+    // logo + title + subtitle, paste/scan card, helper text, full-width
+    // Connect button. The Recommended wallets stack is removed: NWC
+    // ecosystem links live on a separate discovery surface; this screen
+    // is purely "paste your string and connect."
     val accent = WispThemeColors.zapColor
-    Spacer(Modifier.height(24.dp))
+
+    Spacer(Modifier.height(12.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End
+    ) {
+        Surface(
+            modifier = Modifier.clickable(onClick = onClose),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            shape = CircleShape
+        ) {
+            Text(
+                stringResource(R.string.wallet_close),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+        }
+    }
+
+    Spacer(Modifier.height(8.dp))
 
     Box(
         modifier = Modifier.fillMaxWidth(),
@@ -2565,6 +2601,7 @@ private fun SparkSetupContent(
     val isConnecting = walletState is WalletState.Connecting
 
     Column(modifier = Modifier.fillMaxWidth()) {
+        Spacer(Modifier.height(12.dp))
         // Top-right Close button — full dismiss back to mode picker.
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -734,6 +734,8 @@
     <string name="wallet_spark_subtitle">Self-custody, embedded. Use your default wallet or restore from seed/relays.</string>
     <string name="wallet_nwc_title">Nostr Wallet Connect</string>
     <string name="wallet_nwc_subtitle">Paste a connection string from Alby, Zeus, Rizful, Minibits, etc.</string>
+    <string name="wallet_nwc_paste_prompt">Paste the connection string from your NWC-compatible wallet.</string>
+    <string name="wallet_nwc_connection_hint">Connection string starts with nostr+walletconnect://</string>
     <string name="spark_setup_subtitle">Self-custodial Lightning, powered by Spark and Breez.</string>
     <string name="wallet_create_title">Create new wallet</string>
     <string name="wallet_create_subtitle">Generate a fresh 12-word seed phrase</string>


### PR DESCRIPTION
## Summary

Replaces the Android NWC setup screen with the iOS layout — pasting +
scanning a connection string is now the entire surface, no
Recommended-wallets stack.

- Centered NWC logo, large bold title, two-line muted subtitle.
- Single paste/scan card: connection-string display area on top, Paste
  + Scan QR buttons split by a vertical divider on the bottom.
- Info-icon helper line: \"Connection string starts with
  nostr+walletconnect://\".
- Full-width Connect button (height 52dp, 14dp corners). Disabled
  until a non-blank string is present.
- Paste reads \`LocalClipboardManager\` directly with the existing
  \`NsecPasteGuard\` check. Scan QR opens the existing \`QrScanner\`
  dialog and writes the result into the connection-string field.

Two new strings (\`wallet_nwc_paste_prompt\`,
\`wallet_nwc_connection_hint\`); \`wallet_recommended\` is no longer
referenced by this screen.

## Test plan

- [ ] Open the wallet picker → tap Nostr Wallet Connect.
- [ ] Screen matches iOS: centered NWC logo / title / subtitle, large
      paste/scan card, helper line, Connect button. No Recommended-
      wallets stack anywhere.
- [ ] Empty state: the card shows \`nostr+walletconnect://…\` as a dim
      placeholder. Connect button disabled.
- [ ] Tap Paste with a valid NWC URI on the clipboard → the string
      lands in the top of the card. Connect button enables.
- [ ] Tap Paste with an nsec on the clipboard → blocked by
      NsecPasteGuard, no change to the field.
- [ ] Tap Scan QR → camera dialog opens; scanning a
      \`nostr+walletconnect://\` URI populates the field and closes the
      dialog. Cancel button dismisses without populating.
- [ ] Tap Connect → connecting state shows the spinner + \"Connecting\"
      label, plus a Cancel button below.
- [ ] Connection failure surfaces the error message in red between
      the helper line and the Connect button.