### PR TITLE
fix: avoid intrinsic measurement of chat bubble content (SubcomposeLayout crash)

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/DmBubble.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/DmBubble.kt
@@ -200,6 +200,7 @@ fun DmBubble(
                 modifier = Modifier.weight(1f, fill = isSent),
                 contentAlignment = if (isSent) Alignment.BottomEnd else Alignment.BottomStart
             ) {
+                val bubbleMaxWidth = maxWidth
                 @OptIn(ExperimentalFoundationApi::class)
                 Box(
                     modifier = Modifier
@@ -221,13 +222,11 @@ fun DmBubble(
                 ) {
                     Column(
                         modifier = Modifier
-                            .width(IntrinsicSize.Max)
                             .padding(horizontal = 12.dp, vertical = 8.dp)
                     ) {
                         // Header row: sender name + timestamp (received messages only)
                         if (!isSent) {
                             Row(
-                                modifier = Modifier.fillMaxWidth(),
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(4.dp)
                             ) {
@@ -238,7 +237,7 @@ fun DmBubble(
                                     color = MaterialTheme.colorScheme.primary,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.widthIn(max = bubbleMaxWidth - 96.dp)
                                 )
                                 Text(
                                     text = formatTime(message.createdAt),

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/GroupRoomScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/GroupRoomScreen.kt
@@ -1346,6 +1346,7 @@ private fun GroupMessageBubble(
                 modifier = Modifier.weight(1f, fill = isOwnMessage),
                 contentAlignment = if (isOwnMessage) Alignment.BottomEnd else Alignment.BottomStart
             ) {
+                val bubbleMaxWidth = maxWidth
                 Surface(
                     shape = if (isOwnMessage)
                         RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomEnd = 4.dp, bottomStart = 16.dp)
@@ -1359,13 +1360,11 @@ private fun GroupMessageBubble(
                 ) {
                     Column(
                         modifier = Modifier
-                            .width(IntrinsicSize.Max)
                             .padding(horizontal = 12.dp, vertical = 8.dp)
                     ) {
                         // Header row hidden for own messages
                         if (!isOwnMessage) {
                             Row(
-                                modifier = Modifier.fillMaxWidth(),
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(4.dp)
                             ) {
@@ -1375,7 +1374,7 @@ private fun GroupMessageBubble(
                                     color = nameColor,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.widthIn(max = bubbleMaxWidth - 96.dp)
                                 )
                                 if (hasZaps) {
                                     Text(


### PR DESCRIPTION
## Problem

Opening **certain** group rooms / DM conversations crashed with:

> `java.lang.IllegalStateException: Asking for intrinsic measurements of SubcomposeLayout layouts is not supported. This includes components that are built on top of SubcomposeLayout, such as lazy lists, BoxWithConstraints, TabRow, etc.`

(Reported on 1.1.1, Pixel 9a, Android 16.)

## Root cause

The message-bubble content `Column` was sized with `Modifier.width(IntrinsicSize.Max)`:

- `GroupRoomScreen.kt` (group message bubble)
- `DmBubble.kt` (DM / group-DM bubble)

`IntrinsicSize.Max` forces an intrinsic-width measurement of every child. One child is `RichContent`, which can render `MediaCarousel` — a `BoxWithConstraints` + `HorizontalPager`. Both are `SubcomposeLayout`-based and cannot answer intrinsic queries, so the measure pass throws.

This is why the crash was content-dependent: only rooms with a visible message rendering a media carousel (gallery layout with 2+ images/videos, or a quoted-note embed containing such media) were affected. Text-only rooms never hit it.

## Fix

Stop intrinsically measuring `RichContent`:

- Remove `Modifier.width(IntrinsicSize.Max)` from both bubble columns; the bubble now hugs its content naturally.
- Make the received-message header row hug its content (dropped `fillMaxWidth()` and the name's `weight(1f)`), since with the intrinsic sizing gone a filled header would balloon every bubble to max width. The sender name uses `widthIn(max = bubbleMaxWidth - 96.dp)` so long names still ellipsize.

The `MediaCarousel` / pager code is untouched — it was only the illegal intrinsic measurement above it that needed removing. The remaining `IntrinsicSize.Min` sites in these files only contain `Text`/`Box` leaves and are safe.

### Cosmetic note

For received messages the sender name + timestamp now group together at the top-left of the bubble rather than the timestamp being pinned to the far-right edge.

## Verification

- `./gradlew assembleDebug` succeeds.
- Recommended manual check: set media layout to **Gallery**, open a room/DM containing a message with 2+ images — renders the carousel instead of crashing. Spot-check short/long-name received bubbles and sent bubbles.