### PR TITLE
feat: add staging build type for release-performance on-device testing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,19 @@ android {
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
+
+        create("staging") {
+            // Release-performance build for on-device testing. debuggable=true (the
+            // debug type) makes ART ignore the baseline profile and run JIT-only with
+            // deoptimization support, which cripples the per-event hot path (JSON parse,
+            // hex decode, SHA-256, JNI Schnorr verify per relay event). This variant is
+            // non-debuggable + R8 like release, but debug-signed so anyone can install
+            // it without the release keystore. Installs alongside debug/release.
+            initWith(getByName("release"))
+            applicationIdSuffix = ".staging"
+            resValue("string", "app_name", "Wisp Staging")
+            signingConfig = signingConfigs.getByName("debug")
+        }
     }
 
     compileOptions {


### PR DESCRIPTION
Non-debuggable + R8-minified like release (initWith(release)), but debug-signed so anyone can install it without the release keystore. applicationIdSuffix ".staging" and app name "Wisp Staging" let it install alongside debug and release builds.

debuggable=true makes ART ignore the baseline profile and run JIT-only with deoptimization support, which cripples the per-event hot path (JSON parse, hex decode, SHA-256, JNI Schnorr verify per relay event) -- so debug builds can't be used to judge real performance.

Port of barrydeen/dark-wisp-android#24.