### PR TITLE
fix: remove stale wallet translation keys blocking release build

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">Noch keine gerankten Ergebnisse. Schauen Sie später vorbei.</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">Brieftasche Verbinden</string>
-    <string name="wallet_choose_how">Wählen Sie, wie Sie eine Lightning-Brieftasche zum Senden und Empfangen von Sats verbinden.</string>
-    <string name="wallet_create_new">Neue Brieftasche Erstellen</string>
-    <string name="wallet_create_description">Erstellen Sie eine neue Brieftasche direkt in Wisp, Gelder werden von Spark-Anbietern gesichert</string>
-    <string name="wallet_nwc_description">Verbinden Sie eine externe Lightning-Brieftasche mit einer NWC-Verbindungszeichenfolge.</string>
     <string name="wallet_nwc_connection_string">NWC-Verbindungszeichenfolge</string>
     <string name="wallet_connect">Verbinden</string>
-    <string name="wallet_spark">Spark Brieftasche</string>
     <string name="wallet_set_up_lightning">Lightning-Adresse Einrichten</string>
     <string name="wallet_send">Senden</string>
     <string name="wallet_receive">Empfangen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">Sin resultados clasificados aún. Vuelve más tarde.</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">Conectar Billetera</string>
-    <string name="wallet_choose_how">Elige cómo conectar una billetera Lightning para enviar y recibir sats.</string>
-    <string name="wallet_create_new">Crear Nueva Billetera</string>
-    <string name="wallet_create_description">Crea una nueva billetera directamente en Wisp, fondos asegurados por proveedores Spark</string>
-    <string name="wallet_nwc_description">Conecta una billetera Lightning externa usando una cadena de conexión NWC.</string>
     <string name="wallet_nwc_connection_string">Cadena de Conexión NWC</string>
     <string name="wallet_connect">Conectar</string>
-    <string name="wallet_spark">Billetera Spark</string>
     <string name="wallet_set_up_lightning">Configurar tu Dirección Lightning</string>
     <string name="wallet_send">Enviar</string>
     <string name="wallet_receive">Recibir</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">Pas encore de résultats classifiés. Revenez plus tard.</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">Connecter un Portefeuille</string>
-    <string name="wallet_choose_how">Choisissez comment connecter un portefeuille Lightning pour envoyer et recevoir des sats.</string>
-    <string name="wallet_create_new">Créer un Nouveau Portefeuille</string>
-    <string name="wallet_create_description">Créez un nouveau portefeuille directement dans Wisp, les fonds sont sécurisés par les fournisseurs Spark</string>
-    <string name="wallet_nwc_description">Connectez un portefeuille Lightning externe utilisant une chaîne de connexion NWC.</string>
     <string name="wallet_nwc_connection_string">Chaîne de Connexion NWC</string>
     <string name="wallet_connect">Connecter</string>
-    <string name="wallet_spark">Portefeuille Spark</string>
     <string name="wallet_set_up_lightning">Configurer votre Adresse Lightning</string>
     <string name="wallet_send">Envoyer</string>
     <string name="wallet_receive">Recevoir</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">Nessun risultato classificato ancora. Riprova più tardi.</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">Connetti Portafoglio</string>
-    <string name="wallet_choose_how">Scegli come connettere un portafoglio Lightning per inviare e ricevere sats.</string>
-    <string name="wallet_create_new">Crea Nuovo Portafoglio</string>
-    <string name="wallet_create_description">Crea un nuovo portafoglio direttamente in Wisp, i fondi sono protetti da provider Spark</string>
-    <string name="wallet_nwc_description">Connetti un portafoglio Lightning esterno usando una stringa di connessione NWC.</string>
     <string name="wallet_nwc_connection_string">Stringa di Connessione NWC</string>
     <string name="wallet_connect">Connetti</string>
-    <string name="wallet_spark">Portafoglio Spark</string>
     <string name="wallet_set_up_lightning">Configura il tuo Indirizzo Lightning</string>
     <string name="wallet_send">Invia</string>
     <string name="wallet_receive">Ricevi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">まだランキング結果がありません。後でもう一度確認してください。</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">ウォレットを接続</string>
-    <string name="wallet_choose_how">サットを送受信するためのLightningウォレットの接続方法を選択してください。</string>
-    <string name="wallet_create_new">新規ウォレットを作成</string>
-    <string name="wallet_create_description">Wispで直接新しいウォレットを作成、資金はSparkプロバイダーが保護</string>
-    <string name="wallet_nwc_description">NWC接続文字列を使用して外部Lightningウォレットを接続。</string>
     <string name="wallet_nwc_connection_string">NWC接続文字列</string>
     <string name="wallet_connect">接続</string>
-    <string name="wallet_spark">Sparkウォレット</string>
     <string name="wallet_set_up_lightning">Lightningアドレスを設定</string>
     <string name="wallet_send">送る</string>
     <string name="wallet_receive">受け取る</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">아직 순위 결과가 없습니다. 나중에 다시 확인하세요.</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">지갑 연결</string>
