### PR TITLE
refactor(nostr): use Java Base64 for Blossom auth headers

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/nostr/Blossom.kt
+++ b/app/src/main/kotlin/com/wisp/app/nostr/Blossom.kt
@@ -1,8 +1,8 @@
 package com.wisp.app.nostr
 
-import android.util.Base64
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.security.MessageDigest
+import java.util.Base64
 
 object Blossom {
     const val KIND_SERVER_LIST = 10063
@@ -78,7 +78,7 @@ object Blossom {
 
     private fun encodeAuthHeader(event: NostrEvent): String {
         val json = event.toJson()
-        val base64 = Base64.encodeToString(json.toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+        val base64 = Base64.getEncoder().encodeToString(json.toByteArray())
         return "Nostr $base64"
     }
 }


### PR DESCRIPTION
Replace `android.util.Base64` with `java.util.Base64` for Blossom auth headers. This facilitates easier testing of `Blossom.createUploadAuth` by removing the need for android instrumentation or roboelectric tests.

The behavior is equivalent:
- `json.toByteArray(Charsets.UTF_8)` uses [toByteArray](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/to-byte-array.html) default parameter which is already `Charsets.UTF_8`.
- `android.util.Base64`s `NO_WRAP` flag is the default in the `java.util.Base64` [Basic Encoder](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html#basic)