### PR TITLE
fix: prevent ConcurrentModificationException in eventRelays set

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -1047,7 +1047,10 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     }
 
     fun addEventRelay(eventId: String, relayUrl: String) {
-        val relays = eventRelays.get(eventId) ?: mutableSetOf<String>().also {
+        // Thread-safe set: relay IO threads mutate this via addEventRelay while UI coroutines
+        // iterate the live set returned by getEventRelays. A plain LinkedHashSet (mutableSetOf)
+        // throws ConcurrentModificationException here; newKeySet has a weakly-consistent iterator.
+        val relays = eventRelays.get(eventId) ?: ConcurrentHashMap.newKeySet<String>().also {
             eventRelays.put(eventId, it)
         }
         if (relays.add(relayUrl)) {


### PR DESCRIPTION
## Problem

Crash report (`ConcurrentModificationException`):

```
java.util.ConcurrentModificationException
 at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:1061)
 at java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:1084)
```

`EventRepository.eventRelays` (`LruCache<String, MutableSet<String>>`) stored per-event relay URLs in plain `LinkedHashSet` instances created via `mutableSetOf()` — whose key iterator is exactly `LinkedHashMap$LinkedKeyIterator`.

The race:

- **Writers:** `addEventRelay()` adds relay URLs to the *live* set as events stream in from many relays on `Dispatchers.IO` threads.
- **Readers:** `getEventRelays()` returns that same live set, which `getRelayHintsForEvents()` (called from `SocialActionManager`, `FeedViewModel`, `ListCrudManager`) and ~10 UI sites iterate (`.map`/`.take`/`.firstOrNull`) on the Main dispatcher.

A concurrent add mid-iteration tripped the iterator's mod-count check and crashed.

## Fix

Create the set with `ConcurrentHashMap.newKeySet<String>()` instead of `mutableSetOf<String>()`. Its iterator is weakly consistent, so concurrent adds during iteration no longer throw.

This matches the existing pattern already used for the sibling `repostAuthors` cache (which is also a returned-and-iterated `LruCache<String, MutableSet<String>>` and never had this problem). No call sites change — `getEventRelays` still returns `Set<String>`, read-only.