### PR TITLE
fix(wallet): refresh Spark display state on mnemonic swap + banner copy

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/SparkRepository.kt
@@ -131,16 +131,16 @@ class SparkRepository(
      * The same privkey always produces the same mnemonic, so a user's default
      * Spark wallet is recoverable on any device by signing in with their nsec.
      *
-     * Saves the mnemonic and marks it as the default wallet (skips backup nags).
+     * Does NOT auto-acknowledge the seed backup — iOS's equivalent leaves the
+     * ack flag false so the "default wallet is secured by your key" welcome
+     * banner can render, and Android should match. The user can dismiss the
+     * banner by tapping it / acknowledging in the seed-view page.
      */
     fun generateDefaultFromPrivkey(privkey: ByteArray): String {
         val wordlist = requireWordlist()
         val entropy = Keys.deriveSparkEntropy(privkey)
         val mnemonic = entropyToMnemonic(entropy, wordlist)
-        encPrefs.edit()
-            .putString("spark_mnemonic", mnemonic)
-            .putBoolean("seed_backup_acked", true)
-            .apply()
+        saveMnemonic(mnemonic)
         return mnemonic
     }
 
@@ -209,8 +209,19 @@ class SparkRepository(
         return null
     }
 
+    /**
+     * Save a Spark mnemonic. Resets the seed-backup ack flag because
+     * the previous acknowledgement applied to whatever mnemonic was in
+     * place before — a newly-restored / newly-pasted wallet should be
+     * treated as un-acked so the welcome / backup banner renders for
+     * the new seed. Mirrors iOS `SparkWallet.saveMnemonic` which clears
+     * the equivalent `spark_seed_acked_<pubkey>` UserDefaults key.
+     */
     fun saveMnemonic(mnemonic: String) {
-        encPrefs.edit().putString("spark_mnemonic", mnemonic).apply()
+        encPrefs.edit()
+            .putString("spark_mnemonic", mnemonic)
+            .remove("seed_backup_acked")
+            .apply()
     }
 
     fun getMnemonic(): String? = encPrefs.getString("spark_mnemonic", null)

--- a/app/src/main/kotlin/com/wisp/app/repo/SparkRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/SparkRepository.kt
@@ -139,7 +139,6 @@ class SparkRepository(
         val mnemonic = entropyToMnemonic(entropy, wordlist)
         encPrefs.edit()
             .putString("spark_mnemonic", mnemonic)
-            .putBoolean("spark_is_default", true)
             .putBoolean("seed_backup_acked", true)
             .apply()
         return mnemonic
@@ -220,15 +219,34 @@ class SparkRepository(
         encPrefs.edit()
             .remove("spark_mnemonic")
             .remove("seed_backup_acked")
-            .remove("spark_is_default")
             .apply()
         _balance.value = null
         _isConnected.value = false
     }
 
-    /** True when the current wallet was derived from the user's nsec. */
-    fun isDefaultWallet(): Boolean =
-        encPrefs.getBoolean("spark_is_default", false)
+    /**
+     * True when the currently-saved mnemonic matches the deterministic
+     * derivation `entropyToMnemonic(Keys.deriveSparkEntropy(privkey))` for
+     * this account — i.e. the wallet is recoverable on any device by
+     * signing in with the same key.
+     *
+     * Compares the stored mnemonic against the deterministic derivation
+     * rather than relying on a sticky `spark_is_default` flag — a wallet
+     * restored from a non-default NIP-78 backup correctly reports `false`
+     * here even on a device where the user had previously generated the
+     * default wallet (a stale flag was surfacing the "default wallet"
+     * banner over a non-default restored wallet on iOS; mirror fix here).
+     */
+    fun isDefaultWallet(privkey: ByteArray): Boolean {
+        val current = encPrefs.getString("spark_mnemonic", null) ?: return false
+        val wordlist = BIP39_WORDS
+        if (wordlist.size < 2048) return false
+        val derived = entropyToMnemonic(Keys.deriveSparkEntropy(privkey), wordlist)
+        return normalizeMnemonic(current) == normalizeMnemonic(derived)
+    }
+
+    private fun normalizeMnemonic(mnemonic: String): String =
+        mnemonic.trim().lowercase().replace(Regex("\\s+"), " ")
 
     fun isSeedBackupAcknowledged(): Boolean =
         encPrefs.getBoolean("seed_backup_acked", false)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/OnboardingViewModel.kt
@@ -288,7 +288,8 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
             // default wallet's mnemonic is derived from the nsec, and Breez
             // remembers its lightning address registration server-side, so
             // there's nothing extra to persist on relays.
-            if (sparkRepo != null && !sparkRepo.isDefaultWallet()) {
+            val privkey = keyRepo.getKeypair()?.privkey
+            if (sparkRepo != null && privkey != null && !sparkRepo.isDefaultWallet(privkey)) {
                 val mnemonic = sparkRepo.getMnemonic()
                 if (mnemonic != null) {
                     viewModelScope.launch {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
@@ -301,6 +301,11 @@ class WalletViewModel(
         _lightningAddress.value = null
         _lightningAddressError.value = null
         _lightningAddressLoading.value = false
+        // Reset the seed-backup ack flag — sparkRepo.saveMnemonic clears
+        // the underlying prefs key, but the ViewModel-side StateFlow
+        // would otherwise stay at the prior wallet's acknowledged value
+        // until the next refreshState() call.
+        _seedBackupAcked.value = false
     }
 
     /**
@@ -438,7 +443,11 @@ class WalletViewModel(
         val keypair = keyRepo.getKeypair() ?: return
         sparkRepo.generateDefaultFromPrivkey(keypair.privkey)
         _isDefaultWallet.value = true
-        _seedBackupAcked.value = true
+        // Don't auto-ack the seed backup here — iOS leaves it false so
+        // the "default wallet is secured by your key" welcome banner can
+        // render, and Android should match. The user dismisses it by
+        // tapping through to the seed view.
+        _seedBackupAcked.value = false
         skipAutoCreate = false
         walletModeRepo.setAutoCreateSkipped(false)
         // Show SparkSetup's Connecting state instead of a brief ModeSelection flicker.
@@ -662,7 +671,11 @@ class WalletViewModel(
         Log.d("WalletBackup", "restoreSparkWallet: saving and connecting")
         clearWalletDisplayState()
         sparkRepo.saveMnemonic(trimmed)
-        _isDefaultWallet.value = false
+        // Compute isDefaultWallet from the restored mnemonic rather than
+        // hard-coding false — a user restoring their nsec-derived default
+        // via NIP-78 should still light up the "default wallet" surface
+        // (and skip the non-default backup nag).
+        _isDefaultWallet.value = computeIsDefaultWallet()
         skipAutoCreate = false
         walletModeRepo.setAutoCreateSkipped(false)
         connectSparkWallet()

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
@@ -270,8 +270,18 @@ class WalletViewModel(
     val backupMissing: StateFlow<Boolean> = _backupMissing
 
     /** True for the nsec-derived default wallet — drives copy/visibility tweaks. */
-    private val _isDefaultWallet = MutableStateFlow(sparkRepo.isDefaultWallet())
+    private val _isDefaultWallet = MutableStateFlow(computeIsDefaultWallet())
     val isDefaultWallet: StateFlow<Boolean> = _isDefaultWallet
+
+    /**
+     * Resolve the active keypair and ask [sparkRepo] whether the stored
+     * mnemonic matches the deterministic nsec derivation. False for
+     * watch-only / signed-out accounts.
+     */
+    private fun computeIsDefaultWallet(): Boolean {
+        val privkey = keyRepo.getKeypair()?.privkey ?: return false
+        return sparkRepo.isDefaultWallet(privkey)
+    }
 
     /**
      * Set after [deleteWallet] so a subsequent [navigateHome] doesn't
@@ -360,7 +370,7 @@ class WalletViewModel(
         if (page is WalletPage.Settings
             && _walletMode.value == WalletMode.SPARK
             && keyRepo.isLoggedIn()
-            && !sparkRepo.isDefaultWallet()
+            && !computeIsDefaultWallet()
         ) {
             checkRelayBackupStatuses()
         }
@@ -654,7 +664,7 @@ class WalletViewModel(
         viewModelScope.launch {
             sparkRepo.isConnected.first { it }
             fetchLightningAddress()
-            if (keyRepo.isLoggedIn() && !sparkRepo.isDefaultWallet()) {
+            if (keyRepo.isLoggedIn() && !computeIsDefaultWallet()) {
                 checkRelayBackupStatuses()
             }
         }
@@ -739,7 +749,7 @@ class WalletViewModel(
         // seed phrase, so we require the typed DELETE confirmation. Default
         // wallets re-derive from the nsec on demand, so a tap is enough.
         if (_walletMode.value == WalletMode.SPARK
-            && !sparkRepo.isDefaultWallet()
+            && !computeIsDefaultWallet()
             && _deleteConfirmText.value != "DELETE"
         ) return
 
@@ -842,7 +852,7 @@ class WalletViewModel(
 
     fun refreshState() {
         _walletMode.value = walletModeRepo.getMode()
-        _isDefaultWallet.value = sparkRepo.isDefaultWallet()
+        _isDefaultWallet.value = computeIsDefaultWallet()
         _seedBackupAcked.value = sparkRepo.isSeedBackupAcknowledged()
         skipAutoCreate = walletModeRepo.isAutoCreateSkipped()
         val mode = _walletMode.value

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
@@ -284,6 +284,26 @@ class WalletViewModel(
     }
 
     /**
+     * Wipe per-wallet display state so swapping wallets (Spark mnemonic
+     * restored from backup, default-wallet generation, paste a new
+     * mnemonic, disconnect, delete) doesn't carry the previous wallet's
+     * transactions / pagination / lightning address into the new
+     * wallet's UI. Mirrors iOS `WalletStore.clearDisplayState`.
+     *
+     * The repo-side `_balance` flow is cleared inside `clearMnemonic` /
+     * by the new wallet's first balance fetch — only ViewModel-side
+     * display state needs explicit clearing here.
+     */
+    private fun clearWalletDisplayState() {
+        _transactions.value = emptyList()
+        _transactionsError.value = null
+        _hasMoreTransactions.value = true
+        _lightningAddress.value = null
+        _lightningAddressError.value = null
+        _lightningAddressLoading.value = false
+    }
+
+    /**
      * Set after [deleteWallet] so a subsequent [navigateHome] doesn't
      * immediately re-derive the default wallet — the user explicitly
      * disconnected to pick a different one. Persisted in
@@ -410,6 +430,7 @@ class WalletViewModel(
             sparkRepo.disconnect()
             sparkRepo.clearMnemonic()
         }
+        clearWalletDisplayState()
         startDefaultWallet()
     }
 
@@ -616,6 +637,7 @@ class WalletViewModel(
     // --- Spark Connection ---
 
     fun generateSparkWallet() {
+        clearWalletDisplayState()
         val mnemonic = sparkRepo.newMnemonic()
         sparkRepo.saveMnemonic(mnemonic)
         _isDefaultWallet.value = false
@@ -638,6 +660,7 @@ class WalletViewModel(
             return
         }
         Log.d("WalletBackup", "restoreSparkWallet: saving and connecting")
+        clearWalletDisplayState()
         sparkRepo.saveMnemonic(trimmed)
         _isDefaultWallet.value = false
         skipAutoCreate = false
@@ -776,7 +799,7 @@ class WalletViewModel(
         _walletState.value = WalletState.NotConnected
         _connectionString.value = ""
         _statusLines.value = emptyList()
-        _lightningAddress.value = null
+        clearWalletDisplayState()
         _deleteConfirmText.value = ""
         _isDefaultWallet.value = false
 
@@ -819,7 +842,7 @@ class WalletViewModel(
         _walletState.value = WalletState.NotConnected
         _connectionString.value = ""
         _statusLines.value = emptyList()
-        _lightningAddress.value = null
+        clearWalletDisplayState()
         navigateHome()
     }
 
@@ -843,7 +866,7 @@ class WalletViewModel(
         _walletState.value = WalletState.NotConnected
         _connectionString.value = ""
         _statusLines.value = emptyList()
-        _lightningAddress.value = null
+        clearWalletDisplayState()
     }
 
     fun updateDeleteConfirmText(value: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -781,8 +781,8 @@
     <string name="wallet_seed_not_viewed_body">You haven\'t viewed your recovery phrase yet. Write it down to protect your funds.</string>
     <string name="wallet_view_seed">View Recovery Phrase</string>
     <string name="wallet_powered_by">Powered by</string>
-    <string name="wallet_welcome_title">Your default wallet is secured by your key</string>
-    <string name="wallet_welcome_body">Derived from your Nostr key — restores on any device when you sign in. Tap to also save your seed phrase as a backup.</string>
+    <string name="wallet_welcome_title">Secured by your Nostr key</string>
+    <string name="wallet_welcome_body">Restores on any device when you sign in. Tap to also save your seed phrase as a backup.</string>
     <string name="wallet_recent">Recent</string>
     <string name="wallet_view_all">View all</string>
 


### PR DESCRIPTION
Mirrors iOS [barrydeen/wisp-ios#175](https://github.com/barrydeen/wisp-ios/pull/175) and folds in a couple of related per-wallet state-leak fixes that surfaced during the same testing pass.

## Bug 1 — default-wallet banner shows over restored non-default seeds

The "default wallet is secured by your key" banner kept rendering on the Wallet tab even after the user restored a non-default Spark wallet from a NIP-78 backup. The banner's claim is false for any restored wallet whose seed isn't the deterministic nsec-derived mnemonic.

**Root cause:** \`SparkRepository.isDefaultWallet()\` returned a sticky \`encPrefs\` flag (\`spark_is_default\`) that was set by \`generateDefaultFromPrivkey\` when the initial nsec-derived wallet was created and never cleared on the restore path. \`saveMnemonic\` overwrote the mnemonic but left the flag alone.

**Fix:** Replace the flag with a computed check — compare the stored mnemonic against \`entropyToMnemonic(Keys.deriveSparkEntropy(privkey))\` on the fly. \`generateDefaultFromPrivkey\` and \`clearMnemonic\` no longer touch the flag. Call sites (\`WalletViewModel\` via a private \`computeIsDefaultWallet()\` helper, \`OnboardingViewModel\`'s NIP-78 backup-publish gate) pass the active \`keyRepo.getKeypair()?.privkey\` through. Watch-only accounts fall through to \`false\` naturally.

## Bug 2 — transaction history leaks across mnemonic swaps

\`_transactions\`, \`_lightningAddress\`, and \`_hasMoreTransactions\` were cached on the \`WalletViewModel\` and never reset when the Spark mnemonic was replaced. Users saw the previous wallet's transactions briefly above the new wallet's balance.

**Fix:** New private \`clearWalletDisplayState()\` helper that wipes per-wallet ViewModel-side display state. Called from every mnemonic-replace / disconnect path: \`generateSparkWallet\`, \`restoreSparkWallet\`, \`useDefaultWallet\`, \`disconnectWallet\`, \`deleteWallet\`, \`suspendForAccountSwitch\`. Mirrors iOS \`WalletStore.clearDisplayState\`.

## Bug 3 — default-wallet banner missing after restore

After restoring the nsec-derived default wallet via NIP-78, no banner showed at all. Two contributing causes:

1. \`SparkRepository.generateDefaultFromPrivkey\` auto-set \`seed_backup_acked = true\`. iOS doesn't auto-ack — it lets the welcome banner render until the user dismisses it. The banner condition is \`isDefaultWallet && !seedBackupAcked\`, so Android's auto-ack suppressed it.
2. \`saveMnemonic\` didn't clear \`seed_backup_acked\` on restore. A previously-acked default was treated as still-acked even after the wallet was replaced. iOS's \`saveMnemonic\` clears the equivalent key.
3. \`restoreSparkWallet\` hard-coded \`_isDefaultWallet.value = false\` regardless of what was restored. Users restoring their default nsec-derived seed lost the "default wallet" surface.

**Fix:**
- \`saveMnemonic\` clears the \`seed_backup_acked\` prefs key (mirrors iOS).
- \`generateDefaultFromPrivkey\` no longer auto-acks; routes through \`saveMnemonic\`.
- \`restoreSparkWallet\` sets \`_isDefaultWallet\` via \`computeIsDefaultWallet()\` instead of hard-coding false.
- \`startDefaultWallet\` no longer auto-sets \`_seedBackupAcked = true\` on the ViewModel side.
- \`clearWalletDisplayState\` also resets \`_seedBackupAcked\` to false so the StateFlow doesn't carry the prior wallet's acked value across a swap.

## Bug 4 — copy tightening

Title shortens from "Your default wallet is secured by your key" (wrapping to two lines on most phones) to **"Secured by your Nostr key"**. The body drops the redundant "Derived from your Nostr key — " prefix now that the title carries the same idea. Same information, one-line title.

## Existing-user impact

Anyone who previously acknowledged their default wallet's seed backup will see the welcome banner once after this update (until they tap through again). Acceptable noise — the underlying ack-on-generate behaviour was the iOS divergence that caused the missing-banner-after-restore bug, and the welcome banner is informational rather than nagging.

## Test plan

- [x] Restore a non-default Spark wallet via NIP-78 → wallet shows orange "Back up your recovery phrase" warning, not the green banner.
- [x] Restore the nsec-derived default wallet via NIP-78 → wallet shows green "Secured by your Nostr key" banner.
- [x] Tap "Use my default wallet" → green banner appears even if a prior wallet had been acked.
- [x] Generate a new (non-default) Spark wallet → orange warning shows.
- [x] Swap from wallet A to wallet B (any path) → A's transactions don't bleed onto B's balance.
- [x] Watch-only accounts → no Spark banner of any kind.

## Paired iOS PR

[barrydeen/wisp-ios#175](https://github.com/barrydeen/wisp-ios/pull/175) — same fix to the flag→computed transition. The transaction-history-leak and ack-semantics fixes are Android-specific (iOS's \`clearDisplayState\` already handled the former, and iOS's \`saveMnemonic\` already cleared the ack key).