### PR TITLE
feat(relay): strict inbox-only routing for threads and notifications

### DIFF
--- a/app/src/main/kotlin/com/wisp/app/Navigation.kt
+++ b/app/src/main/kotlin/com/wisp/app/Navigation.kt
@@ -1897,7 +1897,6 @@ fun WispNavHost(
                     subManager = feedViewModel.subManager,
                     metadataFetcher = feedViewModel.metadataFetcher,
                     muteRepo = feedViewModel.muteRepo,
-                    topRelayUrls = feedViewModel.getScoredRelays().take(5).map { it.url },
                     relayListRepo = feedViewModel.relayListRepo,
                     relayHintStore = feedViewModel.relayHintStore,
                     spamClassifier = feedViewModel.nspamClassifier,
@@ -2392,7 +2391,6 @@ fun WispNavHost(
                     outboxRouter = feedViewModel.outboxRouter,
                     subManager = feedViewModel.subManager,
                     metadataFetcher = feedViewModel.metadataFetcher,
-                    topRelayUrls = feedViewModel.getScoredRelays().take(5).map { it.url },
                     relayListRepo = feedViewModel.relayListRepo,
                     relayHintStore = feedViewModel.relayHintStore
                 )

--- a/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
+++ b/app/src/main/kotlin/com/wisp/app/relay/OutboxRouter.kt
@@ -308,6 +308,43 @@ class OutboxRouter(
     }
 
     /**
+     * The strict inbox set for [pubkey]: NIP-65 read (inbox) relays, falling back to relay
+     * hints when no NIP-65 list is cached. Empty when neither exists — callers must NOT
+     * fall back to pool broadcasts.
+     */
+    fun getInboxRelaysStrict(pubkey: String): List<String> {
+        val nip65 = relayListRepo.getReadRelays(pubkey)
+        if (!nip65.isNullOrEmpty()) return nip65
+        val hints = relayHintStore?.getHints(pubkey)
+        if (!hints.isNullOrEmpty()) return hints.toList()
+        return emptyList()
+    }
+
+    /**
+     * Strict inbox routing: subscribe to [filters] on [pubkey]'s inbox relays ONLY.
+     * Unlike [subscribeToUserReadRelays], there is no pool-broadcast fallback — if no
+     * inbox relays are known, nothing is sent. Used for threads and notifications.
+     */
+    fun subscribeToUserInboxStrict(
+        subId: String,
+        pubkey: String,
+        filters: List<Filter>
+    ): Set<String> {
+        val targetedRelays = mutableSetOf<String>()
+        val inboxRelays = getInboxRelaysStrict(pubkey)
+        if (inboxRelays.isEmpty()) return targetedRelays
+
+        val msg = if (filters.size == 1) ClientMessage.req(subId, filters[0])
+        else ClientMessage.req(subId, filters)
+        for (url in inboxRelays) {
+            if (relayPool.sendToRelayOrEphemeral(url, msg)) {
+                targetedRelays.add(url)
+            }
+        }
+        return targetedRelays
+    }
+
+    /**
      * Publish an event to own write relays AND the target user's read (inbox) relays.
      * Used for replies, reactions, and reposts so they reach the intended recipient.
      */

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ArticleViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ArticleViewModel.kt
@@ -58,7 +58,6 @@ class ArticleViewModel : ViewModel() {
     private var loadJob: Job? = null
     private var metadataBatchJob: Job? = null
     private var relayPoolRef: RelayPool? = null
-    private var topRelayUrls: List<String> = emptyList()
     private var relayListRepoRef: RelayListRepository? = null
     private var relayHintStoreRef: RelayHintStore? = null
     private var eventRepoRef: EventRepository? = null
@@ -103,12 +102,10 @@ class ArticleViewModel : ViewModel() {
         outboxRouter: OutboxRouter,
         subManager: SubscriptionManager,
         metadataFetcher: MetadataFetcher,
-        topRelayUrls: List<String>,
         relayListRepo: RelayListRepository? = null,
         relayHintStore: RelayHintStore? = null
     ) {
         this.relayPoolRef = relayPool
-        this.topRelayUrls = topRelayUrls
         this.relayListRepoRef = relayListRepo
         this.relayHintStoreRef = relayHintStore
         this.eventRepoRef = eventRepo
@@ -170,22 +167,15 @@ class ArticleViewModel : ViewModel() {
 
         // Two-phase loading matching ThreadViewModel pattern
         loadJob = viewModelScope.launch {
-            // Phase 1a: Subscribe for comments via `a` tag on author's read relays + top relays
+            // Phase 1a: Subscribe for comments via `a` tag — author's inbox relays ONLY.
+            // No pool broadcast or scored-relay safety net.
             val commentFilter = Filter(kinds = listOf(1), aTags = listOf(coordinate))
-            outboxRouter.subscribeToUserReadRelays(commentSubId, author, commentFilter)
-            val aTagMsg = ClientMessage.req(commentSubId, commentFilter)
-            for (url in topRelayUrls) {
-                relayPool.sendToRelayOrEphemeral(url, aTagMsg)
-            }
+            outboxRouter.subscribeToUserInboxStrict(commentSubId, author, listOf(commentFilter))
 
             // Phase 1b: Also subscribe via e-tag — many clients reply with e-tags
             if (articleEventId != null) {
                 val eTagFilter = Filter(kinds = listOf(1), eTags = listOf(articleEventId))
-                outboxRouter.subscribeToUserReadRelays(eTagSubId, author, eTagFilter)
-                val eTagMsg = ClientMessage.req(eTagSubId, eTagFilter)
-                for (url in topRelayUrls) {
-                    relayPool.sendToRelayOrEphemeral(url, eTagMsg)
-                }
+                outboxRouter.subscribeToUserInboxStrict(eTagSubId, author, listOf(eTagFilter))
             }
 
             // Wait for EOSE from both subscriptions
@@ -288,19 +278,15 @@ class ArticleViewModel : ViewModel() {
     }
 
     /**
-     * Send subscription to author's read relays + top scored relays.
-     * Mirrors ThreadViewModel.sendToEngagementRelays().
+     * Send subscription to the author's inbox relays only (NIP-65 read relays,
+     * falling back to relay hints). Mirrors ThreadViewModel.sendToEngagementRelays().
      */
     private fun sendToEngagementRelays(
         relayPool: RelayPool, subId: String, filter: Filter, authorPubkey: String
     ) {
         val msg = ClientMessage.req(subId, filter)
-        val sent = mutableSetOf<String>()
         for (url in getAuthorRelays(authorPubkey)) {
-            if (relayPool.sendToRelayOrEphemeral(url, msg)) sent.add(url)
-        }
-        for (url in topRelayUrls) {
-            if (url !in sent) relayPool.sendToRelayOrEphemeral(url, msg)
+            relayPool.sendToRelayOrEphemeral(url, msg)
         }
     }
 

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/FeedSubscriptionManager.kt
@@ -1158,24 +1158,23 @@ class FeedSubscriptionManager(
     }
 
     private fun subscribeNotifEngagementInner(eventIds: List<String>) {
-        val eventsByAuthor = mutableMapOf<String, MutableList<String>>()
-        for (id in eventIds) {
-            val event = eventRepo.getEvent(id)
-            val author = event?.pubkey ?: "fallback"
-            eventsByAuthor.getOrPut(author) { mutableListOf() }.add(id)
-        }
-        val safetyNet = relayScoreBoard.getScoredRelays().take(5).map { it.url }
+        // Engagement on our own posts comes from OUR inbox relays only — no
+        // per-author routing fallback, no scored-relay safety net.
+        val myPubkey = pubkeyHex ?: eventRepo.currentUserPubkey ?: return
         val since = notifRepo.getLatestNotifTimestamp()?.let { it - 5 * 60 }
-        outboxRouter.subscribeEngagementByAuthors("engage-notif", eventsByAuthor, activeEngagementSubIds, safetyNet, since)
+
+        activeEngagementSubIds.add("engage-notif")
+        val engagementFilters = eventIds.distinct().chunked(OutboxRouter.MAX_ETAGS_PER_FILTER).map { chunk ->
+            Filter(kinds = listOf(1, 5, 6, 7, 1018, 9735), eTags = chunk, limit = 500, since = since)
+        }
+        outboxRouter.subscribeToUserInboxStrict("engage-notif", myPubkey, engagementFilters)
 
         val zapSubId = "engage-notif-zap"
         activeEngagementSubIds.add(zapSubId)
         val zapFilters = eventIds.chunked(OutboxRouter.MAX_ETAGS_PER_FILTER).map { chunk ->
             Filter(kinds = listOf(9735), eTags = chunk, since = since)
         }
-        val zapMsg = if (zapFilters.size == 1) ClientMessage.req(zapSubId, zapFilters[0])
-        else ClientMessage.req(zapSubId, zapFilters)
-        relayPool.sendToReadRelays(zapMsg)
+        outboxRouter.subscribeToUserInboxStrict(zapSubId, myPubkey, zapFilters)
 
         // Also fetch private zap receipts from DM relays
         if (relayPool.hasDmRelays()) {

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/StartupCoordinator.kt
@@ -750,18 +750,9 @@ class StartupCoordinator(
             pTags = listOf(myPubkey),
             limit = 300
         )
-        val notifReqMsg = ClientMessage.req("notif", notifFilter)
-        relayPool.sendToReadRelays(notifReqMsg)
-
-        // Also send to top scored relays for broader coverage
-        val readUrls = relayPool.getReadRelayUrls().toSet()
-        val topScored = relayScoreBoard.getScoredRelays()
-            .take(5)
-            .map { it.url }
-            .filter { it !in readUrls }
-        for (url in topScored) {
-            relayPool.sendToRelay(url, notifReqMsg)
-        }
+        // Notifications come from OUR inbox relays only — no pool-wide read
+        // broadcast, no scored-relay safety net.
+        outboxRouter.subscribeToUserInboxStrict("notif", myPubkey, listOf(notifFilter))
 
         // Fetch private zap receipts from DM relays
         if (relayPool.hasDmRelays()) {
@@ -837,32 +828,14 @@ class StartupCoordinator(
         val filters = myEventIds.chunked(OutboxRouter.MAX_ETAGS_PER_FILTER).map { chunk ->
             Filter(kinds = listOf(1), eTags = chunk, limit = 200, since = since)
         }
-        val replyReqMsg = if (filters.size == 1) ClientMessage.req("notif-replies-etag", filters[0])
-        else ClientMessage.req("notif-replies-etag", filters)
+        // Subscribe on our inbox relays ONLY — replies land where our notes' readers publish.
+        outboxRouter.subscribeToUserInboxStrict("notif-replies-etag", pk, filters)
 
-        relayPool.sendToReadRelays(replyReqMsg)
-        // Replies often land on the relay where the original note was posted
-        val readUrls2 = relayPool.getReadRelayUrls().toSet()
-        val writeNotInRead = relayPool.getWriteRelayUrls().filter { it !in readUrls2 }
-        for (url in writeNotInRead) {
-            relayPool.sendToRelay(url, replyReqMsg)
-        }
-        val topScored2 = relayScoreBoard.getScoredRelays()
-            .take(5)
-            .map { it.url }
-            .filter { it !in readUrls2 && it !in writeNotInRead.toSet() }
-        for (url in topScored2) {
-            relayPool.sendToRelay(url, replyReqMsg)
-        }
         // Also subscribe for quotes of our posts via #q tags
         val quoteFilters = myEventIds.chunked(OutboxRouter.MAX_ETAGS_PER_FILTER).map { chunk ->
             Filter(kinds = listOf(1), qTags = chunk, limit = 200, since = since)
         }
-        val quoteReqMsg = if (quoteFilters.size == 1) ClientMessage.req("notif-quotes-qtag", quoteFilters[0])
-        else ClientMessage.req("notif-quotes-qtag", quoteFilters)
-        relayPool.sendToReadRelays(quoteReqMsg)
-        for (url in writeNotInRead) relayPool.sendToRelay(url, quoteReqMsg)
-        for (url in topScored2) relayPool.sendToRelay(url, quoteReqMsg)
+        outboxRouter.subscribeToUserInboxStrict("notif-quotes-qtag", pk, quoteFilters)
 
         scope.launch {
             subManager.awaitEoseWithTimeout("notif-replies-etag", timeoutMs = 5_000)

--- a/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
+++ b/app/src/main/kotlin/com/wisp/app/viewmodel/ThreadViewModel.kt
@@ -63,7 +63,6 @@ class ThreadViewModel : ViewModel() {
     private var muteRepo: MuteRepository? = null
     private val activeMetadataSubs = mutableListOf<String>()
     private var relayPoolRef: RelayPool? = null
-    private var topRelayUrls: List<String> = emptyList()
     private var relayListRepoRef: RelayListRepository? = null
     private var relayHintStoreRef: RelayHintStore? = null
     private var currentUserPubkey: String? = null
@@ -129,7 +128,6 @@ class ThreadViewModel : ViewModel() {
         subManager: SubscriptionManager,
         metadataFetcher: MetadataFetcher,
         muteRepo: MuteRepository? = null,
-        topRelayUrls: List<String> = emptyList(),
         relayListRepo: RelayListRepository? = null,
         relayHintStore: RelayHintStore? = null,
         spamClassifier: NSpamClassifier? = null,
@@ -152,7 +150,6 @@ class ThreadViewModel : ViewModel() {
             }
         }
         this.relayPoolRef = relayPool
-        this.topRelayUrls = topRelayUrls
         this.relayListRepoRef = relayListRepo
         this.relayHintStoreRef = relayHintStore
         this.currentUserPubkey = eventRepo.currentUserPubkey
@@ -276,24 +273,16 @@ class ThreadViewModel : ViewModel() {
                 subManager.awaitEoseWithTimeout("thread-root", 5_000)
             }
 
-            // Phase 2: Now we (hopefully) have the root — use outbox routing for replies
+            // Phase 2: Now we (hopefully) have the root — query ONLY the root author's
+            // inbox relays. No pool broadcast or scored-relay safety net: if the root
+            // author's NIP-65 list (or hints) is unknown, we stay cache-only.
             val rootEvent = _rootEvent.value
             // Include kind 5 so deletions of the root (or any event tagging the root) come through.
             val repliesFilter = Filter(kinds = listOf(1, 5), eTags = listOf(rootId))
             if (rootEvent != null) {
-                outboxRouter.subscribeToUserReadRelays(
-                    "thread-replies", rootEvent.pubkey, repliesFilter
+                outboxRouter.subscribeToUserInboxStrict(
+                    "thread-replies", rootEvent.pubkey, listOf(repliesFilter)
                 )
-            } else {
-                // Root still not found — query all relays as fallback
-                relayPool.sendToAll(
-                    ClientMessage.req("thread-replies", repliesFilter)
-                )
-            }
-            // Also query top scored relays as safety net
-            for (url in topRelayUrls) {
-                relayPool.sendToRelayOrEphemeral(url,
-                    ClientMessage.req("thread-replies", repliesFilter))
             }
 
             // Wait for replies EOSE, then hide spinner
@@ -332,20 +321,17 @@ class ThreadViewModel : ViewModel() {
     }
 
     /**
-     * Send a subscription to author relays + top scored relays.
+     * Send a subscription to the author's inbox relays only (NIP-65 read relays,
+     * falling back to relay hints). No scored-relay safety net.
      */
     private fun sendToEngagementRelays(
         relayPool: RelayPool, subId: String, filter: Filter, authorPubkey: String?
     ) {
         val msg = ClientMessage.req(subId, filter)
-        val sent = mutableSetOf<String>()
         if (authorPubkey != null) {
             for (url in getAuthorRelays(authorPubkey)) {
-                if (relayPool.sendToRelayOrEphemeral(url, msg)) sent.add(url)
+                relayPool.sendToRelayOrEphemeral(url, msg)
             }
-        }
-        for (url in topRelayUrls) {
-            if (url !in sent) relayPool.sendToRelayOrEphemeral(url, msg)
         }
     }
 


### PR DESCRIPTION
## Summary
- Threads now query **only the root author's NIP-65 inbox relays**; notifications query **only the logged-in user's inbox relays**
- Removes the top-5 scored-relay safety nets and pool-broadcast fallbacks from these queries, so big relays (damus.io, primal.net, etc.) are no longer pulled in just for coverage
- Adds `OutboxRouter.getInboxRelaysStrict()` and `subscribeToUserInboxStrict()`: NIP-65 read relays → relay hints, with **no fallback** — if no inbox is known, nothing is sent
- `thread-root` fetch keeps its pool broadcast (the root author isn't known until the root arrives)
- Same strict rules applied to article comments (mirrors thread behavior)

## Behavior change
When neither a NIP-65 list nor relay hints exist for the target author, no query is sent — the thread/notifications stay cache-only until relay lists are discovered through other subscriptions. This is the intended tradeoff of strict routing.

## Testing
- `./gradlew assembleDebug` passes
- Manual verification recommended: open a thread for an author with/without a NIP-65 list; confirm notifications still arrive on-device