### PR TITLE
fix(compose): move uploading indicator to its own line as a capsule pill

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ComposeScreen.kt
@@ -855,21 +855,6 @@ fun ComposeScreen(
                             )
                         }
 
-                        if (uploadProgress != null) {
-                            Spacer(Modifier.width(8.dp))
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(20.dp),
-                                strokeWidth = 2.dp,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                            Spacer(Modifier.width(6.dp))
-                            Text(
-                                stringResource(R.string.compose_uploading),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-
                         Spacer(Modifier.weight(1f))
 
                             if (content.text.isNotBlank()) {
@@ -877,6 +862,41 @@ fun ComposeScreen(
                                 onClick = onSaveDraft
                             ) {
                                 Text(stringResource(R.string.btn_save_draft))
+                            }
+                        }
+                    }
+
+                    // Uploading indicator on its own line as a capsule pill, so
+                    // the label never has to wrap inside the crowded icon row.
+                    AnimatedVisibility(
+                        visible = uploadProgress != null,
+                        enter = expandVertically() + fadeIn(),
+                        exit = shrinkVertically() + fadeOut()
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 4.dp)
+                        ) {
+                            Surface(
+                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                                shape = RoundedCornerShape(50)
+                            ) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(16.dp),
+                                        strokeWidth = 2.dp,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Text(
+                                        stringResource(R.string.compose_uploading),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        maxLines = 1,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Mirror of barrydeen/dark-wisp-android#38 for this repo.

The "Uploading…" label was crammed into the compose toolbar's icon row alongside six icon buttons, leaving no horizontal space — so the text wrapped to three lines ("Uplo / ading / …"). This pulls the spinner + label out of the icon row onto a dedicated line below it, wrapped in a rounded `surfaceVariant` capsule with `maxLines = 1` so it can never wrap. It animates in/out with the upload lifecycle.

## Screenshots

| Before | After |
|--------|-------|
| <img width="588" height="331" alt="image" src="https://github.com/user-attachments/assets/4bf4da3e-2dad-4e1a-bb3d-eed85bd1972a" />| <img width="588" height="331" alt="image" src="https://github.com/user-attachments/assets/1904af32-3a65-4ba6-8a98-6c71fdb86cd7" />|

## Test plan

- [ ] Open Compose (or Reply), attach an image
- [ ] While the upload is in flight, verify the "Uploading…" indicator shows as a single-line capsule pill on its own line below the toolbar icons — no text wrapping
- [ ] Verify it animates away when the upload completes
- [ ] Verify the toolbar icons and Publish button are unaffected

## Reference

Faithful 1:1 port of barrydeen/dark-wisp-android#38 (same diff, `com.wisp.app` package).