### PR TITLE
feat(wallet): export NWC connection string from settings

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/QrCodeDialog.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/QrCodeDialog.kt
@@ -186,9 +186,16 @@ fun QrCodeDialog(pubkeyHex: String, avatarUrl: String? = null, onDismiss: () -> 
     }
 }
 
-/** Generate a QR bitmap with high error correction (supports center overlay). */
-internal fun generateQrBitmap(content: String, size: Int = 512): Bitmap {
-    val hints = mapOf(EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.H)
+/** Generate a QR bitmap. Defaults to high error correction (supports a center
+ *  overlay); pass a lower level for long payloads (e.g. NWC connection URIs)
+ *  where high correction pushes module density past what on-screen scanning
+ *  handles comfortably. */
+internal fun generateQrBitmap(
+    content: String,
+    size: Int = 512,
+    errorCorrection: ErrorCorrectionLevel = ErrorCorrectionLevel.H
+): Bitmap {
+    val hints = mapOf(EncodeHintType.ERROR_CORRECTION to errorCorrection)
     val writer = QRCodeWriter()
     val matrix = writer.encode(content, BarcodeFormat.QR_CODE, size, size, hints)
     val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/WalletScreen.kt
@@ -84,6 +84,8 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material.icons.filled.Refresh
@@ -162,6 +164,8 @@ import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+import com.wisp.app.ui.component.generateQrBitmap
 import com.wisp.app.BuildConfig
 import com.wisp.app.R
 import com.wisp.app.repo.BalanceUnit
@@ -384,6 +388,21 @@ fun WalletScreen(
                             )
                         }
                     }
