### PR TITLE
test(nostr): unit test `Blossom.buildServerListTags`

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Blossom.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Blossom.kt
@@ -32,6 +32,12 @@ object Blossom {
         }.distinct()
     }
 
+    /**
+     * Builds BUD-03 server tags from a non-empty list of unique already-valid server URLs.
+     * URL validation is expected to happen when URLs enter repository/viewmodel state.
+     *
+     * @throws IllegalArgumentException if [urls] is empty.
+     */
     fun buildServerListTags(urls: List<String>): List<List<String>> {
         require(urls.isNotEmpty()) { "Blossom server list must contain at least one server" }
         return urls.map { listOf("server", it) }

--- a/app/src/main/kotlin/com/wisp/app/nostr/Blossom.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Blossom.kt
@@ -33,6 +33,7 @@ object Blossom {
     }
 
     fun buildServerListTags(urls: List<String>): List<List<String>> {
+        require(urls.isNotEmpty()) { "Blossom server list must contain at least one server" }
         return urls.map { listOf("server", it) }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/nostr/Blossom.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Blossom.kt
@@ -26,8 +26,7 @@ object Blossom {
             if (tag.size >= 2 && tag[0] == "server") {
                 val url = tag[1].toHttpUrlOrNull()
                 url?.toString()
-            }
-            else {
+            } else {
                 null
             }
         }.distinct()

--- a/app/src/test/kotlin/com/wisp/app/nostr/BlossomTest.kt
+++ b/app/src/test/kotlin/com/wisp/app/nostr/BlossomTest.kt
@@ -128,4 +128,30 @@ class BlossomTest {
             result
         )
     }
+
+    @Test
+    fun `buildServerListTags throws IllegalArgumentException when urls are empty`() {
+        val emptyUrls = emptyList<String>()
+        assertFailsWith<IllegalArgumentException> { Blossom.buildServerListTags(emptyUrls) }
+    }
+
+    @Test
+    fun `buildServerListTags builds server tags preserving order`() {
+        val valid1 = "http://example.com"
+        val valid2 = "https://example.com/"
+        val singleServerTags = Blossom.buildServerListTags(listOf(valid1))
+        assertEquals(
+            listOf(
+                listOf("server", valid1)
+            ), singleServerTags
+        )
+
+        val manyServerTags = Blossom.buildServerListTags(listOf(valid2, valid1))
+        assertEquals(
+            listOf(
+                listOf("server", valid2),
+                listOf("server", valid1)
+            ), manyServerTags
+        )
+    }
 }


### PR DESCRIPTION
noticed a quality issue here: 
https://github.com/barrydeen/wisp/blob/56c26c238a88f3fd077fe00ba5341b4fa972d25e/app/src/main/kotlin/com/wisp/app/viewmodel/BlossomServersViewModel.kt#L47-L64

this function allows lots of bad stuff eg.
- `example com` -> `https://example com`
- `HTTPS://example.com` -> `https://HTTPS://example.com`
- `ftp://example.com` -> `https://ftp://example.com`

Also allows fragments (`#`) and query parameters (`?`) in url that can be an issue when appending `/media` in the repository. It should be defined whether we allow something like `https://example.com?query=a#fragment` and then append `/media` like this `https://example.com/media?query=a#fragment` or just don't allow it.

Correct validation logic should be used for user input as well as when parsing kind 10063 events.