### PR TITLE
perf: incremental feed filter + off-lock spam scoring

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -101,6 +101,12 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     private val feedList = mutableListOf<NostrEvent>()
     private val feedIds = HashSet<String>()  // O(1) dedup that doesn't evict like LruCache
 
+    // Filtered view of feedList with the active author/kind filter applied, maintained
+    // incrementally so publishing the feed never re-filters the whole master list per insert.
+    // Always guarded by the feedList monitor (synchronized(feedList)) — never observed out of sync.
+    private val filteredFeed = mutableListOf<NostrEvent>()
+    private val filteredFeedIds = HashSet<String>()
+
     private val _feed = MutableStateFlow<List<NostrEvent>>(emptyList())
     val feed: StateFlow<List<NostrEvent>> = _feed
 
@@ -218,14 +224,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         scope.launch {
             for (signal in feedInserted) {
                 delay(50)  // settle window: coalesce concurrent inserts
-                val authorFilter = _authorFilter.value
-                val kindFilter = _kindFilter
-                val raw = synchronized(feedList) { feedList.toList() }
-                _feed.value = raw.filter { event ->
-                    val authorOk = authorFilter == null || event.pubkey in authorFilter || isRepostedByAny(event.id, authorFilter)
-                    val kindOk = kindFilter == null || event.kind in kindFilter
-                    authorOk && kindOk
-                }
+                publishFeed()
             }
         }
         // Relay feed emission — same 50ms settle pattern but for isolated relay feed
@@ -238,14 +237,7 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         // Immediate emission channel — used for explicit flushes (purge, filter change, etc.)
         scope.launch {
             for (signal in feedDirty) {
-                val authorFilter = _authorFilter.value
-                val kindFilter = _kindFilter
-                val raw = synchronized(feedList) { feedList.toList() }
-                _feed.value = raw.filter { event ->
-                    val authorOk = authorFilter == null || event.pubkey in authorFilter || isRepostedByAny(event.id, authorFilter)
-                    val kindOk = kindFilter == null || event.kind in kindFilter
-                    authorOk && kindOk
-                }
+                publishFeed()
             }
         }
         // Debounce version counter emissions — coalesce into one bump per 50ms window
@@ -423,6 +415,9 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                                     if (idx >= 0) {
                                         feedList.removeAt(idx)
                                         feedIds.remove(inner.id)
+                                        if (filteredFeedIds.remove(inner.id)) {
+                                            filteredFeed.removeAll { it.id == inner.id }
+                                        }
                                     }
                                 }
                                 binaryInsert(inner, sortTime = event.created_at, fromFeed = true)
@@ -677,7 +672,38 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     private fun effectiveSortTime(event: NostrEvent): Long =
         feedSortTime.get(event.id) ?: event.created_at
 
