### PR TITLE
feat: apply web of trust filter to thread replies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = baseApplicationId
         minSdk = 26
         targetSdk = 35
-        versionCode = 80
-        versionName = "1.1.0"
+        versionCode = 81
+        versionName = "1.1.1"
         resValue("string", "app_name", "Wisp")
 
         ndk {

--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -313,7 +313,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     private val WOT_EXEMPT_KINDS = intArrayOf(0, 3, 4, 10002, 10050, 1059, 13, 14)
 
-    private fun isWotFiltered(pubkey: String, kind: Int): Boolean {
+    fun isWotFiltered(pubkey: String, kind: Int): Boolean {
         if (safetyPrefs?.wotFilterEnabled?.value != true) return false
         val netRepo = extendedNetworkRepo ?: return false
         if (!netRepo.isNetworkReady()) return false

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
@@ -434,6 +434,7 @@ class ThreadViewModel : ViewModel() {
             if (deletedRepo?.isDeleted(event.id) == true) continue
             if (muteRepo?.isBlocked(event.pubkey) == true) continue
             if (Nip10.isStandaloneQuote(event)) continue
+            if (eventRepoRef?.isWotFiltered(event.pubkey, event.kind) == true) continue
 
             if (spamEnabled && spamClassifier != null &&
                 event.pubkey != currentUserPubkey &&


### PR DESCRIPTION
## Summary
- WoT filter already silently drops events at `EventRepository.addEvent` and inside `NotificationRepository`, but thread replies bypassed both paths — `ThreadViewModel` keeps its own `threadEvents` map seeded via `cacheEvent()` and `getCachedThreadEvents()`, neither of which checks WoT
- Apply `isWotFiltered` inside `rebuildTree()` alongside the existing block / mute / spam filters
- Root note stays visible (user explicitly navigated to it); replies from authors outside the qualified network are silently dropped, matching feed + notifications behavior
- `isWotFiltered` changed from `private` to package-default so `ThreadViewModel` can reuse the same logic instead of duplicating it
- WOT_EXEMPT_KINDS already excludes the relevant infrastructure kinds (0/3/4/10002/10050/1059/13/14); kind 1 replies are not exempt, which is what we want

## Test plan
- [ ] With WoT disabled: open a thread with replies — all replies render as before
- [ ] With WoT enabled and graph computed: open a thread containing replies from accounts outside your qualified network — those replies are hidden; replies from follows and qualified second-degree accounts remain
- [ ] Open a thread whose root author is outside your network — root still renders (you tapped in deliberately)
- [ ] With WoT enabled but graph not yet computed: replies are not filtered (`isNetworkReady` returns false) — falls open, no regression
- [ ] Confirm own replies in a thread are never filtered (currentUserPubkey carve-out in `isWotFiltered`)