### PR TITLE
fix(content): collapse surplus blank lines in posts

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/component/RichContent.kt
@@ -447,8 +447,55 @@ internal fun parseContent(content: String, emojiMap: Map<String, String> = empty
         }
     }
 
+    // Blank-line pass: normalize newline runs inside the text itself.
+    //
+    // Independent of the block-adjacency pass above, which only trims text
+    // sitting next to a card. This one is about the prose: a post padded with
+    // blank lines, or paragraphs split by three or more newlines, renders
+    // every extra newline as a real empty line. That reads as a ragged gap
+    // the author usually didn't intend (most often an artifact of the client
+    // it was posted from) and the reader can't collapse.
+    //
+    // One blank line survives as the paragraph break; single newlines are
+    // never touched, so a stanza, an address, or a hand-made list keeps every
+    // break the author typed.
+    if (trimBlankLines && finalResult.isNotEmpty()) {
+        val normalized = mutableListOf<ContentSegment>()
+        val lastIndex = finalResult.size - 1
+        for ((i, segment) in finalResult.withIndex()) {
+            if (segment !is ContentSegment.TextSegment) {
+                normalized.add(segment)
+                continue
+            }
+            var t = blankLineRunRegex.replace(segment.text, "\n\n")
+            // Edges of the rendered post, not of every text run: an interior
+            // segment's newlines are a real break between the inline pieces
+            // around it.
+            if (i == 0) t = leadingBlankLinesRegex.replace(t, "")
+            if (i == lastIndex) t = trailingBlankLinesRegex.replace(t, "")
+            if (t.isEmpty()) continue
+            normalized.add(ContentSegment.TextSegment(t))
+        }
+        return normalized
+    }
+
     return finalResult
 }
+
+// Blank-line normalization (mirrors wisp-ios ContentParser pass 6).
+//
+// A run of two or more newlines, tolerating spaces / tabs / stray CRs on the
+// blank lines between them. The run deliberately ends at its last newline so
+// indentation on the following line isn't swallowed with it.
+private val blankLineRunRegex = Regex("""\n(?:[ \t\r]*\n)+""")
+// Blank lines at the very start of a post, up to and including the last of
+// them. Horizontal whitespace after the final newline is kept, so a
+// deliberately indented first line survives.
+private val leadingBlankLinesRegex = Regex("""\A[ \t\r\n]*\n""")
+// Everything from the first trailing newline to the end of the post. The
+// render call site already does trimEnd('\n', '\r'), but that stops at the
+// first space, so "gm\n  \n  " keeps its blank lines without this.
+private val trailingBlankLinesRegex = Regex("""\n[ \t\r\n]*\z""")
 
 private val bolt11Regex = Regex("""(?i)(lightning:)?(lnbc|lntb|lnbcrt)[0-9a-z]{50,}""")
 

