### PR TITLE
feat(bolt): white-core glow pulse for in-flight zap

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt
@@ -57,8 +57,10 @@ import com.wisp.app.ui.util.AmountFormatter
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.graphics.drawscope.translate
 import coil3.compose.AsyncImage
 import com.wisp.app.nostr.Nip30
+import androidx.compose.ui.platform.LocalDensity
 import kotlin.math.sin
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -282,50 +284,65 @@ fun ActionBar(
 
 @Composable
 internal fun LightningAnimation(modifier: Modifier = Modifier) {
-    val transition = rememberInfiniteTransition(label = "lightning")
-
-    val pulse by transition.animateFloat(
-        initialValue = 0.5f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(600, easing = androidx.compose.animation.core.FastOutSlowInEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "pulse"
-    )
-
-    val scale by transition.animateFloat(
-        initialValue = 0.92f,
-        targetValue = 1.08f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(600, easing = androidx.compose.animation.core.FastOutSlowInEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "scale"
-    )
-
+    // White-core glow pulse — matches iOS commit #6 of feat/one-tap-zap.
+    // Single sin-eased oscillator on a 0.9s period drives:
+    //   sine  ∈ [-1, 1]
+    //   phase ∈ [ 0, 1] = (sine + 1) / 2
+    //   iconScale = 1.0 + 0.10 * sine        (0.90 → 1.10)
+    //   verticalOffset = -0.5 * sine          (±0.5dp, centered on baseline)
+    // The silhouette stays solid white — the three stacked stroked
+    // shadows behind it do the warm-glow work (inner constant, medium
+    // and outer breathing on the phase). Vertical motion is held to
+    // ±0.5dp so the icon doesn't lift off the action-bar baseline and
+    // misalign with neighbouring glyphs.
     val zapColor = WispThemeColors.zapColor
+    val density = LocalDensity.current
+    val transition = rememberInfiniteTransition(label = "bolt-pulse")
+
+    val sineAngle by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = (2.0 * Math.PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 900, easing = LinearEasing)
+        ),
+        label = "bolt-sine"
+    )
+
+    val s = sin(sineAngle.toDouble()).toFloat()
+    val phase = (s + 1f) / 2f
+    val iconScale = 1.0f + 0.10f * s
+
+    val verticalOffsetPx = with(density) { (-0.5f * s).dp.toPx() }
+    val innerStrokePx = with(density) { 1.5.dp.toPx() }
+    val medStrokePx = with(density) { (4f + 3f * phase).dp.toPx() }
+    val outerStrokePx = with(density) { (8f + 6f * phase).dp.toPx() }
 
     Canvas(modifier = modifier) {
-        val w = size.width
-        val h = size.height
-        val boltPath = icBoltPath(w, h, scale)
+        translate(top = verticalOffsetPx) {
+            val boltPath = icBoltPath(size.width, size.height, iconScale)
 
-        // Soft outer glow
-        drawPath(
-            path = boltPath,
-            color = zapColor.copy(alpha = pulse * 0.3f),
-            style = Stroke(width = w * 0.14f, cap = StrokeCap.Round, join = StrokeJoin.Round)
-        )
-
-        // Bolt fill
-        drawPath(path = boltPath, color = zapColor)
-
-        // White-hot core
-        drawPath(
-            path = boltPath,
-            color = Color.White.copy(alpha = pulse * 0.4f)
-        )
+            // Outer halo — widest, lowest opacity, breathing with phase.
+            drawPath(
+                path = boltPath,
+                color = zapColor.copy(alpha = 0.3f + 0.5f * phase),
+                style = Stroke(width = outerStrokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
+            )
+            // Medium glow.
+            drawPath(
+                path = boltPath,
+                color = zapColor.copy(alpha = 0.55f + 0.45f * phase),
+                style = Stroke(width = medStrokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
+            )
+            // Inner — tight, constant 95%.
+            drawPath(
+                path = boltPath,
+                color = zapColor.copy(alpha = 0.95f),
+                style = Stroke(width = innerStrokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
+            )
+            // White-core silhouette on top. Don't tint — the white IS
+            // the luminous core; the warm halos do the heat work.
+            drawPath(path = boltPath, color = Color.White)
+        }
     }
 }
 


### PR DESCRIPTION
Slim carve-out from #556. Single-file animation rewrite of the action-bar bolt for in-flight zaps. Ports iOS commit #6 from `feat/one-tap-zap`.

## What changes

Replaces the existing alpha+scale `LightningAnimation` (`tween(600)` reverse-repeat) with a sin-eased single-oscillator on a 0.9s period:

- `sine ∈ [-1, 1]`, `phase ∈ [0, 1] = (sine + 1) / 2`
- `iconScale = 1.0 + 0.10 * sine` (0.90 → 1.10)
- `verticalOffset = -0.5 * sine` (±0.5dp, centered on baseline — kept tight so the bolt doesn't lift off the action-bar baseline and misalign with neighbouring glyphs)

The silhouette stays solid white; three stacked stroked shadows behind it do the warm-glow work:

- **Inner stroke** — `1.5dp`, constant width, holds the white core's outline
- **Medium glow** — `4 + 3·phase dp`, breathes with the phase
- **Outer halo** — `8 + 6·phase dp`, widest bleed, breathes with the phase, alpha 0.3 → 0.8

All three shadows tint with `WispThemeColors.zapColor`.

## Note for reviewer

Main already has `WispThemeColors.zapAnimationColor` (added by #558) — a vivid-floored variant of `zapColor` specifically for animations so the burst never reads muddy on light backgrounds. The bolt animation still tints with `zapColor` in this PR to keep the carve-out faithful to the original commit; we can swap to `zapAnimationColor` here in a follow-up if that's preferred.

## Files

- `app/src/main/kotlin/com/wisp/app/ui/component/ActionBar.kt` (+52 / −35)

## Test plan

- [ ] Trigger an in-flight zap (any send-zap action) → bolt pulses with a soft warm halo around a solid white core
- [ ] Light mode: glow reads as warm orange against the near-white background, not as a flat alpha smear
- [ ] Dark mode: glow reads as vivid orange against the near-black background
- [ ] Bolt stays anchored on the action-bar baseline — no vertical wobble visible against neighbouring icons

## Carve-out context

PRs in the series so far: #570 (wallet setup polish), #571 (wallet dashboard polish), #572 (drop relay-backup status list).