+    /** True if [event] belongs in the filtered feed under the current author/kind filter. */
+    private fun passesFilter(event: NostrEvent): Boolean {
+        val authorFilter = _authorFilter.value
+        val kindFilter = _kindFilter
+        val authorOk = authorFilter == null || event.pubkey in authorFilter || isRepostedByAny(event.id, authorFilter)
+        val kindOk = kindFilter == null || event.kind in kindFilter
+        return authorOk && kindOk
+    }
+
+    /**
+     * Binary-insert [event] into [filteredFeed] keeping the same sort order as feedList.
+     * Caller must hold the feedList monitor. Returns true if the event was inserted.
+     */
+    private fun filteredInsert(event: NostrEvent, sortTime: Long): Boolean {
+        if (!filteredFeedIds.add(event.id)) return false
+        var low = 0
+        var high = filteredFeed.size
+        while (low < high) {
+            val mid = (low + high) / 2
+            if (effectiveSortTime(filteredFeed[mid]) > sortTime) low = mid + 1 else high = mid
+        }
+        filteredFeed.add(low, event)
+        return true
+    }
+
+    /** Publish the current filtered feed snapshot to observers. */
+    private fun publishFeed() {
+        _feed.value = synchronized(feedList) { ArrayList(filteredFeed) }
+    }
+
     private fun binaryInsert(event: NostrEvent, sortTime: Long = event.created_at, fromFeed: Boolean = false) {
+        var filteredChanged = false
         synchronized(feedList) {
             if (!feedIds.add(event.id)) {
                 if (event.kind in intArrayOf(20, 21, 22)) {
@@ -692,11 +718,12 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                 if (effectiveSortTime(feedList[mid]) > sortTime) low = mid + 1 else high = mid
             }
             feedList.add(low, event)
+            if (passesFilter(event)) filteredChanged = filteredInsert(event, sortTime)
             if (event.kind in intArrayOf(20, 21, 22)) {
                 Log.d("GALLERY", "[EventRepo] binaryInsert SUCCESS kind=${event.kind} id=${event.id.take(12)} at pos=$low feedSize=${feedList.size}")
             }
         }
-        feedInserted.trySend(Unit)  // coalesced emission via 50ms settle window
+        if (filteredChanged) feedInserted.trySend(Unit)  // coalesced emission via 50ms settle window
         if (fromFeed && countNewNotes && sortTime > newNotesCutoff) {
             val filter = _authorFilter.value
             if (filter == null || event.pubkey in filter || isRepostedByAny(event.id, filter)) _newNoteCount.value++
@@ -756,6 +783,9 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         synchronized(feedList) {
             if (feedIds.remove(eventId)) {
                 feedList.removeAll { it.id == eventId }
+            }
+            if (filteredFeedIds.remove(eventId)) {
+                filteredFeed.removeAll { it.id == eventId }
             }
         }
         synchronized(relayFeedList) {
@@ -1131,19 +1161,25 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         rebuildFilteredFeed()
     }
 
+    /**
+     * Full rebuild of the filtered feed from the master feedList. Used when the author/kind
+     * filter changes (rare, user-initiated) or after a bulk feedList repopulation. feedList is
+     * already sorted, so the rebuilt filteredFeed is a correctly-ordered subsequence.
+     */
     private fun rebuildFilteredFeed() {
-        val authorFilter = _authorFilter.value
-        val kindFilter = _kindFilter
-        val raw = synchronized(feedList) { feedList.toList() }
-        val galleryInRaw = raw.count { it.kind in intArrayOf(20, 21, 22) }
-        val result = raw.filter { event ->
-            val authorOk = authorFilter == null || event.pubkey in authorFilter || isRepostedByAny(event.id, authorFilter)
-            val kindOk = kindFilter == null || event.kind in kindFilter
-            authorOk && kindOk
+        val rebuilt = synchronized(feedList) {
+            filteredFeed.clear()
+            filteredFeedIds.clear()
+            for (event in feedList) {
+                if (passesFilter(event)) {
+                    filteredFeed.add(event)
+                    filteredFeedIds.add(event.id)
+                }
+            }
+            ArrayList(filteredFeed)
         }
-        val galleryInResult = result.count { it.kind in intArrayOf(20, 21, 22) }
-        Log.d("GALLERY", "[EventRepo] rebuildFilteredFeed: feedList=${raw.size} galleryInFeedList=$galleryInRaw → filtered=${result.size} galleryInFiltered=$galleryInResult kindFilter=$kindFilter authorFilter=${authorFilter?.size}")
-        _feed.value = result
+        Log.d("GALLERY", "[EventRepo] rebuildFilteredFeed: filtered=${rebuilt.size} kindFilter=${_kindFilter} authorFilter=${_authorFilter.value?.size}")
+        _feed.value = rebuilt
     }
 
     fun getNewestFeedEventTimestamp(): Long? {
@@ -1154,14 +1190,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
 
     fun getOldestTimestamp(): Long? {
         // Return oldest from the filtered feed so loadMore pages correctly
-        val authorFilter = _authorFilter.value
-        val kindFilter = _kindFilter
         return synchronized(feedList) {
-            feedList.lastOrNull { event ->
-                val authorOk = authorFilter == null || event.pubkey in authorFilter || isRepostedByAny(event.id, authorFilter)
-                val kindOk = kindFilter == null || event.kind in kindFilter
-                authorOk && kindOk
-            }?.let { effectiveSortTime(it) }
+            filteredFeed.lastOrNull()?.let { effectiveSortTime(it) }
         }
     }
 
@@ -1181,6 +1211,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
             val removed = feedList.filter { it.pubkey == pubkey }
             feedList.removeAll { it.pubkey == pubkey }
             removed.forEach { feedIds.remove(it.id) }
+            filteredFeed.removeAll { it.pubkey == pubkey }
+            removed.forEach { filteredFeedIds.remove(it.id) }
         }
         synchronized(relayFeedList) {
             val removed = relayFeedList.filter { it.pubkey == pubkey }
@@ -1234,6 +1266,8 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
         synchronized(feedList) {
             feedList.clear()
             feedIds.clear()
+            filteredFeed.clear()
+            filteredFeedIds.clear()
         }
         feedSortTime.evictAll()
         _feed.value = emptyList()
@@ -1287,7 +1321,12 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
                     iter.remove()
                 }
             }
-            if (removed.isNotEmpty()) feedIds.removeAll(removed.toSet())
+            if (removed.isNotEmpty()) {
+                val removedSet = removed.toSet()
+                feedIds.removeAll(removedSet)
+                filteredFeedIds.removeAll(removedSet)
+                filteredFeed.removeAll { it.id in removedSet }
+            }
         }
         if (removed.isNotEmpty()) feedInserted.trySend(Unit)
     }

--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -238,6 +238,12 @@ class NotificationRepository(
             }
         }
 
