### PR TITLE
chore: bump version to 1.2.3 and target SDK 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,14 +13,14 @@ android {
     val debugApplicationIdSuffix = rootProject.extra["debugApplicationIdSuffix"] as String
 
     namespace = "com.wisp.app"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = baseApplicationId
         minSdk = 26
-        targetSdk = 35
-        versionCode = 85
-        versionName = "1.2.2"
+        targetSdk = 36
+        versionCode = 88
+        versionName = "1.2.3"
         resValue("string", "app_name", "Wisp")
 
         ndk {


### PR DESCRIPTION
Bumps versionName 1.2.2 → 1.2.3 (versionCode 88) and raises compileSdk/targetSdk to 36.