### PR TITLE
fix(wallet): keep self-send legs distinct + deterministic tx order

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -2319,7 +2319,11 @@ private fun TransactionHistoryContent(
             }
             else -> {
                 LazyColumn {
-                    items(transactions) { tx ->
+                    // Key by paymentHash + direction so a self-send's two legs
+                    // (same hash, opposite type) keep distinct identities and
+                    // both render. The list is deduped by (paymentHash, type)
+                    // upstream, so these keys are unique.
+                    items(transactions, key = { "${it.paymentHash}|${it.type}" }) { tx ->
                         TransactionRow(tx, profileLookup, displayMode)
                         HorizontalDivider(
                             modifier = Modifier.padding(horizontal = 16.dp),

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
@@ -1249,7 +1249,7 @@ class WalletViewModel(
             }
             mapped.fold(
                 onSuccess = { txs ->
-                    _transactions.value = txs
+                    _transactions.value = dedupTransactions(txs)
                     _hasMoreTransactions.value = txs.size >= 50
                     requestMissingProfiles(txs)
                 },
@@ -1266,12 +1266,28 @@ class WalletViewModel(
                     enrichTransactions(current, zapMaps)
                 }
                 if (reEnriched != current) {
-                    _transactions.value = reEnriched
+                    _transactions.value = dedupTransactions(reEnriched)
                     requestMissingProfiles(reEnriched)
                 }
             }
         }
     }
+
+    /**
+     * Collapse exact backend duplicates and order transactions deterministically.
+     *
+     * A self-send surfaces as two records sharing one payment hash — one
+     * outgoing, one incoming. Both legs must survive (we only drop repeats of
+     * the same (paymentHash, type)), and on a timestamp tie the incoming
+     * "received" leg sorts above its outgoing "sent" leg so the conclusion of
+     * the payment reads on top. Mirrors iOS WalletStore.dedupTransactions.
+     */
+    private fun dedupTransactions(txs: List<WalletTransaction>): List<WalletTransaction> =
+        txs.distinctBy { it.paymentHash to it.type }
+            .sortedWith(
+                compareByDescending<WalletTransaction> { it.settledAt ?: it.createdAt }
+                    .thenBy { if (it.type == "incoming") 0 else 1 }
+            )
 
     private fun enrichTransactions(
         txs: List<WalletTransaction>,
@@ -1325,7 +1341,7 @@ class WalletViewModel(
             }
             mapped.fold(
                 onSuccess = { txs ->
-                    _transactions.value = _transactions.value + txs
+                    _transactions.value = dedupTransactions(_transactions.value + txs)
                     _hasMoreTransactions.value = txs.size >= 50
                     val missing = txs.mapNotNull { it.counterpartyPubkey }
                         .distinct()


### PR DESCRIPTION
## Summary

A self-payment (e.g. paying your own lightning address) surfaces in the wallet provider's transaction list as **two records sharing one payment hash** — one outgoing leg and one incoming leg. Two problems followed on Android:

1. **One leg vanished from the UI.** `LazyColumn { items(transactions) }` falls back to identity equality. Because both legs share the same `paymentHash` and equal in most other fields, Compose treated them as the same item and only rendered one.
2. **Order was non-deterministic.** Some providers (notably NWC) return the legs in send-then-receive order; Spark returns receive-then-send. The displayed order followed whatever the provider gave us, so the same self-send rendered differently across wallet backends.

This PR ports the iOS `WalletStore.dedupTransactions` hardening so Android matches.

## Changes

- **`WalletViewModel.kt`** — adds `dedupTransactions()`:
  - drops exact `(paymentHash, type)` repeats the backend returns
  - sorts newest-first
  - on a timestamp tie, places the incoming "received" leg **above** its outgoing "sent" leg
  - applied on initial load, post-enrichment, and load-more
- **`WalletScreen.kt`** — keys the transaction `LazyColumn` by `"$paymentHash|$type"` so the two legs of a self-send keep distinct Compose identities and both render. Mirrors iOS `WalletTransaction.id`.

## Verified on device

Before: NWC wallet self-send pair rendered with the **sent** leg above the **received** leg (opposite of Spark).
After: both wallets show **received above sent** for self-send pairs, and both legs are visible.

(Screenshots in the comment that triggered this fix.)

## Reference

iOS: `WalletStore.swift` → `dedupTransactions` + `WalletTransaction.id`.