### PR TITLE
fix(dm): place date separators above whole day-group in reversed list

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/DmConversationScreen.kt
@@ -394,8 +394,8 @@ fun DmConversationScreen(
                 reverseLayout = true,
                 contentPadding = PaddingValues(bottom = with(density) { bottomBarHeightPx.toDp() })
             ) {
-                var lastDateKey = ""
-                for (msg in messages.reversed()) {
+                val ordered = messages.reversed() // newest -> oldest (reverseLayout draws index 0 at bottom)
+                for ((i, msg) in ordered.withIndex()) {
                     item(key = msg.id) {
                         val icons = msg.relayUrls.map { url ->
                             url to relayInfoRepo?.getIconUrl(url)
@@ -422,9 +422,11 @@ fun DmConversationScreen(
                             onOpenEmojiLibrary = onOpenEmojiLibrary
                         )
                     }
+                    // Emit each day's header at the group's older boundary so reverseLayout
+                    // renders it on top of the whole group (not above just the newest message).
+                    val olderMsg = ordered.getOrNull(i + 1)
                     val dateKey = dayKey(msg.createdAt)
-                    if (dateKey != lastDateKey) {
-                        lastDateKey = dateKey
+                    if (olderMsg == null || dayKey(olderMsg.createdAt) != dateKey) {
                         item(key = "date-$dateKey") {
                             DateHeader(formatDateHeader(msg.createdAt))
                         }


### PR DESCRIPTION
## Problem

In a DM conversation, only the most recently sent message appeared below the "Today" divider. Every older message — even ones sent seconds ago — showed above the divider, visually grouped under the previous day's ("Yesterday") header.

## Cause

The message list renders with `reverseLayout = true` and iterates `messages.reversed()` (newest→oldest), but emitted each day's `DateHeader` **right after the group's newest message**. Because `reverseLayout` inverts emission order on screen, the divider landed just above the single newest message of the group, pushing all older same-day messages up under the previous day's header.

This was **not** a timestamp-unit (seconds vs milliseconds) issue — a millisecond value ×1000 would render as a year ~54000, never "Yesterday".

## Fix

Emit each day's header at the group's *older* boundary — after a message whose next (older) message belongs to a different day, or after the last message — using a lookahead (`ordered.getOrNull(i + 1)`). Under `reverseLayout` this places the divider on top of the entire day-group, with that day's messages rendered chronologically beneath it.

## Testing

- `./gradlew assembleDebug` succeeds.
- Verified on device: sending several messages seconds apart now groups them all below a single "Today" divider (newest at the bottom); prior-day messages stay under their own dated divider.