### PR TITLE
fix(splash): legible Cancel pill, and open sign-in directly when adding an account

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -654,6 +654,7 @@ fun WispNavHost(
                 onContinueWithGoogle = {
                     navController.navigate(Routes.GOOGLE_AUTH)
                 },
+                startOnSignIn = authViewModel.isAddingAccount,
                 onCancel = if (authViewModel.isAddingAccount) {
                     {
                         val prev = authViewModel.previousAccountPubkey

--- a/app/src/main/kotlin/com/wisp/app/ui/screen/SplashScreen.kt
+++ b/app/src/main/kotlin/com/wisp/app/ui/screen/SplashScreen.kt
@@ -87,14 +87,18 @@ fun SplashScreen(
     onAccountCreated: () -> Unit,
     onLoggedIn: () -> Unit,
     onContinueWithGoogle: () -> Unit,
-    onCancel: (() -> Unit)? = null
+    onCancel: (() -> Unit)? = null,
+    // Adding an account opens sign-in straight away rather than making the
+    // user tap through the intro, which is first-run framing. Dismissing the
+    // sheet falls back to this screen, where the Cancel pill lives.
+    startOnSignIn: Boolean = false
 ) {
     val profilePictures by viewModel.profilePictures.collectAsState()
     val liveMetrics by viewModel.liveMetrics.collectAsState()
     val backgroundColor = MaterialTheme.colorScheme.background
     val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
 
-    var showNostrSheet by remember { mutableStateOf(false) }
+    var showNostrSheet by remember { mutableStateOf(startOnSignIn) }
     var showQrScanner by remember { mutableStateOf(false) }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize().background(backgroundColor)) {
@@ -156,13 +160,13 @@ fun SplashScreen(
             Text(
                 text = "Cancel",
                 style = MaterialTheme.typography.labelLarge,
-                color = androidx.compose.ui.graphics.Color.White,
+                color = androidx.compose.ui.graphics.Color.Black,
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .statusBarsPadding()
                     .padding(start = 16.dp, top = 16.dp)
                     .clip(CircleShape)
-                    .background(androidx.compose.ui.graphics.Color.White.copy(alpha = 0.25f))
+                    .background(androidx.compose.ui.graphics.Color.White.copy(alpha = 0.92f))
                     .clickable(onClick = onCancel)
                     .padding(horizontal = 20.dp, vertical = 8.dp)
             )


### PR DESCRIPTION
The add-account Cancel pill was white at 25% alpha with white text, which over the near-black background rendered as a dark grey shape that read as scenery rather than a button. The background goes to 92% white, so the label flips to black to stay legible.

Adding an account also landed on the intro, which is first-run framing, and cost an extra tap to reach sign-in. `SplashScreen` takes `startOnSignIn`, seeded from `isAddingAccount`, so the sheet opens on arrival. Dismissing it falls back to the intro where the Cancel pill lives, so there's no dead end.

Tested on a Galaxy A54.