--- a/app/src/test/kotlin/com/wisp/app/ui/component/RichContentBlankLineTest.kt
+++ b/app/src/test/kotlin/com/wisp/app/ui/component/RichContentBlankLineTest.kt
@@ -1,0 +1,81 @@
+package com.wisp.app.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The blank-line pass in [parseContent]: surplus blank lines inside a post's prose.
+ *
+ * A post padded with blank lines, or paragraphs split by three or more newlines,
+ * rendered every extra newline as a real empty line — a gap the reader can't
+ * collapse and the author usually didn't ask for. One blank line is the paragraph
+ * break and survives; single newlines are always left alone.
+ *
+ * The block-adjacency case (blank lines hugging an image / invoice / embed) is the
+ * preceding pass's job and isn't covered here. Ported from wisp-ios
+ * ContentParser pass 6.
+ */
+class RichContentBlankLineTest {
+
+    private fun soleText(content: String): String {
+        val segments = parseContent(content)
+        assertEquals("expected a single text segment, got $segments", 1, segments.size)
+        return (segments[0] as ContentSegment.TextSegment).text
+    }
+
+    // --- Surplus is removed ---
+
+    @Test
+    fun `trailing blank lines are dropped`() {
+        assertEquals("gm", soleText("gm\n\n\n"))
+        // trimEnd at the call site stops at the first space, so this shape only
+        // survives because the pass handles whitespace-bearing blank lines.
+        assertEquals("gm", soleText("gm\n  \n  "))
+    }
+
+    @Test
+    fun `leading blank lines are dropped`() {
+        assertEquals("gm", soleText("\n\n\ngm"))
+    }
+
+    @Test
+    fun `surplus between paragraphs collapses to one blank line`() {
+        assertEquals("first\n\nsecond", soleText("first\n\n\n\n\nsecond"))
+    }
+
+    @Test
+    fun `blank lines carrying whitespace still collapse`() {
+        assertEquals("first\n\nsecond", soleText("first\n   \n \t \nsecond"))
+    }
+
+    @Test
+    fun `whitespace only post produces no text segment`() {
+        assertTrue(parseContent("\n\n  \n").isEmpty())
+    }
+
+    // --- Meaningful structure survives ---
+
+    @Test
+    fun `single newlines are never touched`() {
+        // A stanza / address / hand-made list: every break is intentional.
+        assertEquals("one\ntwo\nthree", soleText("one\ntwo\nthree"))
+    }
+
+    @Test
+    fun `one blank line paragraph break survives`() {
+        assertEquals("first\n\nsecond", soleText("first\n\nsecond"))
+    }
+
+    @Test
+    fun `indent after leading blank lines survives`() {
+        // Only the newlines go — indentation on the first visible line stays.
+        assertEquals("    indented", soleText("\n\n    indented"))
+    }
+
+    @Test
+    fun `opting out leaves the text alone`() {
+        val segments = parseContent("gm\n\n\n\nbye\n\n", trimBlankLines = false)
+        assertEquals("gm\n\n\n\nbye\n\n", (segments[0] as ContentSegment.TextSegment).text)
+    }
+}


### PR DESCRIPTION
Ports barrydeen/wisp-ios#445 to this app.

Posts padded with blank lines, or with paragraphs split by three or more newlines, render every extra newline as a real empty line. The reader can't collapse that gap, and the author usually didn't ask for it — most often it's an artifact of the client the note was posted from.

Adds a blank-line pass to `parseContent`, after the existing block-adjacency trim:

- runs of 2+ newlines collapse to a single blank line
- blank lines leading or trailing the whole post are dropped
- single newlines are never touched, so a stanza, an address, or a hand-made list keeps every break the author typed

### Why the existing trim wasn't enough

The render call site already did `content.trimEnd('\n', '\r')`, which covered the simplest trailing case. Leading and interior runs were untouched — and `trimEnd` stops at the first space, so a post ending `"gm\n  \n  "` kept its blank lines outright. All three shapes are handled now, and there's a test pinning that space-padded case.

### Details worth calling out

- The blank-line run deliberately ends at its last newline rather than eating the horizontal whitespace after it, so indentation on the following line survives. The first cut of this on iOS got it wrong and turned `"\n\n    indented"` into `"indented"`; a test caught it.
- The leading/trailing trims apply to the ends of the **post**, not of every text run, so the breaks around an inline hashtag or mention stay exactly where they were.

### No compose-side change needed

The iOS PR has a second commit that stops the composer publishing trailing padding. This app already trims the materialized body before publishing, so it never emitted it in the first place. Verified, not assumed.

### Known gap, left deliberately

`trimBlankLines` is wired to `!plainLinks`, so the inline-link surfaces (bio, quoted notes, drafts, group chat) skip normalization entirely. Separating those two concerns means touching the guard that keeps folded inline links off one line — a regression risk that belongs in its own change rather than riding along in a port. iOS keeps the two flags separate, which is why it normalizes everywhere.

### Testing

9 cases in `RichContentBlankLineTest` — surplus removal, whitespace-bearing blank lines, and the non-regressions (single newlines, one-blank-line paragraph breaks, indentation, and the opt-out). All pass, 0 failures.