### PR TITLE
fix(thread): always target the opened note with the reply bar

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/ThreadScreen.kt
@@ -136,10 +136,6 @@ fun ThreadScreen(
     // inserted so the screen keeps its exact position.
     var restoreAnchor by remember { mutableStateOf<Pair<Any, Int>?>(null) }
 
-    // The sticky reply bar targets whichever note is centered in the viewport, not always the root.
-    var focusedReplyEvent by remember { mutableStateOf<NostrEvent?>(null) }
-    val threadState = rememberUpdatedState(flatThread)
-
     LaunchedEffect(listState.isScrollInProgress) {
         if (listState.isScrollInProgress) {
             // Capture position when scroll starts
@@ -179,12 +175,6 @@ fun ThreadScreen(
         val index = flatThread.indexOfFirst { it.key == anchorKey }
         if (index >= 0) listState.scrollToItem(index, anchorOffset)
         restoreAnchor = null
-    }
-
-    LaunchedEffect(listState) {
-        snapshotFlow { listState.firstVisibleItemIndex }.collect { idx ->
-            focusedReplyEvent = (threadState.value.getOrNull(idx) as? ThreadItem.Post)?.event
-        }
     }
 
     val reactionVersion by eventRepo.reactionVersion.collectAsState()
@@ -263,7 +253,10 @@ fun ThreadScreen(
             )
         },
         bottomBar = {
-            val replyTarget = focusedReplyEvent ?: focalEvent
+            // Always targets the note this thread was opened on — never
+            // whatever is scrolled into view. To reply to a specific reply,
+            // tap that note's reply icon.
+            val replyTarget = viewModel.composerDefaultParent ?: focalEvent
             ThreadReplyBar(
                 enabled = replyTarget != null,
                 onClick = { replyTarget?.let { onReply(it) } }

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
@@ -52,6 +52,12 @@ class ThreadViewModel : ViewModel() {
     private val threadEvents = mutableMapOf<String, NostrEvent>()
     private var rootId: String = ""
     private var scrollTargetId: String? = null
+    /**
+     * The note this thread was opened on (the tapped note), before re-rooting.
+     * `rootId` resolves to the conversation root, so this is the only handle on
+     * "the note they came for": the default reply parent for the sticky bar.
+     */
+    private var seedEventId: String? = null
     /** Anchors whose depth-capped subtree the user expanded inline. */
     private val expandedIds = mutableSetOf<String>()
     private var muteRepo: MuteRepository? = null
@@ -97,6 +103,15 @@ class ThreadViewModel : ViewModel() {
         scheduleRebuild()
     }
 
+    /**
+     * Event backing the sticky reply bar's parent — the note the thread was
+     * opened on, not the re-rooted conversation root. Null only when the seed
+     * event hasn't been fetched yet (cold deep-link); callers fall back to the
+     * focal root.
+     */
+    val composerDefaultParent: NostrEvent?
+        get() = threadEvents[seedEventId]
+
     /** Expand a folded subtree inline. Scroll-position anchoring is handled in the screen. */
     fun expandBranch(anchorId: String) {
         if (expandedIds.add(anchorId)) rebuildTree()
@@ -122,6 +137,7 @@ class ThreadViewModel : ViewModel() {
         safetyPrefs: SafetyPreferences? = null,
         contactRepo: ContactRepository? = null
     ) {
+        seedEventId = eventId
         this.muteRepo = muteRepo
         this.spamClassifier = spamClassifier
         this.spamAuthorCache = spamAuthorCache


### PR DESCRIPTION
## Summary
Tapping the reply bar at the bottom of a thread composed the reply to whichever note was topmost in the viewport — so after scrolling, the bar routinely targeted a note the user had scrolled past instead of the thread's subject note. Opening a thread from a mid-thread reply was worse: the pre-scroll fallback targeted the re-rooted conversation root, not the note that was tapped.

The bar now always targets the note the thread was opened on: the OP for a plain thread, the tapped reply for a pushed sub-thread. Replying to a specific reply keeps its own gesture — that note's reply icon. This matches how major clients anchor the composer to the thread subject.

- `ThreadViewModel` keeps the tapped note as `seedEventId` and exposes it as `composerDefaultParent`.
- `ThreadScreen` deletes the `focusedReplyEvent` scroll tracking (`snapshotFlow { firstVisibleItemIndex }`) and targets `composerDefaultParent ?: focalEvent` — the fallback covers the brief window before a cold deep-link's seed event arrives.
- The unrelated `showRootButton` scroll effect is untouched.

Parity with barrydeen/wisp-ios#437.

## Test plan
- [x] `:app:compileDebugKotlin` clean
- [x] Verified on device: open a thread with several replies, scroll deep, tap the reply bar — the reply sheet targets the OP at any scroll depth