### PR TITLE
fix: crash on notes with zero/negative imeta dim values

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -3169,8 +3169,8 @@ internal fun rememberMediaPlaceholderPainter(
             return@produceState
         }
         val dims = dimension?.split('x')
-        val width = dims?.getOrNull(0)?.toIntOrNull()?.coerceAtMost(100) ?: 32
-        val height = dims?.getOrNull(1)?.toIntOrNull()?.coerceAtMost(100) ?: 32
+        val width = dims?.getOrNull(0)?.toIntOrNull()?.takeIf { it > 0 }?.coerceAtMost(100) ?: 32
+        val height = dims?.getOrNull(1)?.toIntOrNull()?.takeIf { it > 0 }?.coerceAtMost(100) ?: 32
         value = withContext(Dispatchers.Default) {
             MediaHashDecoder.decode(thumbhash, blurhash, width, height)
                 ?.asImageBitmap()

--- a/app/src/main/kotlin/com/wisp/app/util/BlurHashDecoder.kt
+++ b/app/src/main/kotlin/com/wisp/app/util/BlurHashDecoder.kt
@@ -10,6 +10,7 @@ object BlurHashDecoder {
 
     fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f): Bitmap? {
         if (blurHash == null || blurHash.length < 6) return null
+        if (width <= 0 || height <= 0) return null
 
         val numComponents = decode83(blurHash, 0, 1)
         val nx = (numComponents % 9) + 1

--- a/app/src/main/kotlin/com/wisp/app/util/MediaHashDecoder.kt
+++ b/app/src/main/kotlin/com/wisp/app/util/MediaHashDecoder.kt
@@ -7,6 +7,7 @@ import com.madebyevan.thumbhash.ThumbHash
 
 object MediaHashDecoder {
     fun decode(thumbHash: String?, blurHash: String?, width: Int, height: Int): Bitmap? {
+        if (width <= 0 || height <= 0) return null
         decodeThumbHash(thumbHash, width, height)?.let { return it }
         return BlurHashDecoder.decode(blurHash, width, height)
     }


### PR DESCRIPTION
## Problem

Notes published by other clients with a malformed `imeta` `dim` attribute (`0x0`, `1920x0`, negative values) crash the app with:

```
java.lang.IllegalArgumentException: width and height must be > 0
  at android.graphics.Bitmap.createBitmap
```

The crash fires when the feed loads or the user scrolls to such a note.

## Root cause

`rememberMediaPlaceholderPainter` (RichContent.kt) clamps parsed `dim` width/height with `coerceAtMost(100)` — an upper bound but no lower bound — so a non-positive dimension flows into `BlurHashDecoder.decode` → `Bitmap.createBitmap(width, height, …)`, which throws. The thumbhash path was already try/catch-guarded; the blurhash path was not.

## Fix

- **RichContent.kt** — non-positive parsed dimensions now fall back to the 32px default instead of passing through.
- **BlurHashDecoder.kt / MediaHashDecoder.kt** — early `return null` when `width <= 0 || height <= 0`, so no caller can reach `createBitmap`/`createScaledBitmap` with invalid dims.

All other `createBitmap` sites use ZXing matrix or locally measured sizes (already positive) — verified by sweep.

## Testing

- `assembleDebug` builds clean.