### PR TITLE
feat(video): add loop video setting for timeline and gallery

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/wisp/app/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : FragmentActivity() {
                 mutableStateOf(MediaSettings(
                     autoLoadMedia = interfacePrefs.isAutoLoadMedia(),
                     videoAutoPlay = interfacePrefs.isVideoAutoPlay(),
+                    videoLoop = interfacePrefs.isVideoLoop(),
                     mediaLayoutStyle = interfacePrefs.getMediaLayoutStyle()
                 ))
             }
@@ -97,6 +98,7 @@ class MainActivity : FragmentActivity() {
                             mediaSettings = MediaSettings(
                                 autoLoadMedia = interfacePrefs.isAutoLoadMedia(),
                                 videoAutoPlay = interfacePrefs.isVideoAutoPlay(),
+                                videoLoop = interfacePrefs.isVideoLoop(),
                                 mediaLayoutStyle = interfacePrefs.getMediaLayoutStyle()
                             )
                         }

--- a/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/InterfacePreferences.kt
@@ -40,6 +40,11 @@ class InterfacePreferences(context: Context) {
     fun isVideoAutoPlay(): Boolean = prefs.getBoolean("video_auto_play", true)
     fun setVideoAutoPlay(enabled: Boolean) = prefs.edit().putBoolean("video_auto_play", enabled).apply()
 
+    // Loop videos in the timeline and full-screen gallery. Not yet
+    // round-tripped over NIP-78 to match iOS, which carries the same TODO.
+    fun isVideoLoop(): Boolean = prefs.getBoolean("video_loop", true)
+    fun setVideoLoop(enabled: Boolean) = prefs.edit().putBoolean("video_loop", enabled).apply()
+
     fun getMediaLayoutStyle(): MediaLayoutStyle =
         MediaLayoutStyle.fromKey(prefs.getString("media_layout_style", null))
     fun setMediaLayoutStyle(style: MediaLayoutStyle) =

--- a/app/src/main/kotlin/com/wisp/app/ui/component/FullScreenVideoPlayer.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/FullScreenVideoPlayer.kt
@@ -22,11 +22,13 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import com.wisp.app.R
 import com.wisp.app.relay.HttpClientFactory
+import com.wisp.app.repo.InterfacePreferences
 import com.wisp.app.util.MediaDownloader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -64,12 +66,15 @@ fun FullScreenVideoPlayer(
     DisposableEffect(videoUrl) {
         val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
 
+        val loopEnabled = InterfacePreferences(context).isVideoLoop()
         val ownsPlayer = existingPlayer == null
-        val exoPlayer = existingPlayer ?: HttpClientFactory.createExoPlayer(context).apply {
+        val exoPlayer = (existingPlayer ?: HttpClientFactory.createExoPlayer(context).apply {
             setMediaItem(MediaItem.fromUri(Uri.parse(videoUrl)))
             prepare()
             seekTo(startPositionMs)
             playWhenReady = true
+        }).apply {
+            repeatMode = if (loopEnabled) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
         }
 
         var minimizedToPip = false

--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -133,6 +133,7 @@ private const val INLINE_CONTENT_TAG = "androidx.compose.foundation.text.inlineC
 data class MediaSettings(
     val autoLoadMedia: Boolean = true,
     val videoAutoPlay: Boolean = true,
+    val videoLoop: Boolean = true,
     val mediaLayoutStyle: com.wisp.app.repo.InterfacePreferences.MediaLayoutStyle =
         com.wisp.app.repo.InterfacePreferences.MediaLayoutStyle.GALLERY
 )
@@ -2310,13 +2311,18 @@ internal fun InlineVideoPlayerWithFullscreen(meta: MediaMeta, onFullScreen: (pos
                 volume = if (globalMuted.value) 0f else 1f
                 playWhenReady = false
             }).apply {
-                repeatMode = Player.REPEAT_MODE_ONE
+                repeatMode = if (mediaSettings.videoLoop) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
             }
     }
 
     // Sync volume with global mute state
     LaunchedEffect(isMuted) {
         exoPlayer.volume = if (isMuted) 0f else 1f
+    }
+
+    LaunchedEffect(mediaSettings.videoLoop) {
+        exoPlayer.repeatMode =
+            if (mediaSettings.videoLoop) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
     }
 
     DisposableEffect(url) {
@@ -2589,12 +2595,17 @@ private fun InlineVideoPlayer(url: String, modifier: Modifier = Modifier) {
                 volume = if (globalMuted.value) 0f else 1f
                 playWhenReady = false
             }).apply {
-                repeatMode = Player.REPEAT_MODE_ONE
+                repeatMode = if (mediaSettings.videoLoop) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
             }
     }
 
     LaunchedEffect(isMuted) {
         exoPlayer.volume = if (isMuted) 0f else 1f
+    }
+
+    LaunchedEffect(mediaSettings.videoLoop) {
+        exoPlayer.repeatMode =
+            if (mediaSettings.videoLoop) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
     }
 
     DisposableEffect(url) {

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/InterfaceScreen.kt
@@ -99,6 +99,7 @@ fun InterfaceScreen(
     var clientTagEnabled by remember { mutableStateOf(interfacePrefs.isClientTagEnabled()) }
     var autoLoadMedia by remember { mutableStateOf(interfacePrefs.isAutoLoadMedia()) }
     var videoAutoPlay by remember { mutableStateOf(interfacePrefs.isVideoAutoPlay()) }
+    var videoLoop by remember { mutableStateOf(interfacePrefs.isVideoLoop()) }
     var mediaLayout by remember { mutableStateOf(interfacePrefs.getMediaLayoutStyle()) }
     var liveStreamsHidden by remember { mutableStateOf(interfacePrefs.isLiveStreamsHidden()) }
     var autoTranslate by remember { mutableStateOf(interfacePrefs.isAutoTranslate()) }
@@ -457,6 +458,29 @@ fun InterfaceScreen(
                     onCheckedChange = {
                         videoAutoPlay = it
                         interfacePrefs.setVideoAutoPlay(it)
+                        onChanged()
+                    },
+                    colors = wispSwitchColors()
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.settings_video_loop), style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        stringResource(R.string.settings_video_loop_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = videoLoop,
+                    onCheckedChange = {
+                        videoLoop = it
+                        interfacePrefs.setVideoLoop(it)
                         onChanged()
                     },
                     colors = wispSwitchColors()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,6 +533,8 @@
     <string name="settings_auto_load_description">Automatically download images and videos in notes. When off, tap to load.</string>
     <string name="settings_video_autoplay">Video autoplay</string>
     <string name="settings_video_autoplay_description">Automatically play videos when they scroll into view</string>
+    <string name="settings_video_loop">Loop videos</string>
+    <string name="settings_video_loop_description">Replays timeline and gallery videos from the beginning when they finish.</string>
     <string name="settings_media_layout">Multi-image layout</string>
     <string name="settings_media_layout_description">Gallery: horizontal swipe through every photo and video. Stack: each item full-width below the next.</string>
     <string name="settings_media_layout_gallery">Gallery</string>


### PR DESCRIPTION
## Summary

Port of [wisp-ios#149](https://github.com/barrydeen/wisp-ios/pull/149).

- Adds a **Loop videos** toggle to Interface Settings (Media section)
- Applies to both the timeline feed and the full-screen gallery viewer
- Defaults to on, matching prior Android timeline behavior
- Not yet round-tripped over NIP-78 — matches iOS, which carries the same TODO

## Test plan

Test note: `nevent1qqsyxre5jsca9ydtepx8atv0f6p3alfqvjwn2xw29jqhckacvhgqx2sprfmhxue69uhhg6r9vehhyetnwshxummnw3erztnrdaksz9thwden5te0wfjkccte9ekk7um5wgh8qatzqy2hwumn8ghj7un9d3shjtnyd968gmewwp6kyq3q37c5pd8gmhhe0njtsgwjgunc5xjr2vmzvglkgqs5sjeh972gqqxq4cyu8m`

- [ ] Open Interface Settings → Media — confirm the **Loop videos** toggle appears below Video autoplay
- [ ] Enable looping — verify the video in the timeline replays continuously
- [ ] Tap the timeline video to enter the gallery viewer — confirm it also loops
- [ ] Disable looping — verify both timeline and gallery videos play once and stop