### PR TITLE
fix(safety): close web of trust filter bypasses

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/EventRepository.kt
@@ -308,7 +308,10 @@ class EventRepository(val profileRepo: ProfileRepository? = null, val muteRepo: 
     fun isWotFiltered(pubkey: String, kind: Int): Boolean {
         if (safetyPrefs?.wotFilterEnabled?.value != true) return false
         val netRepo = extendedNetworkRepo ?: return false
-        if (!netRepo.isNetworkReady()) return false
+        // Only a missing cache fails open; a stale cache still filters using its
+        // qualified set as a best-effort approximation (isNetworkReady would
+        // silently disable filtering for 24h+ old graphs and >10% follow drift).
+        if (!netRepo.hasCachedNetwork()) return false
         if (kind in WOT_EXEMPT_KINDS) return false
         if (pubkey == currentUserPubkey) return false
         return !netRepo.isInQualifiedNetwork(pubkey)

--- a/app/src/main/kotlin/com/wisp/app/repo/ExtendedNetworkRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/ExtendedNetworkRepository.kt
@@ -125,6 +125,13 @@ class ExtendedNetworkRepository(
         return !isCacheStale(cache)
     }
 
+    /**
+     * True when a computed network cache exists, even if stale. Web of trust
+     * filtering uses this instead of [isNetworkReady] so an outdated qualified
+     * set still filters (best-effort) instead of silently disabling the filter.
+     */
+    fun hasCachedNetwork(): Boolean = _cachedNetwork.value != null
+
     fun isCacheStale(cache: ExtendedNetworkCache): Boolean {
         val ageHours = (System.currentTimeMillis() / 1000 - cache.computedAtEpoch) / 3600
         if (ageHours >= STALE_HOURS) return true

--- a/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
+++ b/app/src/main/kotlin/com/wisp/app/repo/NotificationRepository.kt
@@ -118,6 +118,7 @@ class NotificationRepository(
     fun addGroupChatReply(event: NostrEvent, myPubkey: String, replyToId: String, groupId: String) {
         if (event.pubkey == myPubkey) return
         if (muteRepo?.isBlocked(event.pubkey) == true) return
+        if (isWotFiltered(event)) return
         synchronized(lock) {
             if (seenEvents.get(event.id) != null) return
             seenEvents.put(event.id, true)
@@ -164,6 +165,74 @@ class NotificationRepository(
         }
     }
 
+    /**
+     * Web of trust gate shared by all notification entry points. Fails open only
+     * when no network cache exists at all — a stale cache still filters, using
+     * its qualified set as a best-effort approximation.
+     */
+    private fun isWotFiltered(event: NostrEvent): Boolean {
+        if (safetyPrefs?.wotFilterEnabled?.value != true) return false
+        val netRepo = extendedNetworkRepo ?: return false
+        if (!netRepo.hasCachedNetwork()) return false
+        val pubkeyToCheck = if (event.kind == 9735) {
+            eventRepo?.resolveZapSender(event)?.first ?: event.pubkey
+        } else event.pubkey
+        return !netRepo.isInQualifiedNetwork(pubkeyToCheck)
+    }
+
+    /**
+     * Re-apply the web of trust filter to notifications already accepted while the
+     * graph was missing or the filter was off. Called when the filter toggles on or
+     * a network cache arrives. Rows removed here are not resurrected when the filter
+     * is toggled back off — the list repopulates from persistence on next launch.
+     */
+    fun refilterWot() {
+        if (safetyPrefs?.wotFilterEnabled?.value != true) return
+        val netRepo = extendedNetworkRepo ?: return
+        if (!netRepo.hasCachedNetwork()) return
+        fun allowed(pubkey: String) = netRepo.isInQualifiedNetwork(pubkey)
+        synchronized(lock) {
+            val toRemove = mutableListOf<String>()
+            val toUpdate = mutableListOf<NotificationGroup>()
+            for ((key, group) in groupMap) {
+                when (group) {
+                    is NotificationGroup.ReplyNotification ->
+                        if (!allowed(group.senderPubkey)) toRemove.add(key)
+                    is NotificationGroup.QuoteNotification ->
+                        if (!allowed(group.senderPubkey)) toRemove.add(key)
+                    is NotificationGroup.MentionNotification ->
+                        if (!allowed(group.senderPubkey)) toRemove.add(key)
+                    is NotificationGroup.ReactionGroup -> {
+                        val reactions = group.reactions
+                            .mapValues { (_, pks) -> pks.filter { allowed(it) } }
+                            .filterValues { it.isNotEmpty() }
+                        val zaps = group.zapEntries.filter { allowed(it.pubkey) }
+                        if (reactions.isEmpty() && zaps.isEmpty()) {
+                            toRemove.add(key)
+                        } else if (reactions != group.reactions || zaps.size != group.zapEntries.size) {
+                            toUpdate.add(group.copy(
+                                reactions = reactions,
+                                reactionTimestamps = group.reactionTimestamps.filterKeys { allowed(it) },
+                                zapEntries = zaps
+                            ))
+                        }
+                    }
+                }
+            }
+            val removedFlatIds = flatItems.filter { !allowed(it.actorPubkey) }.map { it.id }
+            if (toRemove.isEmpty() && toUpdate.isEmpty() && removedFlatIds.isEmpty()) return
+            toRemove.forEach { groupMap.remove(it) }
+            toUpdate.forEach { groupMap[it.groupId] = it }
+            zapEventIdsByGroup.keys.retainAll(groupMap.keys)
+            if (removedFlatIds.isNotEmpty()) {
+                val removedSet = removedFlatIds.toSet()
+                flatItems.removeAll { it.id in removedSet }
+                removedFlatIds.forEach { flatItemIds.remove(it) }
+            }
+            scheduleRebuildSortedList()
+        }
+    }
+
     fun addEvent(event: NostrEvent, myPubkey: String, replyToMyEvent: Boolean = false, source: String = "") {
         // Reject events whose target pubkey does not match the active account.
         // Catches stale in-flight coroutines (e.g. ObjectBox seeding) that captured
@@ -184,15 +253,7 @@ class NotificationRepository(
             val zapperPubkey = eventRepo?.resolveZapSender(event)?.first
             if (zapperPubkey != null && muteRepo?.isBlocked(zapperPubkey) == true) return
         }
-        if (safetyPrefs?.wotFilterEnabled?.value == true) {
-            val netRepo = extendedNetworkRepo
-            if (netRepo != null && netRepo.isNetworkReady()) {
-                val pubkeyToCheck = if (event.kind == 9735) {
-                    eventRepo?.resolveZapSender(event)?.first ?: event.pubkey
-                } else event.pubkey
-                if (!netRepo.isInQualifiedNetwork(pubkeyToCheck)) return
-            }
-        }
+        if (isWotFiltered(event)) return
         val hasPTag = event.tags.any { it.size >= 2 && it[0] == "p" && it[1] == myPubkey }
         // Kind 6 reposts may omit the p-tag; callers must pre-filter kind 6 ownership.
         // replyToMyEvent bypasses p-tag check for kind 1 replies found via e-tag subscription.

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyFiltersTab.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SafetyFiltersTab.kt
@@ -152,7 +152,7 @@ fun SafetyFiltersTab(
             }
             if (wotEnabled) {
                 Text(
-                    text = stringResource(R.string.safety_wot_inactive),
+                    text = stringResource(R.string.safety_wot_stale_active),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 4.dp)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ArticleViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ArticleViewModel.kt
@@ -61,6 +61,7 @@ class ArticleViewModel : ViewModel() {
     private var topRelayUrls: List<String> = emptyList()
     private var relayListRepoRef: RelayListRepository? = null
     private var relayHintStoreRef: RelayHintStore? = null
+    private var eventRepoRef: EventRepository? = null
     private val activeSubIds = mutableListOf<String>()
 
     // Incremental metadata tracking
@@ -110,6 +111,7 @@ class ArticleViewModel : ViewModel() {
         this.topRelayUrls = topRelayUrls
         this.relayListRepoRef = relayListRepo
         this.relayHintStoreRef = relayHintStore
+        this.eventRepoRef = eventRepo
         this.currentArticleEventId = articleEventId
         _isCommentsLoading.value = true
 
@@ -322,6 +324,8 @@ class ArticleViewModel : ViewModel() {
         val parentToChildren = mutableMapOf<String, MutableList<NostrEvent>>()
 
         for (event in commentEvents.values) {
+            if (eventRepoRef?.muteRepo?.isBlocked(event.pubkey) == true) continue
+            if (eventRepoRef?.isWotFiltered(event.pubkey, event.kind) == true) continue
             val replyTarget = Nip10.getReplyTarget(event)
             val parentId = when {
                 replyTarget != null && replyTarget in commentEvents -> replyTarget

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/EventRouter.kt
@@ -144,7 +144,9 @@ class EventRouter(
                         eventRepo.cacheEvent(event)
                         if (!Nip10.isStandaloneQuote(event)) {
                             val parentId = Nip10.getReplyTarget(event)
-                            if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
+                            if (parentId != null && !eventRepo.isWotFiltered(event.pubkey, event.kind)) {
+                                eventRepo.addReplyCount(parentId, event.id)
+                            }
                         }
                     }
                     else -> eventRepo.cacheEvent(event)
@@ -168,7 +170,9 @@ class EventRouter(
                 val parentId = if (!Nip10.isStandaloneQuote(event)) {
                     Nip10.getReplyTarget(event)
                 } else null
-                if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
+                if (parentId != null && !eventRepo.isWotFiltered(event.pubkey, event.kind)) {
+                    eventRepo.addReplyCount(parentId, event.id)
+                }
                 // Only bypass the p-tag check if this is a DIRECT reply to one of our own
                 // events. The #e subscription also returns nested thread replies (where our
                 // event is the root ancestor but not the direct parent) — those should not
@@ -214,7 +218,9 @@ class EventRouter(
             if (event.kind == 1) {
                 eventRepo.cacheEvent(event)
                 val parentId = Nip10.getReplyTarget(event)
-                if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
+                if (parentId != null && !eventRepo.isWotFiltered(event.pubkey, event.kind)) {
+                    eventRepo.addReplyCount(parentId, event.id)
+                }
             }
         } else if (subscriptionId.startsWith("zap-count-") || subscriptionId.startsWith("zap-rcpt-")) {
             if (event.kind == 9735) {
@@ -261,7 +267,9 @@ class EventRouter(
                 1 -> {
                     eventRepo.cacheEvent(event)
                     val parentId = Nip10.getReplyTarget(event)
-                    if (parentId != null) eventRepo.addReplyCount(parentId, event.id)
+                    if (parentId != null && !eventRepo.isWotFiltered(event.pubkey, event.kind)) {
+                        eventRepo.addReplyCount(parentId, event.id)
+                    }
                 }
             }
             // Engagement events win the dedup race against "notif" subscription,

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedViewModel.kt
@@ -242,6 +242,14 @@ class FeedViewModel(app: Application) : AndroidViewModel(app) {
         notifRepo.safetyPrefs = safetyPrefs
         notifRepo.contactRepo = contactRepo
         notifRepo.extendedNetworkRepo = extendedNetworkRepo
+        // Re-apply the web of trust filter to notifications already accepted while
+        // the graph was missing (fail-open window) or before the user toggled it on.
+        viewModelScope.launch(Dispatchers.Default) {
+            safetyPrefs.wotFilterEnabled.collect { notifRepo.refilterWot() }
+        }
+        viewModelScope.launch(Dispatchers.Default) {
+            extendedNetworkRepo.cachedNetwork.collect { notifRepo.refilterWot() }
+        }
         viewModelScope.launch(Dispatchers.Default) {
             nspamClassifier = try {
                 val weights = com.wisp.app.ml.NSpamWeights.loadFromAssets(app)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -578,6 +578,7 @@
     <string name="safety_wot_last_computed">Last computed %s ago</string>
     <string name="safety_wot_not_computed">Social graph not computed</string>
     <string name="safety_wot_stale">Social graph is stale</string>
+    <string name="safety_wot_stale_active">Filter remains active using the cached graph; recompute to refresh it</string>
     <string name="safety_wot_compute_now">Compute now</string>
     <string name="safety_wot_recompute">Recompute</string>
     <string name="safety_wot_inactive">Filter is inactive until graph is computed</string>


### PR DESCRIPTION
## Summary
- WoT filtering no longer silently disables on a stale graph: fail-open now applies only when no network cache exists. A stale cache (>24h old or >10% follow drift) keeps filtering best-effort using its cached qualified set. Since discovery is user-triggered only, the old fail-open on staleness effectively turned the filter off everywhere a day after the last recompute — the main cause of non-WoT npubs still appearing.
- Article comments bypassed all ingestion guards (direct collector + `cacheEvent()`, no filtering in `rebuildTree`); they now apply block + WoT filtering, matching note threads (198313e only covered ThreadViewModel).
- Group chat replies entered notifications via `addGroupChatReply` without the WoT check; all notification entry points now go through a shared `isWotFiltered` helper.
- New `NotificationRepository.refilterWot()` prunes already-accepted notifications from out-of-network actors; triggered reactively when the filter toggles on or a network cache arrives, so rows accepted during a fail-open window don't survive the session. Reaction rows keep only in-network reactors/zap entries.
- `EventRouter` no longer bumps `addReplyCount` for WoT-filtered reply authors, so comment badges exclude out-of-network replies.
- Safety screen stale-state copy updated: the filter remains active on a stale cache instead of going inactive.

## Test
- `./gradlew :app:compileDebugKotlin` passes (JDK 17 via Android Studio JBR)
- No unit test suite exists yet; manual verification: enable WoT, let the graph go stale (>24h), confirm notifications/comments from out-of-network authors are filtered; recompute and confirm notification list refreshes.

 .../kotlin/com/wisp/app/repo/EventRepository.kt    |  5 +-
 .../com/wisp/app/repo/ExtendedNetworkRepository.kt |  7 ++
 .../com/wisp/app/repo/NotificationRepository.kt    | 79 +++++++++++++++++++---
 .../com/wisp/app/ui/screen/SafetyFiltersTab.kt     |  2 +-
 .../com/wisp/app/viewmodel/ArticleViewModel.kt     |  4 ++
 .../kotlin/com/wisp/app/viewmodel/EventRouter.kt   | 16 +++--
 .../kotlin/com/wisp/app/viewmodel/FeedViewModel.kt |  8 +++
 app/src/main/res/values/strings.xml                |  1 +
 8 files changed, 107 insertions(+), 15 deletions(-)