-    <string name="wallet_choose_how">사트를 보내고 받기 위한 라이트닝 지갑 연결 방법을 선택하세요.</string>
-    <string name="wallet_create_new">새 지갑 만들기</string>
-    <string name="wallet_create_description">Wisp에서 직접 새 지갑 만들기,资金은 Spark 제공자가 보호</string>
-    <string name="wallet_nwc_description">NWC 연결 문자열을 사용하여 외부 라이트닝 지갑을 연결합니다.</string>
     <string name="wallet_nwc_connection_string">NWC 연결 문자열</string>
     <string name="wallet_connect">연결</string>
-    <string name="wallet_spark">Spark 지갑</string>
     <string name="wallet_set_up_lightning">라이트닝 주소 설정</string>
     <string name="wallet_send">보내기</string>
     <string name="wallet_receive">받기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">Nog geen gerangschikte resultaten. Kom later terug.</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">Portemonnee Verbinden</string>
-    <string name="wallet_choose_how">Kies hoe je een Lightning portemonnee verbindt voor het verzenden en ontvangen van sats.</string>
-    <string name="wallet_create_new">Nieuwe Portemonnee Maken</string>
-    <string name="wallet_create_description">Maak een nieuwe portemonnee direct in Wisp, fondsen zijn beveiligd door Spark providers</string>
-    <string name="wallet_nwc_description">Verbind een externe Lightning portemonnee met een NWC verbindingsreeks.</string>
     <string name="wallet_nwc_connection_string">NWC Verbindingsreeks</string>
     <string name="wallet_connect">Verbinden</string>
-    <string name="wallet_spark">Spark Portemonnee</string>
     <string name="wallet_set_up_lightning">Lightning Adres Instellen</string>
     <string name="wallet_send">Verzenden</string>
     <string name="wallet_receive">Ontvangen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">Sem resultados classificados ainda. Volte mais tarde.</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">Conectar Carteira</string>
-    <string name="wallet_choose_how">Escolha como conectar uma carteira Lightning para enviar e receber sats.</string>
-    <string name="wallet_create_new">Criar Nova Carteira</string>
-    <string name="wallet_create_description">Crie uma nova carteira diretamente no Wisp, fundos são protegidos por provedores Spark</string>
-    <string name="wallet_nwc_description">Conecte uma carteira Lightning externa usando uma string de conexão NWC.</string>
     <string name="wallet_nwc_connection_string">String de Conexão NWC</string>
     <string name="wallet_connect">Conectar</string>
-    <string name="wallet_spark">Carteira Spark</string>
     <string name="wallet_set_up_lightning">Configurar seu Endereço Lightning</string>
     <string name="wallet_send">Enviar</string>
     <string name="wallet_receive">Receber</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -544,14 +544,8 @@
     <string name="profile_crawling_no_results">Результатов ранжирования пока нет. Проверьте позже.</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">Подключить Кошелёк</string>
-    <string name="wallet_choose_how">Выберите способ подключения кошелька Lightning для отправки и получения сат.</string>
-    <string name="wallet_create_new">Создать Новый Кошелёк</string>
-    <string name="wallet_create_description">Создайте новый кошелёк прямо в Wisp, средства защищены провайдерами Spark</string>
-    <string name="wallet_nwc_description">Подключите внешний кошелёк Lightning с помощью строки подключения NWC.</string>
     <string name="wallet_nwc_connection_string">Строка Подключения NWC</string>
     <string name="wallet_connect">Подключить</string>
-    <string name="wallet_spark">Кошелёк Spark</string>
     <string name="wallet_set_up_lightning">Настроить Адрес Lightning</string>
     <string name="wallet_send">Отправить</string>
     <string name="wallet_receive">Получить</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -583,14 +583,8 @@
     <string name="profile_crawling_no_results">暂无排名结果。请稍后再试。</string>
 
     <!-- Wallet -->
-    <string name="wallet_connect_wallet">连接钱包</string>
-    <string name="wallet_choose_how">选择如何连接Lightning钱包以发送和接收聪。</string>
-    <string name="wallet_create_new">创建新钱包</string>
-    <string name="wallet_create_description">直接在Wisp中创建新钱包，资金由Spark提供商保障</string>
-    <string name="wallet_nwc_description">使用NWC连接字符串连接外部Lightning钱包。</string>
     <string name="wallet_nwc_connection_string">NWC连接字符串</string>
     <string name="wallet_connect">连接</string>
-    <string name="wallet_spark">Spark钱包</string>
     <string name="wallet_set_up_lightning">设置Lightning地址</string>
     <string name="wallet_send">发送</string>
     <string name="wallet_receive">接收</string>


### PR DESCRIPTION
## Summary
- 60 `ExtraTranslation` lint errors were failing `lintVitalRelease` and blocking `assembleRelease`.
- All 60 stemmed from 6 stale wallet string keys (`wallet_connect_wallet`, `wallet_choose_how`, `wallet_create_new`, `wallet_create_description`, `wallet_nwc_description`, `wallet_spark`) that were renamed in the default locale (now `wallet_connect_title`, `wallet_spark_title`, `wallet_nwc_title`, etc.) but left behind in 10 translation files.
- None of the stale keys are referenced anywhere in Kotlin sources — they're pure dead translations. Removed them across `values-{de,es,fr,it,ja,ko,nl,pt,ru,zh}/strings.xml`.

## Test plan
- [x] `./gradlew assembleRelease` succeeds (was failing with 60 lint errors)
- [ ] Spot-check wallet screens in a release build to confirm the renamed default-locale keys (`wallet_connect_title`, etc.) render correctly