+                    is WalletPage.NwcExport -> {
+                        val page = currentPage as WalletPage.NwcExport
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(padding)
+                                .padding(horizontal = 16.dp)
+                                .verticalScroll(rememberScrollState())
+                        ) {
+                            NwcExportContent(
+                                connectionString = page.connectionString,
+                                onDone = { viewModel.navigateBack() }
+                            )
+                        }
+                    }
                     is WalletPage.Home -> {
                         // Preload recent transactions for the inline footer.
                         LaunchedEffect(walletState) {
@@ -568,6 +587,7 @@ fun WalletScreen(
                             viewModel.resetBackupStatus()
                             viewModel.navigateTo(WalletPage.BackupToRelay)
                         },
+                        onExportConnectionString = { viewModel.showNwcExport() },
                         onDeleteWallet = { viewModel.navigateTo(WalletPage.DeleteWalletConfirm) },
                         relayBackupStatuses = viewModel.relayBackupStatuses.collectAsState().value,
                         relayBackupCheckLoading = viewModel.relayBackupCheckLoading.collectAsState().value,
@@ -3973,6 +3993,213 @@ private fun SparkBackupContent(
     Spacer(Modifier.height(32.dp))
 }
 
+// --- NWC connection string export ---
+
+@Composable
+private fun NwcExportContent(
+    connectionString: String,
+    onDone: () -> Unit
+) {
+    val clipboardManager = LocalClipboardManager.current
+    var copied by remember { mutableStateOf(false) }
+    var revealed by remember { mutableStateOf(false) }
+    var showQr by remember { mutableStateOf(false) }
+    val zapColor = com.wisp.app.ui.theme.WispThemeColors.zapColor
+
+    Spacer(Modifier.height(16.dp))
+
+    Text(
+        "Connection String",
+        style = MaterialTheme.typography.headlineSmall,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+    Spacer(Modifier.height(8.dp))
+
+    // Warning card — mirrors wisp-ios NwcConnectionStringView.
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = zapColor.copy(alpha = 0.12f)
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                Icons.Outlined.Warning,
+                contentDescription = null,
+                tint = zapColor,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(10.dp))
+            Column {
+                Text(
+                    "Keep this string secret",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Anyone with this connection string can spend from your wallet, up to whatever limits your wallet provider set. Only paste it into apps you trust.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+
+    Spacer(Modifier.height(24.dp))
+
+    if (revealed) {
+        // The raw URI, shown sharp once revealed.
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Text(
+                connectionString,
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        // Copy + Hide (mirrors iOS: only offered once revealed).
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedButton(
+                onClick = {
+                    clipboardManager.setText(AnnotatedString(connectionString))
+                    copied = true
+                },
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(if (copied) "Copied ✓" else "Copy")
+            }
+            OutlinedButton(
+                onClick = {
+                    revealed = false
+                    showQr = false
+                },
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    Icons.Default.VisibilityOff,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("Hide")
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        // Show / Hide QR code toggle.
+        OutlinedButton(
+            onClick = { showQr = !showQr },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(
+                Icons.Default.QrCode,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(if (showQr) "Hide QR code" else "Show QR code")
+        }
+
+        if (showQr) {
+            Spacer(Modifier.height(12.dp))
+            // NWC URIs are long, so error correction stays at M — higher levels
+            // push the module density past what on-screen scanning handles.
+            val qrBitmap = remember(connectionString) {
+                generateQrBitmap(connectionString, errorCorrection = ErrorCorrectionLevel.M)
+            }
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = Color.White
+                )
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Image(
+                        bitmap = qrBitmap.asImageBitmap(),
+                        contentDescription = "Connection string QR code",
+                        modifier = Modifier.size(240.dp)
+                    )
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Scan from another wallet-connect app to import this connection.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    } else {
+        // Tap to reveal — the string stays hidden until an explicit tap.
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { revealed = true },
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    Icons.Outlined.Visibility,
+                    contentDescription = "Reveal connection string",
+                    modifier = Modifier.size(32.dp),
+                    tint = zapColor
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Tap to reveal",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+    }
+
+    Spacer(Modifier.height(24.dp))
+
+    Button(
+        onClick = onDone,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text("Done")
+    }
+
+    Spacer(Modifier.height(32.dp))
+}
+
 // --- Wallet Settings ---
 
 @Composable
@@ -3987,6 +4214,7 @@ private fun WalletSettingsContent(
     onDeleteAddress: () -> Unit = {},
     onBackupMnemonic: () -> Unit,
     onBackupToRelay: () -> Unit = {},
+    onExportConnectionString: () -> Unit = {},
     onDeleteWallet: () -> Unit,
     relayBackupStatuses: List<RelayBackupInfo> = emptyList(),
     relayBackupCheckLoading: Boolean = false,
@@ -4246,6 +4474,48 @@ private fun WalletSettingsContent(
             // wallets can still tap "Backup to Nostr Relays" above; the
             // status / delete plumbing in WalletViewModel stays alive in
             // case we want to surface it again later.
+        } else if (walletMode == WalletMode.NWC) {
+            val zapColor = com.wisp.app.ui.theme.WispThemeColors.zapColor
+            Card(
+                onClick = onExportConnectionString,
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Outlined.VpnKey,
+                        contentDescription = null,
+                        tint = zapColor,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            "Connection string",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            "View, copy, or scan to move this wallet to another app",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.outline,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
         }
 
         // Disclaimer

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/WalletViewModel.kt
@@ -102,6 +102,7 @@ sealed class WalletPage {
     object SparkSetup : WalletPage()
     object SparkRestoreSeed : WalletPage()
     data class SparkBackup(val mnemonic: String) : WalletPage()
+    data class NwcExport(val connectionString: String) : WalletPage()
     object SendInput : WalletPage()
     object ScanQR : WalletPage()
     data class SendAmount(val address: String) : WalletPage()
@@ -831,6 +832,11 @@ class WalletViewModel(
     fun showMnemonicBackup() {
         val mnemonic = sparkRepo.getMnemonic() ?: return
         navigateTo(WalletPage.SparkBackup(mnemonic))
+    }
+
+    fun showNwcExport() {
+        val uri = nwcRepo.getConnectionString() ?: return
+        navigateTo(WalletPage.NwcExport(uri))
     }
 
     fun acknowledgeSeedBackup() {


### PR DESCRIPTION
Companion to wisp-ios #435. NWC wallets had no way to get the connection string back out once stored, so moving a wallet to another client required recreating the connection from the provider.

## What this adds

A **Connection string** row in the NWC wallet's **Security** section (the NWC counterpart of the Spark recovery-phrase row) that pushes a reveal-then-copy screen:

- **Tap to reveal** the `nostr+walletconnect://…` URI (kept hidden until an explicit tap).
- Once revealed: **Copy** / **Hide** / **Show QR code**.
- **QR** rendered at default (M) error correction — NWC URIs are long, and higher levels push module density past what on-screen scanning handles comfortably.
- A **zap-tinted warning card**: "Keep this string secret" — anyone with the string can spend from the wallet up to the provider's limits.

Built on top of current `main` (the earlier draft had drifted onto a stale fork base; this rebases cleanly onto `barrydeen/wisp` `main`).

## Android adaptations vs. iOS

- **Reveal uses a tap gate, not a live blur.** SwiftUI blurs the URI; Compose `Modifier.blur` is API 31+ and wisp's `minSdk` is 26, so a blur would render the secret in the clear on older devices. The tap-to-reveal card preserves the same "explicit tap before the secret is shown" guarantee across all supported APIs.
- Kept a **Done** button as the back affordance (iOS uses a header back chevron; this wallet page has no top bar).
- Dropped the iOS empty-state ("No connection string stored") — unreachable here, since `showNwcExport()` early-returns when no URI is stored.

## Verification

- Builds (`assembleDebug`).
- Installed and tapped through on a connected NWC wallet: row opens, reveal shows the stored URI, Copy/Hide/Show QR all work, and the QR scans and imports in another wallet-connect client.