+        // Score reply authors for spam *before* taking the lock. Feature
+        // extraction runs several regex passes over up to ten notes per
+        // author; doing it under the lock stalls every caller — including
+        // the main thread — long enough to trip the input-dispatch ANR.
+        if (event.kind == 1) warmSpamScore(event)
+
         synchronized(lock) {
             // Atomic check-then-put inside lock to prevent race when the same
             // event arrives from multiple relays concurrently (e.g. user-engage
@@ -688,32 +694,43 @@ class NotificationRepository(
         return mergeMention(event)
     }
 
+    /**
+     * Run the spam classifier for a reply author and cache the score.
+     * Called from addEvent before synchronized(lock) — classifier feature
+     * extraction is regex-heavy and must never run while holding the lock,
+     * or main-thread callers (markRead, getAllPostCardEventIds) block past
+     * the 5s input-dispatch deadline. SpamAuthorCache wraps LruCache, which
+     * is thread-safe; a concurrent duplicate scoring is harmless.
+     */
+    private fun warmSpamScore(event: NostrEvent) {
+        if (safetyPrefs?.spamFilterEnabled?.value != true) return
+        if (contactRepo?.isFollowing(event.pubkey) == true) return
+        if (safetyPrefs?.isSpamSafelisted(event.pubkey) == true) return
+        // Only replies are spam-scored (see mergeReply); skip quotes/mentions
+        if (event.tags.any { it.size >= 2 && it[0] == "q" }) return
+        if (Nip10.getReplyTargetWithHint(event) == null) return
+        val classifier = spamClassifier ?: return
+        val cache = spamAuthorCache ?: return
+        val repo = eventRepo ?: return
+        val notes = repo.getCachedEventsByAuthor(event.pubkey, 1, 10)
+        if (notes.isEmpty()) return
+        if (cache.get(event.pubkey, notes.size) != null) return
+        val inputs = notes.map { e ->
+            com.wisp.app.ml.NoteInput(e.content, e.tags, e.created_at)
+        }
+        val score = classifier.score(inputs)
+        if (score != null) cache.put(event.pubkey, score, inputs.size)
+    }
+
     private fun mergeReply(event: NostrEvent, replyTarget: String, replyTargetHint: String?): Boolean {
         if (safetyPrefs?.spamFilterEnabled?.value == true &&
             contactRepo?.isFollowing(event.pubkey) != true &&
             safetyPrefs?.isSpamSafelisted(event.pubkey) != true
         ) {
-            val repo = eventRepo
-            val noteCount = repo?.getCachedEventsByAuthor(event.pubkey, 1, 10)?.size ?: 0
+            // Score was computed off-lock in warmSpamScore; only consult the cache here
+            val noteCount = eventRepo?.getCachedEventsByAuthor(event.pubkey, 1, 10)?.size ?: 0
             val cached = spamAuthorCache?.get(event.pubkey, noteCount)
             if (cached != null && cached >= 0.7f) return false
-            if (cached == null) {
-                val classifier = spamClassifier
-                val cache = spamAuthorCache
-                if (classifier != null && cache != null && repo != null) {
-                    val notes = repo.getCachedEventsByAuthor(event.pubkey, 1, 10)
-                    if (notes.isNotEmpty()) {
-                        val inputs = notes.map { e ->
-                            com.wisp.app.ml.NoteInput(e.content, e.tags, e.created_at)
-                        }
-                        val score = classifier.score(inputs)
-                        if (score != null) {
-                            cache.put(event.pubkey, score, inputs.size)
-                            if (score >= 0.7f) return false
-                        }
-                    }
-                }
-            }
         }
         val key = "reply:${event.id}"
         val hints = listOfNotNull(replyTargetHint)


### PR DESCRIPTION
Ports two performance fixes from the `dark-wisp-android` fork ([#34](https://github.com/barrydeen/dark-wisp-android/pull/34), [#23](https://github.com/barrydeen/dark-wisp-android/pull/23)) into wisp. Both target hot paths that cause jank / ANRs under inbound event bursts. The only systematic difference from the upstream diffs is the package name (`com.darkwisp.app` → `com.wisp.app`).

## EventRepository — incremental feed filter (PR #34)

The feed publish path re-filtered the entire `feedList` (capped at 5,000 events) on every 50ms settle window: a full `toList()` copy, a `.filter{}` pass paying a Set lookup + `isRepostedByAny` LRU lookup per event, then a fresh list allocation and StateFlow emit. During an inbound burst this ran up to ~20×/sec, and re-emitted even when an incoming event was filtered *out* of the visible feed — forcing redundant Compose recompositions over an unchanged list.

This maintains a parallel `filteredFeed` incrementally. Membership is decided once, at insert time, via a single `passesFilter()` predicate (collapsing the predicate that was previously duplicated in four places). The settle/immediate handlers just snapshot the maintained list; the full O(n) pass survives only in `rebuildFilteredFeed()`, used for the rare author/kind filter change. Inserts that don't change the filtered view no longer trigger an emission.

Every `feedList` mutation site is reconciled to keep the two lists in sync: `binaryInsert`, the kind-6 repost re-sort, `removeEvent`, `purgeUser`, `purgeThread`, and the clear path (`resetFeedDisplay`, covering `clearFeed`/`clearAll`).

Upstream's measurement (Pixel 9a, R8-minified staging build, ~350 notes, no filter — the least favorable case): publish dropped from median 167 µs / p90 243 µs to median 5.7 µs / p90 18 µs (~23–29×). The gap widens with feed size toward the 5,000 cap.

## NotificationRepository — off-lock spam scoring (PR #23)

Regex-heavy spam classification ran inside `synchronized(lock)` in `addEvent`. While scoring ran, every other caller of `lock` blocked — including main-thread coroutines calling `markRead()` / `getAllPostCardEventIds()`. During a notification burst each new author serialized another scoring pass under the lock, queuing the main thread past the 5s input-dispatch ANR deadline.

This hoists scoring out of the lock: `addEvent` calls `warmSpamScore(event)` *before* `synchronized(lock)`. It applies the same guards as `mergeReply` (spam filter enabled, not following, not safelisted, is a reply), scores the author, and populates `SpamAuthorCache`. Inside the lock, `mergeReply` only consults the cache.

Filtering semantics are unchanged — same authors scored under the same conditions, same 0.7 threshold rejects inside the lock; only where the CPU time is spent changes. `SpamAuthorCache` wraps `android.util.LruCache` (internally synchronized), so the worst case from two threads racing on one author is a single redundant, idempotent scoring.

## Verification

- `./gradlew assembleDebug` — builds clean (pre-existing warnings only).
- Manual on-device pass still recommended: feed ordering during live inbound events, author/kind filter toggles, spam suppression at the 0.7 threshold, removal paths (block user / delete / purge thread), and no UI freeze during a notification burst.